### PR TITLE
feat: maxRetryDelay option to limit retryBackoff

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -20,7 +20,7 @@ Creates a new job and returns the job id.
 * **priority**, int
 
     optional priority.  Higher numbers have, um, higher priority
-  
+
 * **id**, uuid
 
     optional id.  If not set, a uuid will automatically created
@@ -40,6 +40,10 @@ Available in constructor as a default, or overridden in send.
 * **retryBackoff**, bool
 
     Default: false. Enables exponential backoff retries based on retryDelay instead of a fixed delay. Sets initial retryDelay to 1 if not set.
+
+* **maxRetryDelay**, int
+
+    Default: no limit. Maximum delay between retries of failed jobs, in seconds. Only used when retryBackoff is true.
 
 **Expiration options**
 
@@ -84,7 +88,7 @@ Available in constructor as a default, or overridden in send.
 **Connection options**
 
 * **db**, object
-  
+
   Instead of using pg-boss's default adapter, you can use your own, as long as it implements the following interface (the same as the pg module).
 
     ```ts
@@ -284,7 +288,7 @@ await Promise.allSettled(jobs.map(async job => {
 
 Deletes a job by id.
 
-> Job deletion is offered if desired for a "fetch then delete" workflow similar to SQS. This is not the default behavior for workers so "everything just works" by default, including job throttling and debouncing, which requires jobs to exist to enforce a unique constraint. For example, if you are debouncing a queue to "only allow 1 job per hour", deleting jobs after processing would re-open that time slot, breaking your throttling policy. 
+> Job deletion is offered if desired for a "fetch then delete" workflow similar to SQS. This is not the default behavior for workers so "everything just works" by default, including job throttling and debouncing, which requires jobs to exist to enforce a unique constraint. For example, if you are debouncing a queue to "only allow 1 job per hour", deleting jobs after processing would re-open that time slot, breaking your throttling policy.
 
 ### `deleteJob(name, [ids], options)`
 
@@ -298,7 +302,7 @@ Cancels a pending or active job.
 
 Cancels a set of pending or active jobs.
 
-When passing an array of ids, it's possible that the operation may partially succeed based on the state of individual jobs requested. Consider this a best-effort attempt. 
+When passing an array of ids, it's possible that the operation may partially succeed based on the state of individual jobs requested. Consider this a best-effort attempt.
 
 ### `resume(name, id, options)`
 

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -276,7 +276,8 @@ function applyRetryConfig (config, defaults) {
   assert(!('retryDelay' in config) || (Number.isInteger(config.retryDelay) && config.retryDelay >= 0), 'retryDelay must be an integer >= 0')
   assert(!('retryLimit' in config) || (Number.isInteger(config.retryLimit) && config.retryLimit >= 0), 'retryLimit must be an integer >= 0')
   assert(!('retryBackoff' in config) || (config.retryBackoff === true || config.retryBackoff === false), 'retryBackoff must be either true or false')
-  assert(!('maxRetryDelay' in config) || (Number.isInteger(config.maxRetryDelay) && config.maxRetryDelay >= 0), 'maxRetryDelay must be an integer >= 0')
+  assert(!('maxRetryDelay' in config) || config.maxRetryDelay === undefined || config.retryBackoff === true,'maxRetryDelay can only be set if retryBackoff is true')
+  assert(!('maxRetryDelay' in config) || config.maxRetryDelay === undefined || (Number.isInteger(config.maxRetryDelay) && config.maxRetryDelay >= 0), 'maxRetryDelay must be an integer >= 0')
 
   config.retryDelayDefault = defaults?.retryDelay
   config.retryLimitDefault = defaults?.retryLimit

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -276,7 +276,7 @@ function applyRetryConfig (config, defaults) {
   assert(!('retryDelay' in config) || (Number.isInteger(config.retryDelay) && config.retryDelay >= 0), 'retryDelay must be an integer >= 0')
   assert(!('retryLimit' in config) || (Number.isInteger(config.retryLimit) && config.retryLimit >= 0), 'retryLimit must be an integer >= 0')
   assert(!('retryBackoff' in config) || (config.retryBackoff === true || config.retryBackoff === false), 'retryBackoff must be either true or false')
-  assert(!('maxRetryDelay' in config) || (Number.isInteger(config.retryDelay) && config.retryDelay >= 0), 'maxRetryDelay must be an integer >= 0')
+  assert(!('maxRetryDelay' in config) || (Number.isInteger(config.maxRetryDelay) && config.maxRetryDelay >= 0), 'maxRetryDelay must be an integer >= 0')
 
   config.retryDelayDefault = defaults?.retryDelay
   config.retryLimitDefault = defaults?.retryLimit

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -276,10 +276,12 @@ function applyRetryConfig (config, defaults) {
   assert(!('retryDelay' in config) || (Number.isInteger(config.retryDelay) && config.retryDelay >= 0), 'retryDelay must be an integer >= 0')
   assert(!('retryLimit' in config) || (Number.isInteger(config.retryLimit) && config.retryLimit >= 0), 'retryLimit must be an integer >= 0')
   assert(!('retryBackoff' in config) || (config.retryBackoff === true || config.retryBackoff === false), 'retryBackoff must be either true or false')
+  assert(!('maxRetryDelay' in config) || (Number.isInteger(config.retryDelay) && config.retryDelay >= 0), 'maxRetryDelay must be an integer >= 0')
 
   config.retryDelayDefault = defaults?.retryDelay
   config.retryLimitDefault = defaults?.retryLimit
   config.retryBackoffDefault = defaults?.retryBackoff
+  config.maxRetryDelayDefault = defaults?.maxRetryDelay
 }
 
 function applyPollingInterval (config, defaults) {

--- a/src/manager.js
+++ b/src/manager.js
@@ -347,7 +347,9 @@ class Manager extends EventEmitter {
       retryDelay,
       retryDelayDefault,
       retryBackoff,
-      retryBackoffDefault
+      retryBackoffDefault,
+      maxRetryDelay,
+      maxRetryDelayDefault
     } = options
 
     const values = [
@@ -369,7 +371,9 @@ class Manager extends EventEmitter {
       retryDelay, // 16
       retryDelayDefault, // 17
       retryBackoff, // 18
-      retryBackoffDefault // 19
+      retryBackoffDefault, // 19
+      maxRetryDelay, // 20
+      maxRetryDelayDefault // 21
     ]
 
     const db = wrapper || this.db
@@ -405,7 +409,8 @@ class Manager extends EventEmitter {
       this.config.keepUntil, // 3
       this.config.retryLimit, // 4
       this.config.retryDelay, // 5
-      this.config.retryBackoff // 6
+      this.config.retryBackoff, // 6
+      this.config.maxRetryDelay // 7
     ]
 
     const { rows } = await db.executeSql(this.insertJobsCommand, params)
@@ -529,6 +534,7 @@ class Manager extends EventEmitter {
       retryLimit,
       retryDelay,
       retryBackoff,
+      maxRetryDelay,
       expireInSeconds,
       retentionMinutes,
       deadLetter
@@ -544,6 +550,7 @@ class Manager extends EventEmitter {
       retryLimit,
       retryDelay,
       retryBackoff,
+      maxRetryDelay,
       expireInSeconds,
       retentionMinutes,
       deadLetter
@@ -568,20 +575,22 @@ class Manager extends EventEmitter {
       retryLimit,
       retryDelay,
       retryBackoff,
+      maxRetryDelay,
       expireInSeconds,
       retentionMinutes,
       deadLetter
     } = Attorney.checkQueueArgs(name, options)
 
     const params = [
-      name,
-      policy,
-      retryLimit,
-      retryDelay,
-      retryBackoff,
-      expireInSeconds,
-      retentionMinutes,
-      deadLetter
+      name, // 1
+      policy, // 2
+      retryLimit, // 3
+      retryDelay, // 4
+      retryBackoff, // 5
+      maxRetryDelay, // 6
+      expireInSeconds, // 7
+      retentionMinutes, // 8
+      deadLetter // 9
     ]
 
     await this.db.executeSql(this.updateQueueCommand, params)

--- a/src/migrationStore.js
+++ b/src/migrationStore.js
@@ -65,6 +65,159 @@ function migrate (value, version, migrations) {
 function getAll (schema) {
   return [
     {
+      release: '10.2.0',
+      version: 25,
+      previous: 24,
+      install: [
+        `ALTER TABLE ${schema}.queue
+         ADD COLUMN IF NOT EXISTS max_retry_delay INTEGER`
+      ],
+      uninstall: [
+        `ALTER TABLE ${schema}.queue
+         DROP COLUMN IF EXISTS max_retry_delay`
+      ]
+    },
+    {
+      release: '10.2.0',
+      version: 25,
+      previous: 24,
+      install: [
+        `ALTER TABLE ${schema}.job
+         ADD COLUMN IF NOT EXISTS max_retry_delay INTEGER`
+      ],
+      uninstall: [
+        `ALTER TABLE ${schema}.job
+         DROP COLUMN IF EXISTS max_retry_delay`
+      ]
+    },
+    {
+      release: '10.2.0',
+      version: 25,
+      previous: 24,
+      install: [
+        `
+        CREATE OR REPLACE FUNCTION ${schema}.create_queue(queue_name text, options json)
+        RETURNS VOID AS
+        $$
+        DECLARE
+          table_name varchar := 'j' || encode(sha224(queue_name::bytea), 'hex');
+          queue_created_on timestamptz;
+        BEGIN
+
+          WITH q as (
+          INSERT INTO ${schema}.queue (
+            name,
+            policy,
+            retry_limit,
+            retry_delay,
+            retry_backoff,
+            max_retry_delay,
+            expire_seconds,
+            retention_minutes,
+            dead_letter,
+            partition_name
+          )
+          VALUES (
+            queue_name,
+            options->>'policy',
+            (options->>'retryLimit')::int,
+            (options->>'retryDelay')::int,
+            (options->>'retryBackoff')::bool,
+            (options->>'maxRetryDelay')::int,
+            (options->>'expireInSeconds')::int,
+            (options->>'retentionMinutes')::int,
+            options->>'deadLetter',
+            table_name
+          )
+          ON CONFLICT DO NOTHING
+          RETURNING created_on
+          )
+          SELECT created_on into queue_created_on from q;
+
+          IF queue_created_on IS NULL THEN
+            RETURN;
+          END IF;
+
+          EXECUTE format('CREATE TABLE ${schema}.%I (LIKE ${schema}.job INCLUDING DEFAULTS)', table_name);
+
+          EXECUTE format('${formatPartitionCommand(createPrimaryKeyJob(schema))}', table_name);
+          EXECUTE format('${formatPartitionCommand(createQueueForeignKeyJob(schema))}', table_name);
+          EXECUTE format('${formatPartitionCommand(createQueueForeignKeyJobDeadLetter(schema))}', table_name);
+          EXECUTE format('${formatPartitionCommand(createIndexJobPolicyShort(schema))}', table_name);
+          EXECUTE format('${formatPartitionCommand(createIndexJobPolicySingleton(schema))}', table_name);
+          EXECUTE format('${formatPartitionCommand(createIndexJobPolicyStately(schema))}', table_name);
+          EXECUTE format('${formatPartitionCommand(createIndexJobThrottle(schema))}', table_name);
+          EXECUTE format('${formatPartitionCommand(createIndexJobFetch(schema))}', table_name);
+
+          EXECUTE format('ALTER TABLE ${schema}.%I ADD CONSTRAINT cjc CHECK (name=%L)', table_name, queue_name);
+          EXECUTE format('ALTER TABLE ${schema}.job ATTACH PARTITION ${schema}.%I FOR VALUES IN (%L)', table_name, queue_name);
+        END;
+        $$
+        LANGUAGE plpgsql
+        `
+      ],
+      uninstall: [
+        `
+        CREATE OR REPLACE FUNCTION ${schema}.create_queue(queue_name text, options json)
+        RETURNS VOID AS
+        $$
+        DECLARE
+          table_name varchar := 'j' || encode(sha224(queue_name::bytea), 'hex');
+          queue_created_on timestamptz;
+        BEGIN
+
+          WITH q as (
+            INSERT INTO ${schema}.queue (
+              name,
+              policy,
+              retry_limit,
+              retry_delay,
+              retry_backoff,
+              expire_seconds,
+              retention_minutes,
+              dead_letter,
+              partition_name
+            )
+            VALUES (
+              queue_name,
+              options->>'policy',
+              (options->>'retryLimit')::int,
+              (options->>'retryDelay')::int,
+              (options->>'retryBackoff')::bool,
+              (options->>'expireInSeconds')::int,
+              (options->>'retentionMinutes')::int,
+              options->>'deadLetter',
+              table_name
+            )
+            ON CONFLICT DO NOTHING
+            RETURNING created_on
+          )
+          SELECT created_on into queue_created_on from q;
+
+          IF queue_created_on IS NULL THEN
+            RETURN;
+          END IF;
+
+          EXECUTE format('CREATE TABLE ${schema}.%I (LIKE ${schema}.job INCLUDING DEFAULTS)', table_name);
+
+          EXECUTE format('ALTER TABLE ${schema}.%1$I ADD PRIMARY KEY (name, id)', table_name);
+          EXECUTE format('ALTER TABLE ${schema}.%1$I ADD CONSTRAINT q_fkey FOREIGN KEY (name) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED', table_name);
+          EXECUTE format('ALTER TABLE ${schema}.%1$I ADD CONSTRAINT dlq_fkey FOREIGN KEY (dead_letter) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED', table_name);
+          EXECUTE format('CREATE UNIQUE INDEX %1$s_i1 ON ${schema}.%1$I (name, COALESCE(singleton_key, '''')) WHERE state = ''created'' AND policy = ''short''', table_name);
+          EXECUTE format('CREATE UNIQUE INDEX %1$s_i2 ON ${schema}.%1$I (name, COALESCE(singleton_key, '''')) WHERE state = ''active'' AND policy = ''singleton''', table_name);
+          EXECUTE format('CREATE UNIQUE INDEX %1$s_i3 ON ${schema}.%1$I (name, state, COALESCE(singleton_key, '''')) WHERE state <= ''active'' AND policy = ''stately''', table_name);
+          EXECUTE format('CREATE UNIQUE INDEX %1$s_i4 ON ${schema}.%1$I (name, singleton_on, COALESCE(singleton_key, '''')) WHERE state <> ''cancelled'' AND singleton_on IS NOT NULL', table_name);
+          EXECUTE format('CREATE INDEX %1$s_i5 ON ${schema}.%1$I (name, start_after) INCLUDE (priority, created_on, id) WHERE state < ''active''', table_name);
+
+          EXECUTE format('ALTER TABLE ${schema}.%I ADD CONSTRAINT cjc CHECK (name=%L)', table_name, queue_name);
+          EXECUTE format('ALTER TABLE ${schema}.job ATTACH PARTITION ${schema}.%I FOR VALUES IN (%L)', table_name, queue_name);
+        END;
+        $$
+        LANGUAGE plpgsql
+        `
+      ]
+    },
+    {
       release: '10.1.5',
       version: 24,
       previous: 23,
@@ -111,7 +264,7 @@ function getAll (schema) {
           END IF;
 
           EXECUTE format('CREATE TABLE ${schema}.%I (LIKE ${schema}.job INCLUDING DEFAULTS)', table_name);
-          
+
           EXECUTE format('ALTER TABLE ${schema}.%1$I ADD PRIMARY KEY (name, id)', table_name);
           EXECUTE format('ALTER TABLE ${schema}.%1$I ADD CONSTRAINT q_fkey FOREIGN KEY (name) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED', table_name);
           EXECUTE format('ALTER TABLE ${schema}.%1$I ADD CONSTRAINT dlq_fkey FOREIGN KEY (dead_letter) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED', table_name);

--- a/src/plans.js
+++ b/src/plans.js
@@ -395,7 +395,7 @@ function updateQueue (schema) {
       retry_limit = COALESCE($3, retry_limit),
       retry_delay = COALESCE($4, retry_delay),
       retry_backoff = COALESCE($5, retry_backoff),
-      max_retry_delay = COALESCE($6, max_retry_delay),
+      max_retry_delay = $6,
       expire_seconds = COALESCE($7, expire_seconds),
       retention_minutes = COALESCE($8, retention_minutes),
       dead_letter = COALESCE($9, dead_letter),

--- a/test/insertTest.js
+++ b/test/insertTest.js
@@ -31,6 +31,7 @@ describe('insert', function () {
       retryLimit: 1,
       retryDelay: 2,
       retryBackoff: true,
+      maxRetryDelay: 3,
       startAfter: new Date().toISOString(),
       expireInSeconds: 5,
       singletonKey: '123',
@@ -49,6 +50,7 @@ describe('insert', function () {
     assert.strictEqual(job.retryLimit, input.retryLimit, `retryLimit input ${input.retryLimit} didn't match job ${job.retryLimit}`)
     assert.strictEqual(job.retryDelay, input.retryDelay, `retryDelay input ${input.retryDelay} didn't match job ${job.retryDelay}`)
     assert.strictEqual(job.retryBackoff, input.retryBackoff, `retryBackoff input ${input.retryBackoff} didn't match job ${job.retryBackoff}`)
