### PR TITLE
Add static methods to exported class type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -103,6 +103,9 @@ declare namespace PgBoss {
 declare class PgBoss {
   constructor(connectionString: string);
   constructor(options: PgBoss.ConstructorOptions);
+  
+  static getConstructionPlans(schema: string): string;
+  static getMigrationPlans(schema: string, version: string, uninstall: boolean): string;
 
   on(event: "error", handler: (error: Error) => void): void;
   on(event: "archived", handler: (count: number) => void): void;


### PR DESCRIPTION
Adding `getConstructionPlans` and `getMigrationPlans` to the exported class type so I can use it in my test helpers that are `.ts` :smile: