### PR TITLE
Preserve nested objects in failure payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,29 @@ yarn add pg-boss
 ## Documentation
 * [Usage](docs/usage.md)
 * [Configuration](docs/configuration.md)
+
+## Contributing
+
+To setup a development environment for this library:
+
+```bash
+git clone https://github.com/timgit/pg-boss.git
+npm install
+
+```
+
+To run the test suite you will need to pgboss access to an empty postgres database. You can set one up using the following commands on a local postgres instance:
+
+```sql
+CREATE DATABASE pgboss;
+CREATE user postgres WITH PASSWORD 'postgres';
+GRANT ALL PRIVILEGES ON DATABASE pgboss to postgres;
+```
+
+If you use a different database name, username or password, or want to run the test suite against a database that is running on a remote machine then you will need to edit the `test/config.json` file with the appropriate connection values.
+
+You can then run the linter and test suite using:
+
+```bash
+npm run test
+```

--- a/src/manager.js
+++ b/src/manager.js
@@ -429,7 +429,11 @@ class Manager extends EventEmitter {
   mapCompletionDataArg (data) {
     if (data === null || typeof data === 'undefined' || typeof data === 'function') { return null }
 
-    if (data instanceof Error) { data = JSON.parse(JSON.stringify(data, Object.getOwnPropertyNames(data))) }
+    if (data instanceof Error) {
+      const newData = {}
+      Object.getOwnPropertyNames(data).forEach(key => { newData[key] = data[key] })
+      data = newData
+    }
 
     return (typeof data === 'object' && !Array.isArray(data))
       ? data

--- a/test/failureTest.js
+++ b/test/failureTest.js
@@ -98,11 +98,12 @@ describe('failure', function () {
     assert.strictEqual(job.data.response.someReason, failPayload.someReason)
   })
 
-  it('should preserve nested objects within a payload', async function () {
+  it('should preserve nested objects within a payload that is an instance of Error', async function () {
     const boss = this.test.boss = await helper.start(this.test.bossConfig)
 
     const queue = 'fail-payload'
-    const failPayload = { some: { deeply: { nested: { reason: 'nuna' } } } }
+    const failPayload = new Error('Something went wrong')
+    failPayload.some = { deeply: { nested: { reason: 'nuna' } } }
 
     const jobId = await boss.publish(queue, null, { onComplete: true })
 

--- a/test/failureTest.js
+++ b/test/failureTest.js
@@ -98,6 +98,22 @@ describe('failure', function () {
     assert.strictEqual(job.data.response.someReason, failPayload.someReason)
   })
 
+  it('should preserve nested objects within a payload', async function () {
+    const boss = this.test.boss = await helper.start(this.test.bossConfig)
+
+    const queue = 'fail-payload'
+    const failPayload = { some: { deeply: { nested: { reason: 'nuna' } } } }
+
+    const jobId = await boss.publish(queue, null, { onComplete: true })
+
+    await boss.fail(jobId, failPayload)
+
+    const job = await boss.fetchCompleted(queue)
+
+    assert.strictEqual(job.data.state, 'failed')
+    assert.strictEqual(job.data.response.some.deeply.nested.reason, failPayload.some.deeply.nested.reason)
+  })
+
   it('subscribe failure via done() should pass error payload to failed job', async function () {
     const boss = this.test.boss = await helper.start(this.test.bossConfig)
 


### PR DESCRIPTION
### Context

I am trying to save additional context and debugging information to the completion task in the case of a failed task, using code such as the following:

```javascript
const error = new Error('Something went wrong');
error.additionalContext = foo;
throw err;
```

### Bug
This works fine if `foo` is a number, string, or array. However if `foo` is a non-array object then pg-boss will convert it to the empty object. So if I do:

```javascript
const foo = { bar: 'baz' };
const error = new Error('Something went wrong');
error.additionalContext = foo;
throw err;
```

I will end up with:
```json
{
     "message": "Something went wrong",
     "stack": "...",
     "foo": {}
}
```

in the response property of my completion task.

### Cause of the bug

This is caused by the following line in the `mapCompletionDataArg` function in `manager.js`:

```javascript
if (data instanceof Error) { data = JSON.parse(JSON.stringify(data, Object.getOwnPropertyNames(data))) }
```

Here `Object.getOwnPropertyNames(data)` is an array of strings that functions as a [replacer function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter), which means that only properties whose name is in the array will get serialised. This is a clever trick to ensure that the non-enumerable `error` and `stack` properties get serialized. Unfortunately the replacer function/array also gets applied to properties in any nested objects.

In our example above `Object.getOwnPropertyNames(data)` will return `['message', 'stack', 'foo']`. As the string `bar` is not included in this array, when the `{ bar: 'baz' }` object is filtered by the replacer array the `bar` property is filtered out (if the nested object had more properties, then any other properties that didn't happen to share a name with a property on the top-level object would also be filtered out).

### Solution

I have replaced the problematic line above with the following code:

```javascript
if (data instanceof Error) {
    const newData = {}
    Object.getOwnPropertyNames(data).forEach(key => { newData[key] = data[key] })
    data = newData
}
```

It uses a "dumb loop" to perform the object clone, avoiding the need for `JSON.stringify` entirely. I did it this way because I thought it would be faster, but it does mean that we have a shallow clone of the object rather than deep clone. I believe this shouldn't make any difference here, but if you did want a deep clone then you could run `newData` through a standard `JSON.parse(JSON.serialize(...))` (no replacer needed) to get a deep clone which still retains the nested property data and the message and stack properties.

### Notes

I've also added a test for this case, and a section to the README explaining how to setup and run the test suite.