### PR TITLE
Add a type to MonitorStates.queue

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -203,7 +203,7 @@ declare namespace PgBoss {
     done: JobDoneCallback<ResData>;
   }
 
-  interface MonitorStates {
+  interface MonitorState {
     all: number;
     created: number;
     retry: number;
@@ -212,7 +212,10 @@ declare namespace PgBoss {
     expired: number;
     cancelled: number;
     failed: number;
-    queues: object;
+  }
+
+  interface MonitorStates extends MonitorState {
+    queues: { [queueName: string]: MonitorState };
   }
 
   interface Worker {


### PR DESCRIPTION
This adds a more complete type to `MonitorStates.queue`. The top level `MonitorStates` type shares most of the fields in common with each entry in `MonitorStates.queue` So `MonitorStates` ends up both extending the new type `MonitorState` as well as having an extra field `queue` which is an object with string keys and `MonitorState` values.