### PR TITLE
Prevent node from dying when DB unavailable by wrapping `getMaintenanceTime`

### DIFF
--- a/src/boss.js
+++ b/src/boss.js
@@ -76,13 +76,17 @@ class Boss extends EventEmitter {
     }
   }
 
-  metaMonitor () {
+  metaMonitor() {
     this.metaMonitorInterval = setInterval(async () => {
-      const { secondsAgo } = await this.getMaintenanceTime()
+      try {
+        const { secondsAgo } = await this.getMaintenanceTime()
 
-      if (secondsAgo > this.maintenanceIntervalSeconds * 2) {
-        await this.manager.deleteQueue(queues.MAINTENANCE, { before: states.completed })
-        await this.maintenanceAsync()
+        if (secondsAgo > this.maintenanceIntervalSeconds * 2) {
+          await this.manager.deleteQueue(queues.MAINTENANCE, { before: states.completed })
+          await this.maintenanceAsync()
+        }
+      } catch (err) {
+        this.emit(events.error, err)
       }
     }, this.maintenanceIntervalSeconds * 2 * 1000)
   }


### PR DESCRIPTION
Hey @timgit!

I was doing some testing on the latest release (thanks again for that BTW!) before bumping our version in Wasp and noticed if I killed the DB I could still get an error that took down node. It appears the issue is there was a call in `Boss.metaMonitor` to `Boss.getMaintenanceTime` that was not wrapped like some of the others and will blow up if no DB is available.

This small PR just wraps it the function that calls it. If you would like me to add any tests like the others, or make any other tweaks, I can as well. 👍🏻 

Thanks!
Shayne
