### PR TITLE
Ability to notify the workers to skip waiting

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -74,6 +74,7 @@ class Manager extends EventEmitter {
       this.fetchCompleted,
       this.work,
       this.offWork,
+      this.notifyWorker,
       this.onComplete,
       this.offComplete,
       this.publish,
@@ -292,6 +293,12 @@ class Manager extends EventEmitter {
         this.removeWorker(worker)
       }
     })
+  }
+
+  notifyWorker (workerId) {
+    if (this.workers.has(workerId)) {
+      this.workers.get(workerId).notify()
+    }
   }
 
   async subscribe (event, name) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -27,6 +27,15 @@ class Worker {
     this.stopping = false
     this.stopped = false
     this.loopDelayPromise = null
+    this.beenNotified = false
+  }
+
+  notify () {
+    this.beenNotified = true
+
+    if (this.loopDelayPromise) {
+      this.loopDelayPromise.clear()
+    }
   }
 
   async start () {
@@ -36,6 +45,7 @@ class Worker {
       const started = Date.now()
 
       try {
+        this.beenNotified = false
         const jobs = await this.fetch()
 
         this.lastFetchedOn = Date.now()
@@ -64,7 +74,7 @@ class Worker {
 
       this.lastJobDuration = duration
 
-      if (!this.stopping && duration < this.interval) {
+      if (!this.stopping && !this.beenNotified && duration < this.interval) {
         this.loopDelayPromise = delay(this.interval - duration)
         await this.loopDelayPromise
         this.loopDelayPromise = null

--- a/test/workTest.js
+++ b/test/workTest.js
@@ -68,6 +68,26 @@ describe('work', function () {
     assert.strictEqual(processCount, timeout / 1000 / newJobCheckIntervalSeconds)
   })
 
+  it('should honor when a worker is notified', async function () {
+    const boss = this.test.boss = await helper.start(this.test.bossConfig)
+    const queue = this.test.bossConfig.schema
+
+    let processCount = 0
+    const newJobCheckIntervalSeconds = 5
+
+    await boss.send(queue)
+
+    const workerId = await boss.work(queue, { newJobCheckIntervalSeconds }, () => processCount++)
+    await delay(100)
+    assert.strictEqual(processCount, 1)
+    await boss.send(queue)
+
+    boss.notifyWorker(workerId)
+
+    await delay(100)
+    assert.strictEqual(processCount, 2)
+  })
+
   it('should remove a worker', async function () {
     const boss = this.test.boss = await helper.start(this.test.bossConfig)
     const queue = this.test.bossConfig.schema

--- a/types.d.ts
+++ b/types.d.ts
@@ -308,6 +308,12 @@ declare class PgBoss extends EventEmitter {
   offWork(name: string): Promise<void>;
   offWork(options: PgBoss.OffWorkOptions): Promise<void>;
 
+  /**
+   * Notify worker that something has changed
+   * @param workerId 
+   */
+  notifyWorker(workerId: string): void;
+
   subscribe(event: string, name: string): Promise<void>;
   unsubscribe(event: string, name: string): Promise<void>;
   publish(event: string): Promise<string[]>;


### PR DESCRIPTION
Add a method which notifies the worker that something has been changed and therefore canceling or skipping the loopDelay.

This gives ability reduce the jobs overal latency.