### PR TITLE
Allow partial failure of a batch

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -219,7 +219,7 @@ class Manager extends EventEmitter {
           if (successfulIds?.length) {
             this.complete(name, successfulIds, successfulIds.length === 1 ? result : undefined)
           }
-          if (errorsById && errorsById.keys.length) {
+          if (errorsById?.size) {
             errorsById.forEach((error, id) => this.fail(name, id, error))
           }
         }

--- a/src/manager.js
+++ b/src/manager.js
@@ -212,7 +212,17 @@ class Manager extends EventEmitter {
 
       try {
         const result = await resolveWithinSeconds(callback(jobs), maxExpiration)
-        this.complete(name, jobIds, jobIds.length === 1 ? result : undefined)
+        const { successfulIds, errorsById } = result || {}
+        if (!successfulIds && !errorsById) {
+          this.complete(name, jobIds, jobIds.length === 1 ? result : undefined)
+        } else {
+          if (successfulIds?.length) {
+            this.complete(name, successfulIds, successfulIds.length === 1 ? result : undefined)
+          }
+          if (errorsById && errorsById.keys.length) {
+            errorsById.forEach((error, id) => this.fail(name, id, error))
+          }
+        }
       } catch (err) {
         this.fail(name, jobIds, err)
       }


### PR DESCRIPTION
In case some of the jobs included in a batch fails, make sure to mark only the actually failed ones as failed with the correct error and allow the rest complete successfully (as long as your callback returns the necessary data). 