### PR TITLE
Add missing JobMonitorOptions to ConstructorOptions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ pg-boss can be customized using configuration options when an instance is create
 
 - [Constructor Options](#constructor-options)
     - [Database options](#database-options)
+    - [Job monitor options](#job-monitor-options)
     - [Job creation options](#job-creation-options)
     - [Job fetch options](#job-fetch-options)
     - [Job expiration options](#job-expiration-options)
@@ -76,6 +77,8 @@ Since passing only a connection string is intended to be for convenience, you ca
 * **schema** - string, defaults to "pgboss"
 
     Only alphanumeric and underscore allowed, length: <= 50 characters
+
+### Job monitor options
 
 * **monitorStateIntervalSeconds** - int, default undefined
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -20,6 +20,18 @@ declare namespace PgBoss {
     db?: Db;
   }
 
+  interface JobMonitorOptions {
+    /** 
+     * Specifies how often in seconds an instance will fire the monitor-states event. Cannot be less than 1. 
+    */
+    monitorStateIntervalSeconds?: number
+
+    /**
+     * Specifies how often in minutes an instance will fire the monitor-states event. Cannot be less than 1. Do not use if using monitorStateIntervalSeconds
+     */
+    monitorStateIntervalMinutes?: number
+  }
+
   interface JobCreationOptions {
     uuid?: "v1" | "v4";
   }
@@ -44,7 +56,7 @@ declare namespace PgBoss {
     deleteCheckInterval?: number;
   }
 
-  type ConstructorOptions = DatabaseOptions & JobCreationOptions & JobFetchOptions & JobExpirationOptions & JobArchiveOptions;
+  type ConstructorOptions = DatabaseOptions & JobMonitorOptions & JobCreationOptions & JobFetchOptions & JobExpirationOptions & JobArchiveOptions;
 
   interface PublishOptions {
     priority?: number;


### PR DESCRIPTION
Thank you for this wonderful library!

Seems like `monitorStateIntervalSeconds` and `monitorStateIntervalMinutes` are missing as ConstructorOptions in `types.d.ts` even though the docs mention they are there: https://github.com/timgit/pg-boss/blob/master/docs/configuration.md.

Let me know if PR looks reasonable, if anything is missing, or perhaps if I misunderstood anything.
