### PR TITLE
Retry failed jobs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ pg-boss can be customized using configuration options when an instance is create
     - [Job fetch options](#job-fetch-options)
     - [Job expiration options](#job-expiration-options)
     - [Job archive options](#job-archive-options)
+    - [Job retry options](#job-retry-options)
 - [Publish Options](#publish-options)
     - [Delayed jobs](#delayed-jobs)
     - [Unique jobs](#unique-jobs)
@@ -140,6 +141,27 @@ When `archiveCheckIntervalSeconds` is specified, `archiveCheckInterval` is ignor
 * **deleteCheckInterval**, int
 
     interval to delete jobs in milliseconds, must be >=100.   Default: 1 hour
+
+### Job retry options
+
+By default, only expired jobs are automatically retried when a `retryLimit` is specified.
+To also automatically retry failed jobs, set a check interval using one of the options below.
+
+* **failedCheckInterval**, int
+
+    interval to check for failed jobs to retry in milliseconds, must be >=100
+
+* **failedCheckIntervalSeconds**, int
+
+    interval to check for failed jobs to retry in seconds, must be >=1
+
+* **failedCheckIntervalMinutes**, int
+
+    interval to check for failed jobs to retry in minutes, must be >=1
+
+When `failedCheckIntervalMinutes` is specified, `failedCheckIntervalSeconds` and `failedCheckInterval` are ignored.
+
+When `failedCheckIntervalSeconds` is specified, `failedCheckInterval` is ignored.
 
 ## Publish Options
 

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -97,6 +97,7 @@ function applyConfig(config) {
   config = applyExpireConfig(config);
   config = applyArchiveConfig(config);
   config = applyDeleteConfig(config);
+  config = applyRetryFailedConfig(config);
   config = applyMonitoringConfig(config);
   config = applyUuidConfig(config);
 
@@ -206,6 +207,26 @@ function applyDeleteConfig(config) {
     'configuration assert: deleteArchivedJobsEvery should be a readable PostgreSQL interval such as "7 days"');
 
   config.deleteArchivedJobsEvery = config.deleteArchivedJobsEvery || '7 days';
+
+  return config;
+}
+
+function applyRetryFailedConfig(config){
+  assert(!('failedCheckInterval' in config &&
+    config.failedCheckInterval !== null) || config.failedCheckInterval >=100,
+    'configuration assert: failedCheckInterval must be at least every 100ms');
+
+  assert(!('failedCheckIntervalSeconds' in config) || config.failedCheckIntervalSeconds >=1,
+    'configuration assert: failedCheckIntervalSeconds must be at least every second');
+
+  assert(!('failedCheckIntervalMinutes' in config) || config.failedCheckIntervalMinutes >=1,
+    'configuration assert: failedCheckIntervalMinutes must be at least every minute');
+
+  config.failedCheckInterval =
+    ('failedCheckIntervalMinutes' in config) ? config.failedCheckIntervalMinutes * 60 * 1000
+      : ('failedCheckIntervalSeconds' in config) ? config.failedCheckIntervalSeconds * 1000
+        : ('failedCheckInterval' in config) ? config.failedCheckInterval
+          : null;
 
   return config;
 }

--- a/src/plans.js
+++ b/src/plans.js
@@ -29,6 +29,7 @@ module.exports = {
   expire,
   archive,
   purge,
+  retryFailed,
   countStates,
   states,
   stateJobDelimiter,
@@ -288,6 +289,16 @@ function archive(schema){
     )
     INSERT INTO ${schema}.archive
     SELECT * FROM archived_rows
+  `;
+}
+
+function retryFailed(schema) {
+  return `
+    UPDATE ${schema}.job
+    SET state = '${states.retry}'::${schema}.job_state,
+      completedOn = NULL
+    WHERE state = '${states.failed}'
+      AND retryCount < retryLimit
   `;
 }
 

--- a/test/retryTest.js
+++ b/test/retryTest.js
@@ -5,37 +5,110 @@ describe('retries', function() {
 
   this.timeout(10000);
 
-  let boss;
-
-  before(function(finished){
-    helper.start({expireCheckInterval:200, newJobCheckInterval: 200})
-      .then(dabauce => {
-        boss = dabauce;
+  describe('when a job didn\'t complete', function() {
+    let boss;
+  
+    before(function(finished){
+      helper.start({expireCheckInterval:200, newJobCheckInterval: 200})
+        .then(dabauce => {
+          boss = dabauce;
+          finished();
+        });
+    });
+  
+    after(function(finished){
+      boss.stop().then(() => finished());
+    });
+  
+    it('should retry a job that exceeded its given expiration time', function (finished) {
+      const expireIn = '100 milliseconds';
+      const retryLimit = 1;
+  
+      let subscribeCount = 0;
+  
+      // don't call job.done() so it will expire
+      boss.subscribe('unreliable', job => subscribeCount++);
+  
+      boss.publish({name: 'unreliable', options: {expireIn, retryLimit}});
+  
+      setTimeout(function() {
+        assert.equal(subscribeCount, retryLimit + 1);
         finished();
+  
+      }, 3000);
+    });
+  });
+
+  describe('when failedCheckInterval is specified', function() {
+    let boss;
+
+    before(function(finished){
+      helper.start({
+        newJobCheckInterval: 200,
+        failedCheckInterval: 200
+      })
+        .then(dabauce => {
+          boss = dabauce;
+          finished();
+        });
+    });
+
+    after(function(finished){
+      boss.stop().then(() => finished());
+    });
+
+    it('should retry a job that failed', function (finished) {
+      const retryLimit = 1;
+      const expectedJobRunCount = retryLimit + 1;
+      let jobRunCount = 0;
+  
+      boss.subscribe('failure-job', job => {
+        jobRunCount++
+        job.done(new Error('something went wrong'));
       });
+      
+      boss.publish({name: 'failure-job', options: {retryLimit}});
+  
+      setTimeout(function() {
+        assert.equal(jobRunCount, expectedJobRunCount);
+        finished();
+      }, 3000);
+    });
   });
 
-  after(function(finished){
-    boss.stop().then(() => finished());
-  });
+  describe('when failedCheckInterval is not specified', function() {
+    let boss;
 
-  it('should retry a job that didn\'t complete', function (finished) {
+    before(function(finished){
+      helper.start({
+        newJobCheckInterval: 200
+      })
+        .then(dabauce => {
+          boss = dabauce;
+          finished();
+        });
+    });
 
-    const expireIn = '100 milliseconds';
-    const retryLimit = 1;
+    after(function(finished){
+      boss.stop().then(() => finished());
+    });
 
-    let subscribeCount = 0;
-
-    // don't call job.done() so it will expire
-    boss.subscribe('unreliable', job => subscribeCount++);
-
-    boss.publish({name: 'unreliable', options: {expireIn, retryLimit}});
-
-    setTimeout(function() {
-      assert.equal(subscribeCount, retryLimit + 1);
-      finished();
-
-    }, 3000);
-
+    it('should not retry a job that failed', function (finished) {
+      const retryLimit = 1;
+      const expectedJobRunCount = 1;
+      let jobRunCount = 0;
+  
+      boss.subscribe('failure-job', job => {
+        jobRunCount++
+        job.done(new Error('something went wrong'));
+      });
+      
+      boss.publish({name: 'failure-job', options: {retryLimit}});
+  
+      setTimeout(function() {
+        assert.equal(jobRunCount, expectedJobRunCount);
+        finished();
+      }, 3000);
+    });
   });
 });


### PR DESCRIPTION
This PR adds support for automatic retry of failed jobs (#29) using the existing `retryLimit` mechanism. It works in a similar way to expiration: when enabled it will on a specified interval check for failed jobs that have `retryCount < retryLimit`, and set their state to `retry`.

It's backwards compatible (i.e. a non-breaking change, 2.6.x), that uses a new constructor configuration option `failedCheckInterval` to control how frequently to check. If it isn't specified, pgboss behaves as it did before (i.e. only retries expired jobs).

I realise you have larger plans to address this problem in a new major version, however I'm keen to see if we can find a way to merge an interim solution into 2.x.x. No feelings will be hurt if you're not comfortable with that – keen to hear your honest feedback 👍.