### PR TITLE
Use PostgreSQL client directly

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -2,14 +2,15 @@
 
 declare namespace PgBoss {
   export interface ConnectionOptions {
-    database: string
-    user: string
-    password: string
+    database?: string
+    user?: string
+    password?: string
     host?: string
     port?: number
     schema?: string
     uuid?: string
     poolSize?: number
+    db?: object
   }
 
   interface PublishOptions {


### PR DESCRIPTION
Changes on ConnectionOptions to reflect the possibility to use a db client directly, as seen in the documentation. issue #48
https://github.com/timgit/pg-boss/blob/master/docs/configuration.md#constructor-options