### PR TITLE
Add RETURNING 1 to insertJob plan

### DIFF
--- a/src/plans.js
+++ b/src/plans.js
@@ -334,7 +334,8 @@ function insertJob(schema) {
       $12
     )
     ON CONFLICT DO NOTHING
-  `;
+    RETURNING 1
+  `; // returning 1 here so we can actually return id on publish
 }
 
 function purge(schema) {


### PR DESCRIPTION
Hey :wave: first of all thanks for this awesome library.
Turns out some of the logic that determines whether or not to return an `id` on publish requires that INSERT have some output.

I'm using `typeorm`(https://github.com/typeorm/typeorm/) and while I've gotten everything else to work when using the typeorm connection, this small hurdle is blocking me.

I've confirmed that this works after editing the plan locally.

Think we can roll this in?