### PR TITLE
Add support for destroy option

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -438,6 +438,9 @@ By default, calling `stop()` without any arguments will gracefully wait for all 
 
 * `options`: object
 
+  * `destroy`, bool
+    Default: `false`. If `true` and the database connection is managed by pg-boss, it will destroy the connection pool.
+
   * `graceful`, bool
 
     Default: `true`. If `true`, the PgBoss instance will wait for any workers that are currently processing jobs to finish, up to the specified timeout. During this period, new jobs will not be processed, but active jobs will be allowed to finish.

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ class PgBoss extends EventEmitter {
       this.emit(events.stopped)
     }
 
-    let { graceful = true, timeout = 30000 } = options
+    let { destroy = false, graceful = true, timeout = 30000 } = options
 
     timeout = Math.max(timeout, 1000)
 
@@ -138,6 +138,10 @@ class PgBoss extends EventEmitter {
     const shutdown = async () => {
       this.stopped = true
       this.stoppingOn = null
+
+      if (this.db.isOurs && this.db.opened && destroy) {
+        await this.db.close()
+      }
 
       this.emit(events.stopped)
     }

--- a/test/opsTest.js
+++ b/test/opsTest.js
@@ -63,6 +63,23 @@ describe('ops', function () {
     await boss.stop({ graceful: false })
   })
 
+  it('should destroy the connection pool', async function () {
+    const boss = this.test.boss = await helper.start({ ...this.test.bossConfig, ...defaults })
+    await boss.stop({ destroy: true, graceful: false })
+
+    assert(boss.db.pool.totalCount === 0)
+  })
+
+  it('should destroy the connection pool gracefully', async function () {
+    const boss = this.test.boss = await helper.start({ ...this.test.bossConfig, ...defaults })
+    await boss.stop({ destroy: true })
+    await new Promise((resolve) => {
+      boss.on('stopped', () => resolve())
+    })
+
+    assert(boss.db.pool.totalCount === 0)
+  })
+
   it('should emit error during graceful stop if worker is busy', async function () {
     const boss = await helper.start({ ...this.test.bossConfig, ...defaults, __test__throw_stop: true })
     const queue = this.test.bossConfig.schema

--- a/types.d.ts
+++ b/types.d.ts
@@ -242,6 +242,7 @@ declare namespace PgBoss {
   }
 
   interface StopOptions {
+    destroy?: boolean,
     graceful?: boolean,
     timeout?: number
   }


### PR DESCRIPTION
This PR adds support for `destroy` as an option for the `stop()` method.  
If the database connection is handled by `pb-boss`, this option will make it possible to close the `pg` connection pool.  

Closes #318 