### PR TITLE
Options are not passed correct when scheduling jobs

### DIFF
--- a/src/timekeeper.js
+++ b/src/timekeeper.js
@@ -144,7 +144,7 @@ class Timekeeper extends EventEmitter {
     const scheduled = schedules
       .filter(i => this.shouldSendIt(i.cron, i.timezone))
       .map(({ name, data, options }) =>
-        ({ name: QUEUES.SEND_IT, data: { name, data, options }, singletonKey: name, singletonSeconds: 60 }))
+        ({ name: QUEUES.SEND_IT, data: { name, data, ...options }, singletonKey: name, singletonSeconds: 60 }))
 
     if (scheduled.length > 0 && !this.stopped) {
       await this.manager.insert(scheduled)


### PR DESCRIPTION
The documentation mentions that 

> options supports all properties in send() 

So I assume that means I should be able to pass e.g. `{ retryLimit: 42 }`, and have my scheduled jobs retry 42 times.

I'm adding a failing test to showcase the expected behaviour :)

The options are being correct stored in the DB, but it seems they are not being set correctly when the job is queued.

I had a brief look at the code, and I _think_  we need to spread the options here https://github.com/timgit/pg-boss/blob/463f2fc892895b7d0c14e91574c66e4e565b1638/src/timekeeper.js#L147 
LMK if that makes sense, then I will update the PR.