### PR TITLE
Document retry parameters

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,7 +193,7 @@ Setting `singletonNextSlot` to true will cause the job to be scheduled to run af
 
 * **retryBackoff**, bool
 
-    Default: false. Enables exponential backoff, doubles retry delay every retry. Sets initial retryDelay to 1 if not set.
+    Default: false. Enables exponential backoff retries based on retryDelay instead of a fixed delay. Sets initial retryDelay to 1 if not set.
 
 ### Job expiration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,15 +185,15 @@ Setting `singletonNextSlot` to true will cause the job to be scheduled to run af
 
 * **retryLimit**, int
 
-    Default: 0
+    Default: 0. Max number of retries of failed jobs. Default is no retries.
 
 * **retryDelay**, int
 
-    Default: 0
+    Default: 0. Delay between retries of failed jobs, in seconds.
 
 * **retryBackoff**, bool
 
-    Default: false
+    Default: false. Enables exponential backoff, doubles retry delay every retry. Sets initial retryDelay to 1 if not set.
 
 ### Job expiration
 


### PR DESCRIPTION
Retry parameters were slightly underdocumented. Fix that.