### PR TITLE
Importing types from @types/pg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-boss",
-  "version": "4.2.0",
+  "version": "4.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -295,6 +295,28 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
+      "dev": true
+    },
+    "@types/pg": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.14.3.tgz",
+      "integrity": "sha512-go5zddQ1FrUQHeBvqPzQ1svKo4KKucSwvqLsvwc/EIuQ9sxDA21b68xc/RwhzAK5pPCnez8NrkYatFIGdJBVvA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/pg-types": "*"
+      }
+    },
+    "@types/pg-types": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.5.tgz",
+      "integrity": "sha512-L8ogeT6vDzT1vxlW3KITTCt+BVXXVkLXfZ/XNm6UqbcJgxf+KPO7yjWx7dQQE8RW07KopL10x2gNMs41+IkMGQ==",
       "dev": true
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "coveralls": "^3.1.0",
     "mocha": "^7.1.2",
     "nyc": "^15.0.1",
-    "standard": "^14.3.3"
+    "standard": "^14.3.3",
+    "@types/pg": "^7.14.3"
   },
   "scripts": {
     "test": "standard && mocha --exit --no-warnings",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,24 +1,11 @@
 // Type definitions for pg-boss
-
+import {PoolConfig} from 'pg';
 declare namespace PgBoss {
   interface Db {
     executeSql(text: string, values: any[]): Promise<{ rows: any[]; rowCount: number }>;
   }
 
-  interface DatabaseOptions {
-    application_name?: string;
-    database?: string;
-    user?: string;
-    password?: string;
-    host?: string;
-    port?: number;
-    schema?: string;
-    ssl?: boolean;
-    connectionString?: string;
-    poolSize?: number;
-    max?: number;
-    db?: Db;
-  }
+  type DatabaseOptions = PoolConfig;
 
   interface QueueOptions {
     uuid?: "v1" | "v4";


### PR DESCRIPTION
This PR includes the fix suggested in issue #89 to have the more correct typings for the ssl parameter (used in pg's PoolConfig).