### PR TITLE
add new sendQueued() that sets `options.shouldQueueAll`

### DIFF
--- a/test/throttleTest.js
+++ b/test/throttleTest.js
@@ -111,4 +111,23 @@ describe('throttle', function () {
 
     assert.strictEqual(jobId2, null)
   })
+
+  it('should log 4 jobs when called by 4 sendQueued()', async function () {
+    const boss = this.test.boss = await helper.start(this.test.bossConfig)
+
+    const queue = 'debounced-compile-4-jobs'
+    const seconds = 60
+
+    const jobId1 = await boss.sendQueued(queue, null, null, seconds)
+
+    assert(jobId1)
+
+    const jobId2 = await boss.sendQueued(queue, null, null, seconds)
+
+    assert.notEqual(jobId2, null)
+
+    const jobId3 = await boss.sendQueued(queue, null, { shouldQueueAll: true }, seconds)
+
+    assert.notEqual(jobId3, null)
+  })
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -310,6 +310,9 @@ declare class PgBoss extends EventEmitter {
   sendDebounced(name: string, data: object, options: PgBoss.SendOptions, seconds: number): Promise<string | null>;
   sendDebounced(name: string, data: object, options: PgBoss.SendOptions, seconds: number, key: string): Promise<string | null>;
 
+  sendQueued(name: string, data: object, options: PgBoss.SendOptions, seconds: number): Promise<string | null>;
+  sendQueued(name: string, data: object, options: PgBoss.SendOptions, seconds: number, key: string): Promise<string | null>;
+
   insert(jobs: PgBoss.JobInsert[]): Promise<void>;
   insert(jobs: PgBoss.JobInsert[], options: PgBoss.InsertOptions): Promise<void>;
 


### PR DESCRIPTION
## Background
As listed on #433

## Changelog
- Enables capability to queue jobs that respects singleton slot while not dropping any of valid calls via `sendQueued`
- Introduces `options.shouldQueueAll` 