### PR TITLE
Graceful stop docs & improved types

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ pg-boss can be customized using configuration options when an instance is create
 - [Fetch options](#fetch-options)
 - [Subscribe options](#subscribe-options)
   - [Job polling options](#job-polling-options)
+- [Stop options](#stop-options)
 
 <!-- /TOC -->
 
@@ -321,3 +322,15 @@ How often subscriptions will poll the queue table for jobs. Available in the con
 Default: 2 seconds
 
 > When a higher unit is is specified, lower unit configuration settings are ignored.
+
+## Stop options
+
+Options to configure the graceful stop feature when calling `stop()` on the PgBoss instance.
+
+* **graceful**, bool
+
+    Default: `true`. If `true`, the PgBoss instance will wait for any workers that are currently processing jobs to finish, up to the specified timeout. During this period, new jobs will not be processed, but active jobs will be allowed to finish.
+
+* **timeout**, int
+
+    Default: 30000. Maximum time (in milliseconds) to wait for workers to finish job processing before shutting down the PgBoss instance.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -307,11 +307,17 @@ Additionally, all schema operations, both first-time provisioning and migrations
 
 One example of how this is useful would be including `start()` inside the bootstrapping of a pod in a ReplicaSet in Kubernetes. Being able to scale up your job processing using a container orchestration tool like k8s is becoming more and more popular, and pg-boss can be dropped into this system with no additional logic, fear, or special configuration.
 
-## `stop()`
+## `stop(options)`
+
+**Arguments**
+
+- `options`: optional object ([stop options](configuration.md#stop-options))
 
 **returns: Promise**
 
 All job monitoring will be stopped and all subscriptions on this instance will be removed. Basically, it's the opposite of `start()`. Even though `start()` may create new database objects during initialization, `stop()` will never remove anything from the database.
+
+By default, calling `stop()` without any arguments will gracefully wait for all workers to finish processing active jobs before closing the internal connection pool and stopping maintenance operations. This behaviour can be configured using the stop options object. In graceful stop mode, the promise returned by `stop()` will be resolved once all active jobs have finished, or will be rejected if the timeout is reached before jobs have finished processing.
 
 ## `publish()`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -317,7 +317,7 @@ One example of how this is useful would be including `start()` inside the bootst
 
 All job monitoring will be stopped and all subscriptions on this instance will be removed. Basically, it's the opposite of `start()`. Even though `start()` may create new database objects during initialization, `stop()` will never remove anything from the database.
 
-By default, calling `stop()` without any arguments will gracefully wait for all workers to finish processing active jobs before closing the internal connection pool and stopping maintenance operations. This behaviour can be configured using the stop options object. In graceful stop mode, the promise returned by `stop()` will be resolved once all active jobs have finished, or will be rejected if the timeout is reached before jobs have finished processing.
+By default, calling `stop()` without any arguments will gracefully wait for all workers to finish processing active jobs before closing the internal connection pool and stopping maintenance operations. This behaviour can be configured using the stop options object. In graceful stop mode, the promise returned by `stop()` will still be resolved immediately.  If monitoring for the end of the stop is needed, add a listener to the `stopped` event.
 
 ## `publish()`
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -214,8 +214,8 @@ declare namespace PgBoss {
   }
 
   interface StopOptions {
-    graceful: boolean,
-    timeout: number
+    graceful?: boolean,
+    timeout?: number
   }
 
   interface UnsubscribeOptions {
@@ -255,7 +255,7 @@ declare class PgBoss {
   off(event: "stopped", handler: () => void): void;
 
   start(): Promise<PgBoss>;
-  stop(options?: Partial<PgBoss.StopOptions>): Promise<void>;
+  stop(options?: PgBoss.StopOptions): Promise<void>;
 
   publish(request: PgBoss.Request): Promise<string | null>;
   publish(name: string, data: object): Promise<string | null>;


### PR DESCRIPTION
Thanks for landing the graceful stop feature in v6! It's something that will really help us in production.

I couldn't find any docs on this, so I took a stab at adding them. I must admit that I wasn't sure about the finer details, e.g. how the promise resolution works for `stop()` in graceful mode, so I would very much appreciate your insight here if anything isn't correct.

I also made a slight tweak to the types to be more consistent with the rest of the package, namely making the fields optional directly in the type, rather than using the `Partial` utility type.

Thanks again for all your hard work on this lib, it's working wonderfully for us. ❤️ 