### PR TITLE
Types: Extend core events.EventEmitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pg-boss",
       "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
@@ -16,6 +17,7 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
+        "@types/node": "^17.0.2",
         "coveralls": "^3.1.0",
         "luxon": "^2.0.1",
         "mocha": "^9.0.1",
@@ -534,6 +536,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
+      "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -5771,6 +5779,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
+      "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==",
       "dev": true
     },
     "@ungap/promise-all-settled": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/node": "^17.0.2",
     "coveralls": "^3.1.0",
     "luxon": "^2.0.1",
     "mocha": "^9.0.1",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'events'
+
 declare namespace PgBoss {
   interface Db {
     executeSql(text: string, values: any[]): Promise<{ rows: any[]; rowCount: number }>;
@@ -239,7 +241,7 @@ declare namespace PgBoss {
 
 }
 
-declare class PgBoss {
+declare class PgBoss extends EventEmitter {
   constructor(connectionString: string);
   constructor(options: PgBoss.ConstructorOptions);
 
@@ -254,20 +256,20 @@ declare class PgBoss {
   static getRollbackPlans(schema: string): string;
   static getRollbackPlans(): string;
 
-  on(event: "error", handler: (error: Error) => void): void;
-  off(event: "error", handler: (error: Error) => void): void;
+  on(event: "error", handler: (error: Error) => void): this;
+  off(event: "error", handler: (error: Error) => void): this;
 
-  on(event: "maintenance", handler: () => void): void;
-  off(event: "maintenance", handler: () => void): void;
+  on(event: "maintenance", handler: () => void): this;
+  off(event: "maintenance", handler: () => void): this;
 
-  on(event: "monitor-states", handler: (monitorStates: PgBoss.MonitorStates) => void): void;
-  off(event: "monitor-states", handler: (monitorStates: PgBoss.MonitorStates) => void): void;
+  on(event: "monitor-states", handler: (monitorStates: PgBoss.MonitorStates) => void): this;
+  off(event: "monitor-states", handler: (monitorStates: PgBoss.MonitorStates) => void): this;
 
-  on(event: "wip", handler: (data: PgBoss.Worker[]) => void): void;
-  off(event: "wip", handler: (data: PgBoss.Worker[]) => void): void;
+  on(event: "wip", handler: (data: PgBoss.Worker[]) => void): this;
+  off(event: "wip", handler: (data: PgBoss.Worker[]) => void): this;
 
-  on(event: "stopped", handler: () => void): void;
-  off(event: "stopped", handler: () => void): void;
+  on(event: "stopped", handler: () => void): this;
+  off(event: "stopped", handler: () => void): this;
 
   start(): Promise<PgBoss>;
   stop(options?: PgBoss.StopOptions): Promise<void>;


### PR DESCRIPTION
This extends the PgBoss class declaration with the core EventEmitter, to enable usage of other EventEmitter methods, such as `.removeListener()`, and also updates the `on()` and `off()` return values accordingly.

It does bring in an implicit peer-dependency on `@types/node` for TypeScript users though, which I'm not quite sure about how to deal with best. Another option could be adding it as a (peer-)dependency in the `package.json`, but that would impact non-TypeScript users, and TypeScript users would most likely already have the core types present anyway.