### PR TITLE
Add cron options to constructor options type

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -854,6 +854,8 @@ but **not** this format which is parsed as "only run exactly at 3:30:30 am every
 30 30 3 * * *
 ```
 
+To change how often schedules are checked, you can set `cronMonitorIntervalSeconds`. To change how often cron jobs are run, you can set `cronWorkerIntervalSeconds`.
+
 In order mitigate clock skew and drift, every 10 minutes the clocks of each instance are compared to the database server's clock. The skew, if any, is stored and used as an offset during cron evaluation to ensure all instances are synchronized. Internally, job throttling options are then used to make sure only 1 job is sent even if multiple instances are running.
 
 If needed, the default clock monitoring interval can be adjusted using `clockMonitorIntervalSeconds` or `clockMonitorIntervalMinutes`. Additionally, to disable scheduling on an instance completely, use the following in the constructor options.

--- a/types.d.ts
+++ b/types.d.ts
@@ -45,6 +45,9 @@ declare namespace PgBoss {
 
     clockMonitorIntervalSeconds?: number;
     clockMonitorIntervalMinutes?: number;
+
+    cronMonitorIntervalSeconds?: number;
+    cronWorkerIntervalSeconds?: number;
   }
 
   interface MaintenanceOptions {


### PR DESCRIPTION
I noticed that the type of `ConstructorOptions` was missing some undocumented ways of adjusting the behaviour of the cron scheduler.