### PR TITLE
Rename purge to drop in TS types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -357,7 +357,9 @@ declare class PgBoss extends EventEmitter {
 
   clearStorage(): Promise<void>;
   archive(): Promise<void>;
-  purge(): Promise<void>;
+  supervise(): Promise<void>;
+  monitor(): Promise<void>;
+  drop(): Promise<void>;
   expire(): Promise<void>;
   maintain(): Promise<void>;
   isInstalled(): Promise<Boolean>;


### PR DESCRIPTION
Since pg-boss 10, purge was renamed to `drop`

Also, `monitor` and `supervise` were not declared