### PR TITLE
Allow passing a connection from publish to executeSql

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -170,6 +170,7 @@ class Manager extends EventEmitter {
 
   async createJob (name, data, options, singletonOffset = 0) {
     const {
+      connection,
       expireIn,
       priority,
       startAfter,
@@ -199,7 +200,7 @@ class Manager extends EventEmitter {
       keepUntil // 13
     ]
 
-    const result = await this.db.executeSql(this.insertJobCommand, values)
+    const result = await this.db.executeSql(this.insertJobCommand, values, { connection })
 
     if (result.rowCount === 1) {
       return result.rows[0].id

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,6 @@
 declare namespace PgBoss {
   interface Db {
-    executeSql(text: string, values: any[]): Promise<{ rows: any[]; rowCount: number }>;
+    executeSql(text: string, values: any[], options?: ExecutionOptions): Promise<{ rows: any[]; rowCount: number }>;
   }
 
   interface DatabaseOptions {
@@ -80,7 +80,11 @@ declare namespace PgBoss {
     singletonNextSlot?: boolean;
   }
 
-  type PublishOptions = JobOptions & ExpirationOptions & RetentionOptions & RetryOptions
+  interface ExecutionOptions {
+    connection?: any;
+  }
+
+  type PublishOptions = JobOptions & ExpirationOptions & RetentionOptions & RetryOptions & ExecutionOptions
 
   type ScheduleOptions = PublishOptions & { tz?: string }
 


### PR DESCRIPTION
Adds the option to pass a connection from publish to executeSql.
This allows creating transactions that encompass inserting jobs.

The test seems a bit messy, open to suggestions.

Fixes #199 