### PR TITLE
fix: limit 1 active singleton queue job

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Queueing jobs in Node.js using PostgreSQL like a boss.
 
-[![PostgreSql Version](https://img.shields.io/badge/PostgreSQL-9.5+-blue.svg?maxAge=2592000)](http://www.postgresql.org)
+[![PostgreSql Version](https://img.shields.io/badge/PostgreSQL-11+-blue.svg?maxAge=2592000)](http://www.postgresql.org)
 [![npm version](https://badge.fury.io/js/pg-boss.svg)](https://badge.fury.io/js/pg-boss)
 [![Build Status](https://app.travis-ci.com/timgit/pg-boss.svg?branch=master)](https://app.travis-ci.com/github/timgit/pg-boss)
 [![Coverage Status](https://coveralls.io/repos/github/timgit/pg-boss/badge.svg?branch=master)](https://coveralls.io/github/timgit/pg-boss?branch=master)
@@ -51,7 +51,7 @@ This will likely cater the most to teams already familiar with the simplicity of
 
 ## Requirements
 * Node 14 or higher
-* PostgreSQL 9.5 or higher
+* PostgreSQL 11 or higher
 
 ## Installation
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -559,7 +559,7 @@ Available in constructor as a default, or overridden in send.
 
 * **singletonKey** string
 
-  Only allows 1 job (within the same name) to be queued or active with the same singletonKey.
+  Allows a max of 1 job (with the same name and singletonKey) to be queued or active.
 
   ```js
   boss.send('my-job', {}, {singletonKey: '123'}) // resolves a jobId
@@ -570,7 +570,9 @@ Available in constructor as a default, or overridden in send.
 
   * **useSingletonQueue** boolean
 
-  When used in conjunction with singletonKey, only allows 1 job (within the same name) to be queued with the same singletonKey.
+    When used in conjunction with singletonKey, allows a max of 1 job to be queued.
+
+    >By default, there is no limit on the number of these jobs that may be active. However, this behavior may be modified by passing the [enforceSingletonQueueActiveLimit](#fetch) option.
 
   ```js
   boss.send('my-job', {}, {singletonKey: '123', useSingletonQueue: true}) // resolves a jobId
@@ -744,6 +746,11 @@ Typically one would use `work()` for automated polling for new jobs based upon a
     | oncomplete | bool |
     | output | object |
 
+  * `enforceSingletonQueueActiveLimit`, bool
+
+    If `true`, modifies the behavior of the `useSingletonQueue` flag to allow a max of 1 job to be queued plus a max of 1 job to be active.
+    >Note that use of this option can impact performance on instances with large numbers of jobs.
+
 
 **Resolves**
 - `[job]`: array of job objects, `null` if none found
@@ -816,6 +823,10 @@ The default concurrency for `work()` is 1 job every 2 seconds. Both the interval
     How many jobs can be fetched per polling interval.  Callback will be executed once per batch.
 
 * **includeMetadata**, bool
+
+    Same as in [`fetch()`](#fetch)
+
+* **enforceSingletonQueueActiveLimit**, bool
 
     Same as in [`fetch()`](#fetch)
 

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -129,6 +129,7 @@ function checkWorkArgs (name, args, defaults) {
   assert(!('teamSize' in options) || (Number.isInteger(options.teamSize) && options.teamSize >= 1), 'teamSize must be an integer > 0')
   assert(!('batchSize' in options) || (Number.isInteger(options.batchSize) && options.batchSize >= 1), 'batchSize must be an integer > 0')
   assert(!('includeMetadata' in options) || typeof options.includeMetadata === 'boolean', 'includeMetadata must be a boolean')
+  assert(!('enforceSingletonQueueActiveLimit' in options) || typeof options.enforceSingletonQueueActiveLimit === 'boolean', 'enforceSingletonQueueActiveLimit must be a boolean')
 
   return { options, callback }
 }
@@ -140,6 +141,7 @@ function checkFetchArgs (name, batchSize, options) {
 
   assert(!batchSize || (Number.isInteger(batchSize) && batchSize >= 1), 'batchSize must be an integer > 0')
   assert(!('includeMetadata' in options) || typeof options.includeMetadata === 'boolean', 'includeMetadata must be a boolean')
+  assert(!('enforceSingletonQueueActiveLimit' in options) || typeof options.enforceSingletonQueueActiveLimit === 'boolean', 'enforceSingletonQueueActiveLimit must be a boolean')
 
   return { name }
 }

--- a/src/db.js
+++ b/src/db.js
@@ -28,6 +28,14 @@ class Db extends EventEmitter {
       return await this.pool.query(text, values)
     }
   }
+
+  static quotePostgresStr (str) {
+    const delimeter = '$sanitize$'
+    if (str.includes(delimeter)) {
+      throw new Error(`Attempted to quote string that contains reserved Postgres delimeter: ${str}`)
+    }
+    return `${delimeter}${str}${delimeter}`
+  }
 }
 
 module.exports = Db

--- a/src/manager.js
+++ b/src/manager.js
@@ -184,7 +184,8 @@ class Manager extends EventEmitter {
       teamSize = 1,
       teamConcurrency = 1,
       teamRefill: refill = false,
-      includeMetadata = false
+      includeMetadata = false,
+      enforceSingletonQueueActiveLimit = false
     } = options
 
     const id = uuid.v4()
@@ -208,7 +209,7 @@ class Manager extends EventEmitter {
       createTeamRefillPromise()
     }
 
-    const fetch = () => this.fetch(name, batchSize || (teamSize - queueSize), { includeMetadata })
+    const fetch = () => this.fetch(name, batchSize || (teamSize - queueSize), { includeMetadata, enforceSingletonQueueActiveLimit })
 
     const onFetch = async (jobs) => {
       if (this.config.__test__throw_worker) {
@@ -475,7 +476,7 @@ class Manager extends EventEmitter {
     const values = Attorney.checkFetchArgs(name, batchSize, options)
     const db = options.db || this.db
     const result = await db.executeSql(
-      this.nextJobCommand(options.includeMetadata || false),
+      this.nextJobCommand(options.includeMetadata || false, options.enforceSingletonQueueActiveLimit || false),
       [values.name, batchSize || 1]
     )
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -6,6 +6,7 @@ const debounce = require('lodash.debounce')
 const { serializeError: stringify } = require('serialize-error')
 const Attorney = require('./attorney')
 const Worker = require('./worker')
+const Db = require('./db')
 const pMap = require('p-map')
 
 const { QUEUES: BOSS_QUEUES } = require('./boss')
@@ -475,10 +476,26 @@ class Manager extends EventEmitter {
   async fetch (name, batchSize, options = {}) {
     const values = Attorney.checkFetchArgs(name, batchSize, options)
     const db = options.db || this.db
-    const result = await db.executeSql(
-      this.nextJobCommand(options.includeMetadata || false, options.enforceSingletonQueueActiveLimit || false),
-      [values.name, batchSize || 1]
-    )
+    const preparedStatement = this.nextJobCommand(options.includeMetadata || false, options.enforceSingletonQueueActiveLimit || false)
+    const statementValues = [values.name, batchSize || 1]
+
+    let result
+    if (options.enforceSingletonQueueActiveLimit && !options.db) {
+      // Prepare/format now and send multi-statement transaction
+      const fetchQuery = preparedStatement
+        .replace('$1', Db.quotePostgresStr(statementValues[0]))
+        .replace('$2', statementValues[1].toString())
+      // eslint-disable-next-line no-unused-vars
+      const [_begin, _setLocal, fetchResult, _commit] = await db.executeSql([
+        'BEGIN',
+        'SET LOCAL jit = OFF', // JIT can slow things down significantly
+        fetchQuery,
+        'COMMIT'
+      ].join(';\n'))
+      result = fetchResult
+    } else {
+      result = await db.executeSql(preparedStatement, statementValues)
+    }
 
     if (!result || result.rows.length === 0) {
       return null

--- a/src/plans.js
+++ b/src/plans.js
@@ -364,11 +364,12 @@ function fetchNextJob (schema) {
             WHEN singletonKey IS NOT NULL
               AND singletonKey LIKE '${SINGLETON_QUEUE_KEY_ESCAPED}%'
               THEN NOT EXISTS (
-                SELECT *
+                SELECT 1
                 FROM ${schema}.job active_job
                 WHERE active_job.state = '${states.active}'
                   AND active_job.name = j.name
                   AND active_job.singletonKey = j.singletonKey
+                  LIMIT 1
               )
             ELSE
               true

--- a/test/databaseTest.js
+++ b/test/databaseTest.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const PgBoss = require('../')
+const Db = require('../src/db')
 
 describe('database', function () {
   it('should fail on invalid database host', async function () {
@@ -24,5 +25,22 @@ describe('database', function () {
     const response = await boss.db.executeSql(query)
 
     assert(response.text === query)
+  })
+
+  describe('Db.quotePostgresStr', function () {
+    it('should dollar-sign quote specified input', async function () {
+      const str = Db.quotePostgresStr('Here\'s my input')
+      assert(str === '$sanitize$Here\'s my input$sanitize$')
+    })
+
+    it('should error if input contains reserved quote delimiter', async function () {
+      const badInput = '$sanitize$; DROP TABLE job --'
+      try {
+        Db.quotePostgresStr(badInput)
+        assert(false, 'Error was expected but did not occur')
+      } catch (err) {
+        assert(err.message === `Attempted to quote string that contains reserved Postgres delimeter: ${badInput}`)
+      }
+    })
   })
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -113,12 +113,14 @@ declare namespace PgBoss {
     teamRefill?: boolean;
     batchSize?: number;
     includeMetadata?: boolean;
+    enforceSingletonQueueActiveLimit?: boolean;
   }
 
   type WorkOptions = JobFetchOptions & JobPollingOptions
 
   type FetchOptions = {
     includeMetadata?: boolean;
+    enforceSingletonQueueActiveLimit?: boolean;
   } & ConnectionOptions;
 
   interface WorkHandler<ReqData, ResData> {


### PR DESCRIPTION
See relevant issue: https://github.com/timgit/pg-boss/issues/367

This PR would change the behavior of "singleton queue" jobs (i.e., `singletonKey` + `useSingletonQueue=true`) as follows:
- BEFORE: Max 1 job queued, no restrictions on active jobs
- AFTER: Max 1 job queued, max 1 job active

My assumption is that this is a bug--or at least not intentional or desired behavior--and so it does not warrant a breaking change or the need for configurability.