### PR TITLE
Missing typescript option, wrong default value

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -774,7 +774,7 @@ The default concurrency for `work()` is 1 job every 2 seconds. Both the interval
 
 * **teamConcurrency**, int
 
-    Default: 2. How many callbacks will be called concurrently if promises are used for polling backpressure. Intended to be used along with `teamSize`.
+    Default: 1. How many callbacks will be called concurrently if promises are used for polling backpressure. Intended to be used along with `teamSize`.
 
 * **teamRefill**, bool
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -102,6 +102,7 @@ declare namespace PgBoss {
   interface JobFetchOptions {
     teamSize?: number;
     teamConcurrency?: number;
+    teamRefill?: boolean;
     batchSize?: number;
     includeMetadata?: boolean;
   }


### PR DESCRIPTION
Based on the current version of the documentation, I couldn't find the teamRefill option in the typescript type definition. Also, the default value of teamConcurrency seems to be `1` in the manager.js file, and not `2` as written in the doc.