### PR TITLE
Update types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-boss",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/types.d.ts
+++ b/types.d.ts
@@ -32,7 +32,7 @@ declare namespace PgBoss {
 
   interface MaintenanceOptions {
     noSupervisor?: boolean;
-    
+
     deleteAfterSeconds?: number;
     deleteAfterMinutes?: number;
     deleteAfterHours?: number;
@@ -65,6 +65,7 @@ declare namespace PgBoss {
   }
 
   interface RetentionOptions {
+    retentionSeconds?: number;
     retentionMinutes?: number;
     retentionHours?: number;
     retentionDays?: number;
@@ -206,6 +207,10 @@ declare class PgBoss {
   on(event: "error", handler: (error: Error) => void): void;
   on(event: "maintenance", handler: () => void): void;
   on(event: "monitor-states", handler: (monitorStates: PgBoss.MonitorStates) => void): void;
+
+  off(event: "error", handler: (error: Error) => void): void;
+  off(event: "maintenance", handler: () => void): void;
+  off(event: "monitor-states", handler: (monitorStates: PgBoss.MonitorStates) => void): void;
 
   start(): Promise<PgBoss>;
   stop(): Promise<void>;


### PR DESCRIPTION
A few types were missing, so I added them in.

Technically speaking, since the main pg-boss object extends from a node `EventEmitter` it also has access to `emit`, `once`, `removeAllListeners`, etc. But I figured they aren't really needed here.

Oh, and the `package.lock` file was updated when I ran `npm install` since its version didn't match up with that in the main `package.json`.