### PR TITLE
removed up-front housekeeping on start() for deadlocks

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,6 @@ coverage/
 .travis.yml
 *.tgz
 .nyc_output/
+docs/
+changelog.md
+readme.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 3.2.2
+
+- Deferring housekeeping operations on start to reduce deadlocks during concurrent start() instances
+
 ## 3.2.1
 
 - Fixed rare deadlocks by stacking housekeeping operations one at a time during start().

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-boss",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Queueing jobs in Node.js using PostgreSQL like a boss",
   "main": "./src/index.js",
   "engines": {

--- a/src/boss.js
+++ b/src/boss.js
@@ -43,7 +43,6 @@ class Boss extends EventEmitter {
     }
 
     async function monitor (func, interval) {
-      await exec()
       repeat()
 
       async function exec () {


### PR DESCRIPTION
For #133. In this case, if you start up a new pg-boss instance while another one is active, the up-front housekeeping in start() may overlap with the interval on the existing one.  This change removes up-front housekeeping, which as of 3.2.1 is also re-exported in the module if this behavior is still desired.