### PR TITLE
schema length to max. 50

### DIFF
--- a/src/attorney.js
+++ b/src/attorney.js
@@ -20,7 +20,7 @@ function checkConfig(config) {
 
     if(config.schema){
         assert(typeof config.schema == 'string', 'configuration assert: schema must be a string');
-        assert(config.schema.length < 20, 'configuration assert: schema should be between 1 and 20 characters');
+        assert(config.schema.length < 50, 'configuration assert: schema should be between 1 and 50 characters');
         assert(!/\W/.test(config.schema), `configuration assert: ${config.schema} cannot be used as a schema. Only alphanumeric characters and underscores are allowed`);
     }
 


### PR DESCRIPTION
I have a schema longer than 20 chars. 

Is there a reason why you limited it to 20?