### PR TITLE
allow 'v4' instead of 'v2'

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -21,7 +21,7 @@ declare namespace PgBoss {
   }
 
   interface JobCreationOptions {
-    uuid?: "v1" | "v2";
+    uuid?: "v1" | "v4";
   }
 
   interface JobFetchOptions {


### PR DESCRIPTION
Fix for https://github.com/timgit/pg-boss/issues/82