### PR TITLE
Include `expireInSeconds` in the `Job` type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -175,11 +175,7 @@ declare namespace PgBoss {
     expireInSeconds: number;
   }
 
-  interface JobWithMetadata<T = object> {
-    id: string;
-    name: string;
-    data: T;
-    expireInSeconds: number;
+  interface JobWithMetadata<T = object> extends Job<T> {
     priority: number;
     state: 'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed';
     retryLimit: number;

--- a/types.d.ts
+++ b/types.d.ts
@@ -172,6 +172,7 @@ declare namespace PgBoss {
     id: string;
     name: string;
     data: T;
+    expireInSeconds: number;
   }
 
   interface JobWithMetadata<T = object> {

--- a/types.d.ts
+++ b/types.d.ts
@@ -179,6 +179,7 @@ declare namespace PgBoss {
     id: string;
     name: string;
     data: T;
+    expireInSeconds: number;
     priority: number;
     state: 'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed';
     retryLimit: number;


### PR DESCRIPTION
There is currently a mismatch between the data returned and type of `Job` for jobs fetched without metadata. The details returned in the job include the `expireInSeconds`, see a sample below:

```
[
  {
    id: 'd2c11056-0a3f-42f3-850b-a2b0bc9775e6',
    name: 'myQueue',
    data: { foo: 1, bar: '1' },
    expireInSeconds: '900.000000'
  }
]
```

This also changes `JobWithMetadata` to extend the `Job` to ensure the base type is consistent