### PR TITLE
Support singleton queue behavior for any singletonKey

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -547,6 +547,15 @@ Available in constructor as a default, or overridden in send.
 
   This can be used in conjunction with throttling explained below.
 
+  * **useSingletonQueue** boolean
+
+  When used in conjunction with singletonKey, only allows 1 job (within the same name) to be queued with the same singletonKey.
+
+  ```js
+  boss.send('my-job', {}, {singletonKey: '123', useSingletonQueue: true}) // resolves a jobId
+  boss.send('my-job', {}, {singletonKey: '123', useSingletonQueue: true}) // resolves a null jobId until first job becomes active
+  ```
+
 **Throttled jobs**
 
 * **singletonSeconds**, int

--- a/src/manager.js
+++ b/src/manager.js
@@ -446,8 +446,8 @@ class Manager extends EventEmitter {
   }
 
   async insert (jobs) {
-    assert(Array.isArray(jobs), `jobs argument should be an array.  Received '${typeof jobs}'`)
-    const data = JSON.stringify(jobs)
+    const checkedJobs = Attorney.checkInsertArgs(jobs)
+    const data = JSON.stringify(checkedJobs)
     return await this.db.executeSql(this.insertJobsCommand, [data])
   }
 

--- a/src/migrationStore.js
+++ b/src/migrationStore.js
@@ -68,6 +68,23 @@ function getAll (schema, config) {
 
   return [
     {
+      release: '7.4.0', // TODO: verify this version
+      version: 20,
+      previous: 19,
+      install: [
+        `DROP INDEX ${schema}.job_singletonKey`,
+        `DROP INDEX ${schema}.job_singleton_queue`,
+        `CREATE UNIQUE INDEX job_singletonKey ON ${schema}.job (name, singletonKey) WHERE state < 'completed' AND singletonOn IS NULL AND NOT singletonKey LIKE '\\_\\_pgboss\\_\\_singleton\\_queue%'`,
+        `CREATE UNIQUE INDEX job_singleton_queue ON ${schema}.job (name, singletonKey) WHERE state < 'active' AND singletonOn IS NULL AND singletonKey LIKE '\\_\\_pgboss\\_\\_singleton\\_queue%'`
+      ],
+      uninstall: [
+        `DROP INDEX ${schema}.job_singletonKey`,
+        `DROP INDEX ${schema}.job_singleton_queue`,
+        `CREATE UNIQUE INDEX job_singletonKey ON ${schema}.job (name, singletonKey) WHERE state < 'completed' AND singletonOn IS NULL AND NOT singletonKey = '__pgboss__singleton_queue'`,
+        `CREATE UNIQUE INDEX job_singleton_queue ON ${schema}.job (name, singletonKey) WHERE state < 'active' AND singletonOn IS NULL AND singletonKey = '__pgboss__singleton_queue'`
+      ]
+    },
+    {
       release: '7.0.0',
       version: 19,
       previous: 18,

--- a/src/plans.js
+++ b/src/plans.js
@@ -13,6 +13,7 @@ const states = {
 const DEFAULT_SCHEMA = 'pgboss'
 const COMPLETION_JOB_PREFIX = `__state__${states.completed}__`
 const SINGLETON_QUEUE_KEY = '__pgboss__singleton_queue'
+const SINGLETON_QUEUE_KEY_ESCAPED = SINGLETON_QUEUE_KEY.replace(/_/g, '\\_')
 
 const MIGRATE_RACE_MESSAGE = 'division by zero'
 const CREATE_RACE_MESSAGE = 'already exists'
@@ -214,14 +215,14 @@ function getQueueSize (schema, options = {}) {
 function createIndexSingletonKey (schema) {
   // anything with singletonKey means "only 1 job can be queued or active at a time"
   return `
-    CREATE UNIQUE INDEX job_singletonKey ON ${schema}.job (name, singletonKey) WHERE state < '${states.completed}' AND singletonOn IS NULL AND NOT singletonKey = '${SINGLETON_QUEUE_KEY}'
+    CREATE UNIQUE INDEX job_singletonKey ON ${schema}.job (name, singletonKey) WHERE state < '${states.completed}' AND singletonOn IS NULL AND NOT singletonKey LIKE '${SINGLETON_QUEUE_KEY_ESCAPED}%'
   `
 }
 
 function createIndexSingletonQueue (schema) {
   // "singleton queue" means "only 1 job can be queued at a time"
   return `
-    CREATE UNIQUE INDEX job_singleton_queue ON ${schema}.job (name, singletonKey) WHERE state < '${states.active}' AND singletonOn IS NULL AND singletonKey = '${SINGLETON_QUEUE_KEY}'
+    CREATE UNIQUE INDEX job_singleton_queue ON ${schema}.job (name, singletonKey) WHERE state < '${states.active}' AND singletonOn IS NULL AND singletonKey LIKE '${SINGLETON_QUEUE_KEY_ESCAPED}%'
   `
 }
 

--- a/test/multiMasterTest.js
+++ b/test/multiMasterTest.js
@@ -20,7 +20,7 @@ describe('multi-master', function () {
     try {
       await pMap(instances, i => i.start())
     } catch (err) {
-      assert(false)
+      assert(false, err.message)
     } finally {
       await pMap(instances, i => i.stop({ graceful: false }))
     }

--- a/types.d.ts
+++ b/types.d.ts
@@ -84,6 +84,7 @@ declare namespace PgBoss {
     priority?: number;
     startAfter?: number | string | Date;
     singletonKey?: string;
+    useSingletonQueue?: boolean;
     singletonSeconds?: number;
     singletonMinutes?: number;
     singletonHours?: number;

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "schema": 19
+  "schema": 20
 }


### PR DESCRIPTION
This updates the `job_singleton_queue` index to drive the special singleton queue behavior for any singletonKey that _starts with_ `__pgboss__singleton_queue`--not just equal to it. In effect, this allows multiple singleton queues per job name (see discussion: https://github.com/timgit/pg-boss/discussions/285).

I included the new boolean option `useSingletonQueue` to prepend the passed singletonKey with `__pgboss__singleton_queue`. Otherwise, it has no effect.

This should not impact existing behavior UNLESS someone already had a singletonKey that is prepended with `__pgboss__singleton_queue` but not equal to `__pgboss__singleton_queue`. That seems highly unlikely.

FYI: I wasn't sure about the appropriate versioning and I had some issues running the CI tests locally. I'll add some comments about that.