### PR TITLE
Inserts job in existing transaction by passing pgClient instance

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -89,9 +89,35 @@ Available in constructor as a default, or overridden in send.
 
     ```ts
     interface Db {
-      executeSql(text: string, values: any[]): Promise<{ rows: any[] }>;
-  }
+      executeSql(text: string, values: any[], options?: ExecuteOptions): Promise<{ rows: any[] }>;
+    }
     ```
+
+**Execute options**
+
+* **executeOptions**, object
+  
+  This object allows you to pass options to the `executeSql` function of the underlying database adapter.
+
+  * **pgClient**, `pg.Client` object
+
+    You can provide a custom `pgClient` instance, so PGBoss can insert jobs in an already started database transaction.
+      ```ts
+      const pgClient = new pg.Client("postgres://...")
+      try {
+        await pgClient.query('BEGIN')
+        await pgClient.query(`INSERT INTO public.my_business_table (label) VALUES('My data')`)
+
+        boss.send('my-job', { someData: 'someValue' }, {
+          executeOptions: { pgClient }
+        })
+
+        await pgClient.query('COMMIT')
+      } catch (e) {
+        await pgClient.query('ROLLBACK')
+      }
+      ```
+      PostgreSQL supports cross-schema transactions, so this is a great way to provide strong consistency guarantees between your business data and PGBoss jobs.
 
 **Deferred jobs**
 

--- a/src/db.js
+++ b/src/db.js
@@ -27,7 +27,10 @@ class Db extends EventEmitter {
     }
   }
 
-  async executeSql (text, values) {
+  async executeSql (text, values, executeOptions) {
+    if (executeOptions?.pgClient) {
+      return await executeOptions.pgClient.query(text, values)
+    }
     if (this.opened) {
       // if (this.config.debug === true) {
       //   console.log(`${new Date().toISOString()}: DEBUG SQL`)

--- a/src/manager.js
+++ b/src/manager.js
@@ -333,6 +333,7 @@ class Manager extends EventEmitter {
     const {
       id = null,
       db: wrapper,
+      executeOptions,
       priority,
       startAfter,
       singletonKey = null,
@@ -373,7 +374,7 @@ class Manager extends EventEmitter {
     ]
 
     const db = wrapper || this.db
-    const { rows } = await db.executeSql(this.insertJobCommand, values)
+    const { rows } = await db.executeSql(this.insertJobCommand, values, executeOptions)
 
     if (rows.length === 1) {
       return rows[0].id

--- a/test/databaseTest.js
+++ b/test/databaseTest.js
@@ -25,4 +25,16 @@ describe('database', function () {
 
     assert(response.text === query)
   })
+
+  it('uses custom pg Client when provided', async function () {
+    const query = 'SELECT something FROM somewhere'
+    const pgClientMock = {
+      query: async (text, values) => ({ rows: [], text })
+    }
+
+    const boss = new PgBoss('postgres://bobby:tables@wat:12345/northwind')
+    const response = await boss.getDb().executeSql(query, [], { pgClient: pgClientMock })
+
+    assert(response.text === query)
+  })
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events'
+import { ClientBase } from 'pg'
 
 declare namespace PgBoss {
 
@@ -17,8 +18,13 @@ declare namespace PgBoss {
     singleton: 'singleton',
     stately: 'stately'
   }
+
+  interface ExecuteOptions {
+    pgClient?: ClientBase;
+  }
+
   interface Db {
-    executeSql(text: string, values: any[]): Promise<{ rows: any[] }>;
+    executeSql(text: string, values: any[], options?: ExecuteOptions): Promise<{ rows: any[] }>;
   }
 
   interface DatabaseOptions {
@@ -109,6 +115,7 @@ declare namespace PgBoss {
 
   interface ConnectionOptions {
     db?: Db;
+    executeOptions?: ExecuteOptions;
   }
 
   type InsertOptions = ConnectionOptions;


### PR DESCRIPTION
This is my take at the attempt made four years ago with the PR #200.

These changes don't introduce any breaking change with the existing behavior.

Fixes #199

## Description

The idea is to be able to pass a `pg.Client` instance to be used by the `executeSql()` of the database wrapper instead of using the connection pool.
For this, I created a new property `executeOptions` in the `ConnectionOptions` to allow us to add more options later if we need it.
This new `executeOptions` property is optional and can totally be used by custom implementation of the `Db` wrapper since it was the only workaround available since then.