+    assert.strictEqual(job.maxRetryDelay, input.maxRetryDelay, `maxRetryDelay input ${input.maxRetryDelay} didn't match job ${job.maxRetryDelay}`)
     assert.strictEqual(new Date(job.startAfter).toISOString(), input.startAfter, `startAfter input ${input.startAfter} didn't match job ${job.startAfter}`)
     assert.strictEqual(job.expireIn.seconds, input.expireInSeconds, `expireInSeconds input ${input.expireInSeconds} didn't match job ${job.expireIn}`)
     assert.strictEqual(job.singletonKey, input.singletonKey, `name input ${input.singletonKey} didn't match job ${job.singletonKey}`)
@@ -71,6 +73,7 @@ describe('insert', function () {
       retryLimit: 1,
       retryDelay: 2,
       retryBackoff: true,
+      maxRetryDelay: 3,
       startAfter: new Date().toISOString(),
       expireInSeconds: 5,
       singletonKey: '123',
@@ -99,6 +102,7 @@ describe('insert', function () {
     assert.strictEqual(job.retryLimit, input.retryLimit, `retryLimit input ${input.retryLimit} didn't match job ${job.retryLimit}`)
     assert.strictEqual(job.retryDelay, input.retryDelay, `retryDelay input ${input.retryDelay} didn't match job ${job.retryDelay}`)
     assert.strictEqual(job.retryBackoff, input.retryBackoff, `retryBackoff input ${input.retryBackoff} didn't match job ${job.retryBackoff}`)
+    assert.strictEqual(job.maxRetryDelay, input.maxRetryDelay, `maxRetryDelay input ${input.maxRetryDelay} didn't match job ${job.maxRetryDelay}`)
     assert.strictEqual(new Date(job.startAfter).toISOString(), input.startAfter, `startAfter input ${input.startAfter} didn't match job ${job.startAfter}`)
     assert.strictEqual(job.expireIn.seconds, input.expireInSeconds, `expireInSeconds input ${input.expireInSeconds} didn't match job ${job.expireIn}`)
     assert.strictEqual(job.singletonKey, input.singletonKey, `name input ${input.singletonKey} didn't match job ${job.singletonKey}`)

--- a/test/queueTest.js
+++ b/test/queueTest.js
@@ -132,9 +132,10 @@ describe('queues', function () {
       policy: 'standard',
       retryLimit: 1,
       retryBackoff: false,
-      retryDelay: 1,
-      expireInSeconds: 1,
-      retentionMinutes: 1,
+      retryDelay: 2,
+      maxRetryDelay: 3,
+      expireInSeconds: 4,
+      retentionMinutes: 5,
       deadLetter
     }
 
@@ -147,6 +148,7 @@ describe('queues', function () {
     assert.strictEqual(createProps.retryLimit, queueObj.retryLimit)
     assert.strictEqual(createProps.retryBackoff, queueObj.retryBackoff)
     assert.strictEqual(createProps.retryDelay, queueObj.retryDelay)
+    assert.strictEqual(createProps.maxRetryDelay, queueObj.maxRetryDelay)
     assert.strictEqual(createProps.expireInSeconds, queueObj.expireInSeconds)
     assert.strictEqual(createProps.retentionMinutes, queueObj.retentionMinutes)
     assert.strictEqual(createProps.deadLetter, queueObj.deadLetter)
@@ -158,11 +160,12 @@ describe('queues', function () {
 
     const updateProps = {
       policy: 'short',
-      retryLimit: 2,
+      retryLimit: 1,
       retryBackoff: true,
       retryDelay: 2,
-      expireInSeconds: 2,
-      retentionMinutes: 2,
+      maxRetryDelay: 3,
+      expireInSeconds: 4,
+      retentionMinutes: 5,
       deadLetter
     }
 
@@ -174,6 +177,7 @@ describe('queues', function () {
     assert.strictEqual(updateProps.retryLimit, queueObj.retryLimit)
     assert.strictEqual(updateProps.retryBackoff, queueObj.retryBackoff)
     assert.strictEqual(updateProps.retryDelay, queueObj.retryDelay)
+    assert.strictEqual(updateProps.maxRetryDelay, queueObj.maxRetryDelay)
     assert.strictEqual(updateProps.expireInSeconds, queueObj.expireInSeconds)
     assert.strictEqual(updateProps.retentionMinutes, queueObj.retentionMinutes)
     assert.strictEqual(updateProps.deadLetter, queueObj.deadLetter)
@@ -190,8 +194,9 @@ describe('queues', function () {
       retryLimit: 1,
       retryBackoff: true,
       retryDelay: 2,
-      expireInSeconds: 3,
-      retentionMinutes: 4,
+      maxRetryDelay: 3,
+      expireInSeconds: 4,
+      retentionMinutes: 5,
       deadLetter
     }
 
@@ -206,6 +211,7 @@ describe('queues', function () {
     assert.strictEqual(createProps.retryLimit, job.retryLimit)
     assert.strictEqual(createProps.retryBackoff, job.retryBackoff)
     assert.strictEqual(createProps.retryDelay, job.retryDelay)
+    assert.strictEqual(createProps.maxRetryDelay, job.maxRetryDelay)
     assert.strictEqual(createProps.expireInSeconds, job.expireIn.seconds)
     assert.strictEqual(createProps.retentionMinutes, retentionMinutes)
     assert.strictEqual(createProps.deadLetter, job.deadLetter)

--- a/test/queueTest.js
+++ b/test/queueTest.js
@@ -131,7 +131,7 @@ describe('queues', function () {
     const createProps = {
       policy: 'standard',
       retryLimit: 1,
-      retryBackoff: false,
+      retryBackoff: true,
       retryDelay: 2,
       maxRetryDelay: 3,
       expireInSeconds: 4,
@@ -161,9 +161,9 @@ describe('queues', function () {
     const updateProps = {
       policy: 'short',
       retryLimit: 1,
-      retryBackoff: true,
+      retryBackoff: false,
       retryDelay: 2,
-      maxRetryDelay: 3,
+      maxRetryDelay: undefined,
       expireInSeconds: 4,
       retentionMinutes: 5,
       deadLetter
@@ -177,7 +177,7 @@ describe('queues', function () {
     assert.strictEqual(updateProps.retryLimit, queueObj.retryLimit)
     assert.strictEqual(updateProps.retryBackoff, queueObj.retryBackoff)
     assert.strictEqual(updateProps.retryDelay, queueObj.retryDelay)
-    assert.strictEqual(updateProps.maxRetryDelay, queueObj.maxRetryDelay)
+    assert.strictEqual(null, queueObj.maxRetryDelay)
     assert.strictEqual(updateProps.expireInSeconds, queueObj.expireInSeconds)
     assert.strictEqual(updateProps.retentionMinutes, queueObj.retentionMinutes)
     assert.strictEqual(updateProps.deadLetter, queueObj.deadLetter)

--- a/types.d.ts
+++ b/types.d.ts
@@ -93,6 +93,7 @@ declare namespace PgBoss {
     retryLimit?: number;
     retryDelay?: number;
     retryBackoff?: boolean;
+    maxRetryDelay?: number;
   }
 
   interface JobOptions {
@@ -185,6 +186,7 @@ declare namespace PgBoss {
     retryCount: number;
     retryDelay: number;
     retryBackoff: boolean;
+    maxRetryDelay?: number;
     startAfter: Date;
     startedOn: Date;
     singletonKey: string | null;
@@ -206,6 +208,7 @@ declare namespace PgBoss {
     retryLimit?: number;
     retryDelay?: number;
     retryBackoff?: boolean;
+    maxRetryDelay?: number;
     startAfter?: Date | string;
     singletonKey?: string;
     singletonSeconds?: number;

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "schema": 24
+  "schema": 25
 }


### PR DESCRIPTION
Closes https://github.com/timgit/pg-boss/issues/520

Implements a new flag in `new PgBoss()`, `queue` and `job`

This flag limits the exponential backoff to the desired delay, in seconds.

I decided to only apply its value if `retryBackoff` is true.

Alternatives:
1. Rename new parameter to `maxRetryBackoffDelay`
2. `maxRetryDelay` should also limit `retryDelay`, but that seems redundant

Observations:
1. It is possible to unset this value in `updateQueue`, with an undefined parameter (maybe use explicit null in this case?)