### PR TITLE
fixed promise returns warnings on manager.js

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -141,6 +141,8 @@ class Manager extends EventEmitter {
     let worker = new Worker(workerConfig);
     worker.start();
     subscription.worker = worker;
+
+    return Promise.resolve(true);
   }
 
   unsubscribe(name){


### PR DESCRIPTION
It fixes node's warning of promise created in handler but wasn't returned from it.