### PR TITLE
Fix .stop() types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -255,7 +255,7 @@ declare class PgBoss {
   off(event: "stopped", handler: () => void): void;
 
   start(): Promise<PgBoss>;
-  stop(options: PgBoss.StopOptions): Promise<void>;
+  stop(options?: Partial<PgBoss.StopOptions>): Promise<void>;
 
   publish(request: PgBoss.Request): Promise<string | null>;
   publish(name: string, data: object): Promise<string | null>;


### PR DESCRIPTION
Currently this causes a typescript error:

<img width="226" alt="image" src="https://user-images.githubusercontent.com/2981250/120243071-e89d2e80-c266-11eb-93f6-574d2fa03d5b.png">

This PR fixes that by allowing `.stop()` to be called without any argument, truly using fallback/default options.