### PR TITLE
feat: allow opt-in to full job rows on subscribe/fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-boss",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -97,13 +97,13 @@ function checkSubscribeArgs (name, args, defaults) {
   return { options, callback }
 }
 
-function checkFetchArgs (name, batchSize, includeMetadata) {
+function checkFetchArgs (name, batchSize, options) {
   assert(name, 'missing queue name')
 
   name = sanitizeQueueNameForFetch(name)
 
-  assert(!batchSize || batchSize >= 1, 'fetch() assert: optional batchSize arg must be at least 1')
-  assert(includeMetadata === undefined || typeof includeMetadata === 'boolean', 'includeMetadata must be a boolean')
+  assert(!batchSize || (Number.isInteger(batchSize) && batchSize >= 1), 'batchSize must be an integer > 0')
+  assert(!('includeMetadata' in options) || typeof options.includeMetadata === 'boolean', 'includeMetadata must be a boolean')
 
   return { name }
 }

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -92,16 +92,18 @@ function checkSubscribeArgs (name, args, defaults) {
 
   assert(!('teamSize' in options) || (Number.isInteger(options.teamSize) && options.teamSize >= 1), 'teamSize must be an integer > 0')
   assert(!('batchSize' in options) || (Number.isInteger(options.batchSize) && options.batchSize >= 1), 'batchSize must be an integer > 0')
+  assert(!('includeMetadata' in options) || typeof options.includeMetadata === 'boolean', 'includeMetadata must be a boolean')
 
   return { options, callback }
 }
 
-function checkFetchArgs (name, batchSize) {
+function checkFetchArgs (name, batchSize, includeMetadata) {
   assert(name, 'missing queue name')
 
   name = sanitizeQueueNameForFetch(name)
 
   assert(!batchSize || batchSize >= 1, 'fetch() assert: optional batchSize arg must be at least 1')
+  assert(includeMetadata === undefined || typeof includeMetadata === 'boolean', 'includeMetadata must be a boolean')
 
   return { name }
 }

--- a/src/manager.js
+++ b/src/manager.js
@@ -221,10 +221,10 @@ class Manager extends EventEmitter {
     return this.createJob(name, data, options, singletonOffset)
   }
 
-  async fetch (name, batchSize, includeMetadata) {
-    const values = Attorney.checkFetchArgs(name, batchSize, includeMetadata)
+  async fetch (name, batchSize, options = {}) {
+    const values = Attorney.checkFetchArgs(name, batchSize, options)
     const result = await this.db.executeSql(
-      this.nextJobCommand(includeMetadata || false),
+      this.nextJobCommand(options.includeMetadata || false),
       [values.name, batchSize || 1]
     )
 
@@ -244,8 +244,8 @@ class Manager extends EventEmitter {
         : jobs
   }
 
-  async fetchCompleted (name, batchSize, includeMetadata) {
-    return this.fetch(completedJobPrefix + name, batchSize, includeMetadata)
+  async fetchCompleted (name, batchSize, options = {}) {
+    return this.fetch(completedJobPrefix + name, batchSize, options)
   }
 
   mapCompletionIdArg (id, funcName) {

--- a/src/manager.js
+++ b/src/manager.js
@@ -96,11 +96,12 @@ class Manager extends EventEmitter {
       ).catch(() => {}) // allow promises & non-promises to live together in harmony
     }
 
+    const fetchOptions= { includeMetadata: options.includeMetadata || false }
     const onError = error => this.emit(events.error, error)
 
     const workerConfig = {
       name,
-      fetch: () => this.fetch(name, options.batchSize || options.teamSize || 1, options.includeMetadata || false),
+      fetch: () => this.fetch(name, options.batchSize || options.teamSize || 1, fetchOptions),
       onFetch: jobs => sendItBruh(jobs),
       onError,
       interval: options.newJobCheckInterval

--- a/src/manager.js
+++ b/src/manager.js
@@ -100,7 +100,7 @@ class Manager extends EventEmitter {
 
     const workerConfig = {
       name,
-      fetch: () => this.fetch(name, options.batchSize || options.teamSize || 1),
+      fetch: () => this.fetch(name, options.batchSize || options.teamSize || 1, options.includeMetadata || false),
       onFetch: jobs => sendItBruh(jobs),
       onError,
       interval: options.newJobCheckInterval
@@ -221,9 +221,12 @@ class Manager extends EventEmitter {
     return this.createJob(name, data, options, singletonOffset)
   }
 
-  async fetch (name, batchSize) {
-    const values = Attorney.checkFetchArgs(name, batchSize)
-    const result = await this.db.executeSql(this.nextJobCommand, [values.name, batchSize || 1])
+  async fetch (name, batchSize, includeMetadata) {
+    const values = Attorney.checkFetchArgs(name, batchSize, includeMetadata)
+    const result = await this.db.executeSql(
+      this.nextJobCommand(includeMetadata || false),
+      [values.name, batchSize || 1]
+    )
 
     const jobs = result.rows.map(job => {
       job.done = async (error, response) => {
@@ -241,8 +244,8 @@ class Manager extends EventEmitter {
         : jobs
   }
 
-  async fetchCompleted (name, batchSize) {
-    return this.fetch(completedJobPrefix + name, batchSize)
+  async fetchCompleted (name, batchSize, includeMetadata) {
+    return this.fetch(completedJobPrefix + name, batchSize, includeMetadata)
   }
 
   mapCompletionIdArg (id, funcName) {

--- a/src/plans.js
+++ b/src/plans.js
@@ -193,7 +193,7 @@ function insertVersion (schema, version) {
 }
 
 function fetchNextJob (schema) {
-  return `
+  return (includeMetadata) => `
     WITH nextJob as (
       SELECT id
       FROM ${schema}.job
@@ -210,7 +210,7 @@ function fetchNextJob (schema) {
       retryCount = CASE WHEN state = '${states.retry}' THEN retryCount + 1 ELSE retryCount END
     FROM nextJob
     WHERE j.id = nextJob.id
-    RETURNING j.id, name, data
+    RETURNING ${includeMetadata ? 'j.*' : 'j.id, name, data'}
   `
 }
 

--- a/test/fetchTest.js
+++ b/test/fetchTest.js
@@ -55,7 +55,7 @@ describe('fetch', function () {
 
     const boss = await helper.start(this.test.bossConfig)
     await boss.publish(jobName)
-    const job = await boss.fetch(jobName, undefined, true)
+    const job = await boss.fetch(jobName, undefined, { includeMetadata: true })
     assert(jobName === job.name)
     assert(job.priority === 0)
     assert(job.state === 'active')
@@ -87,7 +87,7 @@ describe('fetch', function () {
       boss.publish(jobName)
     ])
 
-    const jobs = await boss.fetch(jobName, batchSize, true)
+    const jobs = await boss.fetch(jobName, batchSize, { includeMetadata: true })
     assert(jobs.length === batchSize)
 
     jobs.forEach(job => {

--- a/test/fetchTest.js
+++ b/test/fetchTest.js
@@ -23,6 +23,8 @@ describe('fetch', function () {
     await boss.publish(jobName)
     const job = await boss.fetch(jobName)
     assert(jobName === job.name)
+    // Metadata should only be included when specifically requested
+    assert(job.startedon === undefined)
     await boss.stop()
   })
 
@@ -42,7 +44,69 @@ describe('fetch', function () {
     const jobs = await boss.fetch(jobName, batchSize)
 
     assert(jobs.length === batchSize)
+    // Metadata should only be included when specifically requested
+    assert(jobs[0].startedon === undefined)
 
+    await boss.stop()
+  })
+
+  it('should fetch all metadata for a single job when requested', async function () {
+    const jobName = 'fetch-include-metadata'
+
+    const boss = await helper.start(this.test.bossConfig)
+    await boss.publish(jobName)
+    const job = await boss.fetch(jobName, undefined, true)
+    assert(jobName === job.name)
+    assert(job.priority === 0)
+    assert(job.state === 'active')
+    assert(job.retrylimit === 0)
+    assert(job.retrycount === 0)
+    assert(job.retrydelay === 0)
+    assert(job.retrybackoff === false)
+    assert(job.startafter !== undefined)
+    assert(job.startedon !== undefined)
+    assert(job.singletonkey === null)
+    assert(job.singletonon === null)
+    assert(job.expirein.minutes === 15)
+    assert(job.createdon !== undefined)
+    assert(job.completedon === null)
+    assert(job.keepuntil !== undefined)
+    await boss.stop()
+  })
+
+  it('should fetch all metadata for a batch of jobs when requested', async function () {
+    const jobName = 'fetch-include-metadata-batch'
+    const batchSize = 4
+
+    const boss = await helper.start(this.test.bossConfig)
+
+    await Promise.all([
+      boss.publish(jobName),
+      boss.publish(jobName),
+      boss.publish(jobName),
+      boss.publish(jobName)
+    ])
+
+    const jobs = await boss.fetch(jobName, batchSize, true)
+    assert(jobs.length === batchSize)
+
+    jobs.forEach(job => {
+      assert(jobName === job.name)
+      assert(job.priority === 0)
+      assert(job.state === 'active')
+      assert(job.retrylimit === 0)
+      assert(job.retrycount === 0)
+      assert(job.retrydelay === 0)
+      assert(job.retrybackoff === false)
+      assert(job.startafter !== undefined)
+      assert(job.startedon !== undefined)
+      assert(job.singletonkey === null)
+      assert(job.singletonon === null)
+      assert(job.expirein.minutes === 15)
+      assert(job.createdon !== undefined)
+      assert(job.completedon === null)
+      assert(job.keepuntil !== undefined)
+    })
     await boss.stop()
   })
 })

--- a/test/subscribeTest.js
+++ b/test/subscribeTest.js
@@ -292,4 +292,24 @@ describe('subscribe', function () {
 
     await boss.stop()
   })
+
+  it('should honor the includeMetadata option', function (finished) {
+    const queue = 'subscribe-includeMetadata'
+
+    const config = this.test.bossConfig
+
+    test()
+
+    async function test () {
+      const boss = await helper.start(config)
+
+      await boss.publish(queue)
+
+      boss.subscribe(queue, { includeMetadata: true }, async job => {
+        assert(job.startedon !== undefined)
+        await boss.stop()
+        finished()
+      }).catch(finished)
+    }
+  })
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -95,12 +95,17 @@ declare namespace PgBoss {
     teamSize?: number;
     teamConcurrency?: number;
     batchSize?: number;
+    includeMetadata?: boolean;
   }
 
   type SubscribeOptions = JobFetchOptions & JobPollingOptions
 
   interface SubscribeHandler<ReqData, ResData> {
     (job: PgBoss.JobWithDoneCallback<ReqData, ResData>, done: PgBoss.JobDoneCallback<ResData>): void;
+  }
+
+  interface SubscribeWithMetadataHandler<ReqData, ResData> {
+    (job: PgBoss.JobWithMetadataDoneCallback<ReqData, ResData>, done: PgBoss.JobDoneCallback<ResData>): void;
   }
 
   interface Request {
@@ -119,7 +124,30 @@ declare namespace PgBoss {
     data: T;
   }
 
+  interface JobWithMetadata<T = object> extends Job<T> {
+    priority: number;
+    state: 'created' | 'retry' | 'active' | 'completed' | 'expired' | 'cancelled' | 'failed';
+    retrylimit: number;
+    retrycount: number;
+    retrydelay: number;
+    retrybackoff: boolean;
+    startafter: Date;
+    // This is nullable in the schema, but by the time this type is reified,
+    // it will have been set.
+    startedon: Date;
+    singletonkey: string | null;
+    singletonon: Date | null;
+    expirein: PostgresInterval;
+    createdon: Date;
+    completedon: Date | null;
+    keepuntil: Date;
+  }
+
   interface JobWithDoneCallback<ReqData, ResData> extends Job<ReqData> {
+    done: JobDoneCallback<ResData>;
+  }
+
+  interface JobWithMetadataDoneCallback<ReqData, ResData> extends JobWithMetadata<ReqData> {
     done: JobDoneCallback<ResData>;
   }
 
@@ -171,6 +199,7 @@ declare class PgBoss {
   publishDebounced(name: string, data: object, options: PgBoss.PublishOptions, seconds: number, key: string): Promise<string | null>;
 
   subscribe<ReqData, ResData>(name: string, handler: PgBoss.SubscribeHandler<ReqData, ResData>): Promise<void>;
+  subscribe<ReqData, ResData>(name: string, options: PgBoss.SubscribeOptions & { includeMetadata: true }, handler: PgBoss.SubscribeWithMetadataHandler<ReqData, ResData>): Promise<void>;
   subscribe<ReqData, ResData>(name: string, options: PgBoss.SubscribeOptions, handler: PgBoss.SubscribeHandler<ReqData, ResData>): Promise<void>;
 
   unsubscribe(name: string): Promise<boolean>;
@@ -182,9 +211,13 @@ declare class PgBoss {
 
   fetch<T>(name: string): Promise<PgBoss.Job<T> | null>;
   fetch<T>(name: string, batchSize: number): Promise<PgBoss.Job<T>[] | null>;
+  fetch<T>(name: string, batchSize: number, includeMetadata: true): Promise<PgBoss.JobWithMetadata<T>[] | null>;
+  fetch<T>(name: string, batchSize: number, includeMetadata: boolean): Promise<PgBoss.Job<T>[] | null>;
 
   fetchCompleted<T>(name: string): Promise<PgBoss.Job<T> | null>;
   fetchCompleted<T>(name: string, batchSize: number): Promise<PgBoss.Job<T>[] | null>;
+  fetchCompleted<T>(name: string, batchSize: number, includeMetadata: true): Promise<PgBoss.JobWithMetadata<T>[] | null>;
+  fetchCompleted<T>(name: string, batchSize: number, includeMetadata: boolean): Promise<PgBoss.Job<T>[] | null>;
 
   cancel(id: string): Promise<void>;
   cancel(ids: string[]): Promise<void>;

--- a/types.d.ts
+++ b/types.d.ts
@@ -100,6 +100,10 @@ declare namespace PgBoss {
 
   type SubscribeOptions = JobFetchOptions & JobPollingOptions
 
+  type FetchOptions = {
+    includeMetadata?: boolean;
+  }
+
   interface SubscribeHandler<ReqData, ResData> {
     (job: PgBoss.JobWithDoneCallback<ReqData, ResData>, done: PgBoss.JobDoneCallback<ResData>): void;
   }
@@ -211,13 +215,13 @@ declare class PgBoss {
 
   fetch<T>(name: string): Promise<PgBoss.Job<T> | null>;
   fetch<T>(name: string, batchSize: number): Promise<PgBoss.Job<T>[] | null>;
-  fetch<T>(name: string, batchSize: number, includeMetadata: true): Promise<PgBoss.JobWithMetadata<T>[] | null>;
-  fetch<T>(name: string, batchSize: number, includeMetadata: boolean): Promise<PgBoss.Job<T>[] | null>;
+  fetch<T>(name: string, batchSize: number, options: PgBoss.FetchOptions & { includeMetadata: true }): Promise<PgBoss.JobWithMetadata<T>[] | null>;
+  fetch<T>(name: string, batchSize: number, options: PgBoss.FetchOptions): Promise<PgBoss.Job<T>[] | null>;
 
   fetchCompleted<T>(name: string): Promise<PgBoss.Job<T> | null>;
   fetchCompleted<T>(name: string, batchSize: number): Promise<PgBoss.Job<T>[] | null>;
-  fetchCompleted<T>(name: string, batchSize: number, includeMetadata: true): Promise<PgBoss.JobWithMetadata<T>[] | null>;
-  fetchCompleted<T>(name: string, batchSize: number, includeMetadata: boolean): Promise<PgBoss.Job<T>[] | null>;
+  fetchCompleted<T>(name: string, batchSize: number, options: PgBoss.FetchOptions & { includeMetadata: true }): Promise<PgBoss.JobWithMetadata<T>[] | null>;
+  fetchCompleted<T>(name: string, batchSize: number, options: PgBoss.FetchOptions): Promise<PgBoss.Job<T>[] | null>;
 
   cancel(id: string): Promise<void>;
   cancel(ids: string[]): Promise<void>;


### PR DESCRIPTION
As discussed in #166, this change allows a user to specify a boolean, `includeMetadata`, in both the `subscribe` options object and the `fetch` function. When `true`, those functions will return an extended version of the `Job` type that includes all columns in `pgboss.job`.

Includes tests and types.