### PR TITLE
Fixed default for `includeMetadata` in Workers doc

### DIFF
--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -21,7 +21,7 @@ The default options for `work()` is 1 job every 2 seconds.
 
   Same as in [`fetch()`](#fetch)
 
-* **includeMetadata**, bool, *(default=true)*
+* **includeMetadata**, bool, *(default=false)*
 
   Same as in [`fetch()`](#fetch)
 


### PR DESCRIPTION
If `includeMetadata` isn't specified in `work()`, it defaults to false.
Tested with 10.1.5