### PR TITLE
Highlight unknown Resolute namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "forcover": "npm run cover && nyc report --reporter=text-lcov | coveralls",
     "export-schema": "node ./scripts/construct.js",
     "export-migration": "node ./scripts/migrate.js",
-    "export-rollback": "node ./scripts/rollback.js"
+    "export-rollback": "node ./scripts/rollback.js",
+    "tsc": "tsc --noEmit types.d.ts"
   },
   "mocha": {
     "timeout": 10000,

--- a/types.d.ts
+++ b/types.d.ts
@@ -304,7 +304,7 @@ declare class PgBoss {
 
   subscribe(event: string, name: string): Promise<void>;
   unsubscribe(event: string, name: string): Promise<void>;
-  publish(request: Resolute.Request): Promise<string[]>;
+  publish(request: PgBoss.Request): Promise<string[]>;
 
   offComplete(name: string): Promise<void>;
   offComplete(options: PgBoss.OffWorkOptions): Promise<void>;


### PR DESCRIPTION
I updated to pg-boss 7 and got an error during compilation about an unknown namespace `Resolute` - was this a typo?  IIUC it should be `PgBoss` - anyway - feel free to close this PR - I raised it in the event my change was correct.

Also - looking in `publishTest.js` - it looks like there should be additional method signatures for `publish` (similar to send). I did not address that - in the event I was on the wrong track.

```
$ tsc --noEmit types.d.ts
types.d.ts:307:20 - error TS2503: Cannot find namespace 'Resolute'.

307   publish(request: Resolute.Request): Promise<string[]>;
                       ~~~~~~~~


Found 1 error.
```