### PR TITLE
Creating new function to edit the startAfter date of a job

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -61,7 +61,7 @@
   - [`deleteQueue(name)`](#deletequeuename)
   - [`deleteAllQueues()`](#deleteallqueues)
   - [`clearStorage()`](#clearstorage)
-  - [`updateStartAfterDate(id, newDate, options)`](#cancelid-options)
+  - [`updateStartAfterDate(id, newDate, options)`](#updateStartAfterDateid-newDate-options)
 
 <!-- /TOC -->
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -61,6 +61,7 @@
   - [`deleteQueue(name)`](#deletequeuename)
   - [`deleteAllQueues()`](#deleteallqueues)
   - [`clearStorage()`](#clearstorage)
+  - [`updateStartAfterDate(id, newDate, options)`](#cancelid-options)
 
 <!-- /TOC -->
 
@@ -1096,3 +1097,23 @@ Deletes all pending jobs from all queues in the active job table. All jobs in th
 ## `clearStorage()`
 
 Utility function if and when needed to empty all job storage. Internally, this issues a `TRUNCATE` command against all jobs tables, archive included.
+
+## `updateStartAfterDate(id, newDate, options)`
+
+Edits the ``startafter`` value of a job
+
+```js
+
+    const originalDate = new Date()
+    
+    const jobId = await boss.send('start_after_date_should_change', null, { startAfter: originalDate })
+
+    const newDate = new Date(originalDate.setMonth(originalDate.getMonth() + 1))
+
+    await boss.updateStartAfterDate(jobId, newDate)
+
+    const job = await boss.getJobById(jobId)
+
+    console.log(job.startafter) // should now resemble newDate 
+
+```

--- a/src/manager.js
+++ b/src/manager.js
@@ -614,6 +614,11 @@ class Manager extends EventEmitter {
   }
 
   async updateStartAfterDate (id, newDate, options = {}) {
+    // check if newDate is a valid date
+    if (isNaN(newDate.getTime())) {
+      throw new Error('Invalid date')
+    }
+
     const db = options.db || this.db
     const ids = this.mapCompletionIdArg(id, 'updateStartAfterDate')
     const result = await db.executeSql(this.updateStartAfterDateCommand, [ids, newDate])

--- a/src/manager.js
+++ b/src/manager.js
@@ -64,6 +64,7 @@ class Manager extends EventEmitter {
     this.subscribeCommand = plans.subscribe(config.schema)
     this.unsubscribeCommand = plans.unsubscribe(config.schema)
     this.getQueuesForEventCommand = plans.getQueuesForEvent(config.schema)
+    this.updateStartAfterDateCommand = plans.updateStartAfterDate(config.schema)
 
     // exported api to index
     this.functions = [
@@ -92,7 +93,8 @@ class Manager extends EventEmitter {
       this.deleteAllQueues,
       this.clearStorage,
       this.getQueueSize,
-      this.getJobById
+      this.getJobById,
+      this.updateStartAfterDate
     ]
 
     this.emitWipThrottled = debounce(() => this.emit(events.wip, this.getWipData()), WIP_EVENT_INTERVAL, WIP_DEBOUNCE_OPTIONS)
@@ -609,6 +611,13 @@ class Manager extends EventEmitter {
     }
 
     return null
+  }
+
+  async updateStartAfterDate (id, newDate, options = {}) {
+    const db = options.db || this.db
+    const ids = this.mapCompletionIdArg(id, 'updateStartAfterDate')
+    const result = await db.executeSql(this.updateStartAfterDateCommand, [ids, newDate])
+    return this.mapCompletionResponse(ids, result)
   }
 }
 

--- a/src/plans.js
+++ b/src/plans.js
@@ -54,6 +54,7 @@ module.exports = {
   assertMigration,
   getArchivedJobById,
   getJobById,
+  updateStartAfterDate,
   states: { ...states },
   COMPLETION_JOB_PREFIX,
   SINGLETON_QUEUE_KEY,
@@ -710,4 +711,17 @@ function getArchivedJobById (schema) {
 
 function getJobByTableAndId (schema, table) {
   return `SELECT * From ${schema}.${table} WHERE id = $1`
+}
+
+function updateStartAfterDate (schema, newDate) {
+  return `
+    with results as (
+      UPDATE ${schema}.job
+      SET startafter = $2
+      WHERE id IN (SELECT UNNEST($1::uuid[]))
+        AND state < '${states.completed}'
+      RETURNING 1
+    )
+    SELECT COUNT(*) from results
+  `
 }

--- a/test/updateStartAfterDateTest.js
+++ b/test/updateStartAfterDateTest.js
@@ -21,6 +21,24 @@ describe('updateStartAfter', function () {
     assert.strictEqual(jobStartAfterDateMs, newDateMs)
   })
 
+  it('should throw an error if date is not valid', async function () {
+    const config = this.test.bossConfig
+    const boss = this.test.boss = await helper.start(config)
+
+    const queue = 'invalid_start_after_date_should_throw_error'
+
+    const id = await boss.send(queue)
+
+    const newDate = "I'm not a date!"
+
+    try {
+      await boss.updateStartAfterDate(id, newDate)
+      assert(false)
+    } catch (err) {
+      assert(err)
+    }
+  })
+
   it('should not update a completed job', async function () {
     const config = this.test.bossConfig
     const boss = this.test.boss = await helper.start(config)

--- a/test/updateStartAfterDateTest.js
+++ b/test/updateStartAfterDateTest.js
@@ -1,0 +1,42 @@
+const assert = require('assert')
+const helper = require('./testHelper')
+
+describe('updateStartAfter', function () {
+  it('should edit the startAfter date of a job', async function () {
+    const config = this.test.bossConfig
+    const boss = this.test.boss = await helper.start(config)
+
+    const originalDate = new Date()
+    const newDate = new Date(originalDate.setMonth(originalDate.getMonth() + 1))
+
+    const jobId = await boss.send('start_after_date_should_change', null, { startAfter: originalDate })
+
+    await boss.updateStartAfterDate(jobId, newDate)
+
+    const job = await boss.getJobById(jobId)
+
+    const jobStartAfterDateMs = new Date(job.startafter).getTime()
+    const newDateMs = newDate.getTime()
+
+    assert.strictEqual(jobStartAfterDateMs, newDateMs)
+  })
+
+  it('should not update a completed job', async function () {
+    const config = this.test.bossConfig
+    const boss = this.test.boss = await helper.start(config)
+
+    const queue = 'will_not_update_start_after_date'
+
+    const newDate = new Date(Date.now() + 10000)
+
+    await boss.send(queue)
+
+    const fetchedJob = await boss.fetch(queue)
+
+    await boss.complete(fetchedJob.id)
+
+    const response = await boss.updateStartAfterDate(fetchedJob.id, newDate)
+
+    assert.strictEqual(response.updated, 0)
+  })
+})

--- a/types.d.ts
+++ b/types.d.ts
@@ -379,6 +379,8 @@ declare class PgBoss extends EventEmitter {
   schedule(name: string, cron: string, data?: object, options?: PgBoss.ScheduleOptions): Promise<void>;
   unschedule(name: string): Promise<void>;
   getSchedules(): Promise<PgBoss.Schedule[]>;
+
+  updateStartAfterDate(id: string, newDate: Date, options?: PgBoss.ConnectionOptions): Promise<void>;
 }
 
 export = PgBoss;


### PR DESCRIPTION
🚀 **Enhancement**: Introduced a function to seamlessly update the startAfter date of a job.
🔍 **Why**? Avoids using raw SQL or the inefficient method of deleting and recreating jobs if a job is to have a rescheduled startAfter date.
🛠 **How**? Accepts job ID and a valid new date, updating the startAfter field.
✅ **Extras**: Tests written and README updated.

Related: https://github.com/timgit/pg-boss/discussions/398 