### PR TITLE
Add missing `all` property to MonitorStates interface

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -156,6 +156,7 @@ declare namespace PgBoss {
   }
 
   interface MonitorStates {
+    all: number;
     created: number;
     retry: number;
     active: number;


### PR DESCRIPTION
As mentioned [here](https://github.com/timgit/pg-boss/blob/master/docs/usage.md#monitor-states), `MonitorStates` has an `all` property that's missing from the type definitions.