### PR TITLE
Respect custom schema along with connectionString

### DIFF
--- a/src/attorney.js
+++ b/src/attorney.js
@@ -105,11 +105,15 @@ function applyConfig(config) {
 }
 
 function applyDatabaseConfig(config) {
-
-  if(typeof config === 'string' || (config.connectionString && typeof config.connectionString === 'string')) {
-    config = {connectionString: config.connectionString || config};
+  if(typeof config === 'string') {
+    return {
+      connectionString: config,
+      schema: 'pgboss',
+      poolSize: 10
+    };
   }
-  else {
+
+  if (typeof (config.connectionString) !== 'string') {
     assert(config.database && config.user && 'password' in config,
       'configuration assert: not enough database settings to connect to PostgreSQL');
 

--- a/test/configTest.js
+++ b/test/configTest.js
@@ -55,4 +55,14 @@ describe('initialization', function(){
       });
   });
 
+  it('should accept a connectionString and schema properties', function(finished){
+    const connectionString = 'postgresql://postgres@127.0.0.1:5432/db';
+    const schema = 'pgboss_custom_schema';
+    const boss = new PgBoss({connectionString, schema});
+
+    assert.equal(boss.config.schema, schema);
+
+    finished();
+  });
+
 });


### PR DESCRIPTION
Custom schema (and poolSize) ignored when connectionString is used.