### PR TITLE
Next job with LIMIT teamSize (Performance Boost)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-boss",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Queueing jobs in Node.js using PostgreSQL like a boss",
   "main": "./lib/index.js",
   "engines": { "node" : ">=4.0.0" },

--- a/src/plans.js
+++ b/src/plans.js
@@ -125,7 +125,7 @@ function fetchNextJob(schema) {
         AND name = $1
         AND (createdOn + startIn) < now()
       ORDER BY createdOn, id
-      LIMIT 1
+      LIMIT $2
       FOR UPDATE SKIP LOCKED
     )
     UPDATE ${schema}.job SET


### PR DESCRIPTION
changed behaviour of teamSize > 1: 
* do not start multiple workers, just one!
* fetch jobs with a `LIMIT teamSize` to get multiple jobs with one query

Pros:
+ saves connections to db
+ less queries
+ less db work (-CPU)