### PR TITLE
Minor change to README to make queue vs job clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ boss.start()
   .catch(onError);
 
 function ready() {
-  boss.publish('some-job', {param1: 'parameter1'})
+  boss.publish('some-queue-name', {param1: 'parameter1'})
     .then(jobId => console.log(`created some-job ${jobId}`))
     .catch(onError);
 
-  boss.subscribe('some-job', someJobHandler)
+  boss.subscribe('some-queue-name', someJobHandler)
     .then(() => console.log('subscribed to some-job'))
     .catch(onError);
 }


### PR DESCRIPTION
The semantics in the README are I think confusing to new people (like me). The README example has `some-job` in the `publish` and `subscribe` calls but that is really a queue for jobs, right? I think it's clearer to call it `some-queue-name` or `some-queue`.

I was scratching my head about this until I got it. At least I think I got it so opening this PR partly for other new people and partly to confirm!

Would you also take a PR to add a minor part to the README that links to the schema section that outlines the db usage? That was my other question -- what tables, what namespace, etc. I see that now after clicking around but would be nice to call it out up front by linking directly. If sounds good, happy to do a PR for that too.

Thanks!