### PR TITLE
pass the error supplied to the done callback on through the fail handler

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -102,7 +102,7 @@ class Manager extends EventEmitter {
       if(!error)
         return this.complete(job.id, response);
 
-      return this.fail(job.id)
+      return this.fail(job.id, error)
         .then(() => this.emit(events.failed, {job, error}));
     };
 


### PR DESCRIPTION
when failing a job by passing an error to `job.done`, the error is dropped, causing `data` to be undefined here: https://github.com/timgit/pg-boss/blob/248e21274f768fbddad55a1c713cf376902a25b9/src/manager.js#L255


example:

```

const PgBoss = require('pg-boss');
const boss = new PgBoss('postgres://pgbosstest:pgbosstest@localhost/pgbosstest');

boss.on('error', onError);

boss.start()
  .then(ready)
  .catch(onError);

function ready() {

  boss.publish('failed-job', {param1: 'parameter1'})
    .then(jobId => console.log(`created failed-job ${jobId}`))
    .catch(onError);

  boss.subscribe('failed-job', failedJobHandler)
    .then(() => console.log('subscribed to failed-job'))
    .catch(onError);
}

function failedJobHandler(job) {
  console.log(`received ${job.name} ${job.id}`);
  console.log(`data: ${JSON.stringify(job.data)}`);

  job.done('this job failed')
    .then(() => console.log(`failed-job ${job.id} failed`))
    .catch(onError);
}
function onError(error) {
  console.error(error);
}
```
before/after this commit:

```
----------------------------------------------------------------------------------------------------------------------------------------------------
id           | a9afb020-af74-11e7-927f-d55cf5669043
name         | failed-job__state__failed
priority     | 0
data         | {"request": {"id": "a9151dd0-af74-11e7-927f-d55cf5669043", "data": {"param1": "parameter1"}, "name": "failed-job"}, "response": null}
state        | created
retrylimit   | 0
retrycount   | 0
startin      | 00:00:00
startedon    |
singletonkey |
singletonon  |
expirein     | 00:15:00
createdon    | 2017-10-12 13:42:05.602788-04
completedon  |
----------------------------------------------------------------------------------------------------------------------------------------------------
id           | 321220a0-af76-11e7-b2d5-f7ed48d6a25c
name         | failed-job__state__failed
priority     | 0
data         | {"request": {"id": "3176f210-af76-11e7-b2d5-f7ed48d6a25c", "data": {"param1": "parameter1"}, "name": "failed-job"}, "response": "this job failed"}
state        | created
retrylimit   | 0
retrycount   | 0
startin      | 00:00:00
startedon    |
singletonkey |
singletonon  |
expirein     | 00:15:00
createdon    | 2017-10-12 13:53:03.914305-04
completedon  |
```
