### PR TITLE
accept connectionString as a config property

### DIFF
--- a/src/attorney.js
+++ b/src/attorney.js
@@ -25,6 +25,9 @@ function applyDatabaseConfig(config) {
   if(typeof config == 'string') {
     config = {connectionString: config};
   }
+  else if ('connectionString' in config) {
+    assert(typeof config.connectionString == 'string', 'configuration assert: connectionString must be a string');
+  }
   else {
     assert(config.database && config.user && 'password' in config,
       'configuration assert: not enough database settings to connect to PostgreSQL');


### PR DESCRIPTION
It's currently possible to initialize with a PG connection string, or with configuration object including a database, user, password, and other params, but not both. When a string is provided, it converts to `{ connectionString: config }`; this provides no obvious way to set the other params through a config object.

This commit provides for initializing Boss with a connection string and also allowing `schema`, `poolSize`, and `uuid` to be set, e.g.

```javascript
new PgBoss({
    connectionString: 'postgres://postgres@localhost:5432/db',
    schema:           'boss',
    poolSize:         10
});
```