### PR TITLE
Make JobDoneCallback params optional

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -72,8 +72,7 @@ declare namespace PgBoss {
   }
 
   interface JobDoneCallback<T> {
-    (err: Error): void;
-    (err: null | undefined, data: T): void;
+    (err?: Error | null, data?: T): void;
   }
 
   interface Job<T = object> {


### PR DESCRIPTION
Verified this works locally. This basically lets you call `job.done()` rather than `job.done(null, null)`  in typescript.