### PR TITLE
Update subscribe handler types to reflect removal of done arg and promise-returning handlers.

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -105,11 +105,11 @@ declare namespace PgBoss {
   }
 
   interface SubscribeHandler<ReqData, ResData> {
-    (job: PgBoss.JobWithDoneCallback<ReqData, ResData>, done: PgBoss.JobDoneCallback<ResData>): void;
+    (job: PgBoss.JobWithDoneCallback<ReqData, ResData>): Promise<ResData> | void;
   }
 
   interface SubscribeWithMetadataHandler<ReqData, ResData> {
-    (job: PgBoss.JobWithMetadataDoneCallback<ReqData, ResData>, done: PgBoss.JobDoneCallback<ResData>): void;
+    (job: PgBoss.JobWithMetadataDoneCallback<ReqData, ResData>): Promise<ResData> | void;
   }
 
   interface Request {


### PR DESCRIPTION
It looks like, since [3.0](https://github.com/timgit/pg-boss/blob/master/CHANGELOG.md#tada-300-tada), `SubscribeHandler`s no longer receive the `done` callback as a separate argument, and those handlers can optionally return a Promise rather than calling `done`. This updates the types to reflect those changes.