### PR TITLE
fix: queue creation bugs (v10)

### DIFF
--- a/src/attorney.js
+++ b/src/attorney.js
@@ -179,7 +179,7 @@ function assertPostgresObjectName (name) {
   assert(typeof name === 'string', 'Name must be a string')
   assert(name.length <= 50, 'Name cannot exceed 50 characters')
   assert(!/\W/.test(name), 'Name can only contain alphanumeric characters and underscores')
-  assert(!/^d/.test(name), 'Name cannot start with a number')
+  assert(!/^\d/.test(name), 'Name cannot start with a number')
 }
 
 function applyArchiveConfig (config) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -348,7 +348,7 @@ declare class PgBoss extends EventEmitter {
   getQueueSize(name: string, options?: object): Promise<number>;
   getJobById(name: string, id: string, options?: PgBoss.ConnectionOptions): Promise<PgBoss.JobWithMetadata | null>;
 
-  createQueue(name: string, policy: 'standard' | 'short' | 'singleton' | 'stately'): Promise<void>;
+  createQueue(name: string, options?: { policy: 'standard' | 'short' | 'singleton' | 'stately' }): Promise<void>;
   deleteQueue(name: string): Promise<void>;
   purgeQueue(name: string): Promise<void>;
   clearStorage(): Promise<void>;


### PR DESCRIPTION
Two small bug fixes for runtime and type issues found while using the new `createQueue` method:
- Corrected regex that was selecting for the character `d` instead of digits
- Corrected typing for second parameter of `createQueue`