### PR TITLE
adds skipStartAfterNow option for fetch

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -234,7 +234,7 @@ Returns an array of jobs from a queue
 
     If `true`, all job metadata will be returned on the job object.
 
-  * `skipStartAfterNow`, bool, *default: false*
+  * `ignoreStartAfter`, bool, *default: false*
 
     If `true`, jobs with a `startAfter` timestamp in the future will be fetched. Useful for fetching jobs immediately without waiting for a retry delay.
 

--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -20,7 +20,7 @@ Creates a new job and returns the job id.
 * **priority**, int
 
     optional priority.  Higher numbers have, um, higher priority
-  
+
 * **id**, uuid
 
     optional id.  If not set, a uuid will automatically created
@@ -84,7 +84,7 @@ Available in constructor as a default, or overridden in send.
 **Connection options**
 
 * **db**, object
-  
+
   Instead of using pg-boss's default adapter, you can use your own, as long as it implements the following interface (the same as the pg module).
 
     ```ts
@@ -234,6 +234,10 @@ Returns an array of jobs from a queue
 
     If `true`, all job metadata will be returned on the job object.
 
+  * `skipStartAfterNow`, bool, *default: false*
+
+    If `true`, jobs with a `startAfter` timestamp in the future will be fetched. Useful for fetching jobs immediately without waiting for a retry delay.
+
     ```js
     interface JobWithMetadata<T = object> {
       id: string;
@@ -284,7 +288,7 @@ await Promise.allSettled(jobs.map(async job => {
 
 Deletes a job by id.
 
-> Job deletion is offered if desired for a "fetch then delete" workflow similar to SQS. This is not the default behavior for workers so "everything just works" by default, including job throttling and debouncing, which requires jobs to exist to enforce a unique constraint. For example, if you are debouncing a queue to "only allow 1 job per hour", deleting jobs after processing would re-open that time slot, breaking your throttling policy. 
+> Job deletion is offered if desired for a "fetch then delete" workflow similar to SQS. This is not the default behavior for workers so "everything just works" by default, including job throttling and debouncing, which requires jobs to exist to enforce a unique constraint. For example, if you are debouncing a queue to "only allow 1 job per hour", deleting jobs after processing would re-open that time slot, breaking your throttling policy.
 
 ### `deleteJob(name, [ids], options)`
 
@@ -298,7 +302,7 @@ Cancels a pending or active job.
 
 Cancels a set of pending or active jobs.
 
-When passing an array of ids, it's possible that the operation may partially succeed based on the state of individual jobs requested. Consider this a best-effort attempt. 
+When passing an array of ids, it's possible that the operation may partially succeed based on the state of individual jobs requested. Consider this a best-effort attempt.
 
 ### `resume(name, id, options)`
 

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -143,6 +143,7 @@ function checkFetchArgs (name, options) {
   assert(!('batchSize' in options) || (Number.isInteger(options.batchSize) && options.batchSize >= 1), 'batchSize must be an integer > 0')
   assert(!('includeMetadata' in options) || typeof options.includeMetadata === 'boolean', 'includeMetadata must be a boolean')
   assert(!('priority' in options) || typeof options.priority === 'boolean', 'priority must be a boolean')
+  assert(!('skipStartAfterNow' in options) || typeof options.skipStartAfterNow === 'boolean', 'skipStartAfterNow must be a boolean')
 
   options.batchSize = options.batchSize || 1
 }

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -143,7 +143,7 @@ function checkFetchArgs (name, options) {
   assert(!('batchSize' in options) || (Number.isInteger(options.batchSize) && options.batchSize >= 1), 'batchSize must be an integer > 0')
   assert(!('includeMetadata' in options) || typeof options.includeMetadata === 'boolean', 'includeMetadata must be a boolean')
   assert(!('priority' in options) || typeof options.priority === 'boolean', 'priority must be a boolean')
-  assert(!('skipStartAfterNow' in options) || typeof options.skipStartAfterNow === 'boolean', 'skipStartAfterNow must be a boolean')
+  assert(!('ignoreStartAfter' in options) || typeof options.ignoreStartAfter === 'boolean', 'ignoreStartAfter must be a boolean')
 
   options.batchSize = options.batchSize || 1
 }

--- a/src/plans.js
+++ b/src/plans.js
@@ -503,13 +503,13 @@ function insertVersion (schema, version) {
 }
 
 function fetchNextJob (schema) {
-  return ({ includeMetadata, priority = true, skipStartAfterNow = false } = {}) => `
+  return ({ includeMetadata, priority = true, ignoreStartAfter = false } = {}) => `
     WITH next as (
       SELECT id
       FROM ${schema}.job
       WHERE name = $1
         AND state < '${JOB_STATES.active}'
-        ${skipStartAfterNow ? '' : 'AND start_after < now()'}
+        ${ignoreStartAfter ? '' : 'AND start_after < now()'}
       ORDER BY ${priority ? 'priority desc, ' : ''}created_on, id
       LIMIT $2
       FOR UPDATE SKIP LOCKED

--- a/test/fetchTest.js
+++ b/test/fetchTest.js
@@ -141,7 +141,7 @@ describe('fetch', function () {
       }
     }
 
-    const jobs = await boss.fetch(queue, { ...options, skipStartAfterNow: true })
+    const jobs = await boss.fetch(queue, { ...options, ignoreStartAfter: true })
     assert(jobs.length === 1)
     assert(sqlStatements.length === 1)
     assert(!sqlStatements[0].includes('start_after < now()'))

--- a/test/fetchTest.js
+++ b/test/fetchTest.js
@@ -124,4 +124,26 @@ describe('fetch', function () {
     assert(job.startedOn === undefined)
     assert.strictEqual(calledCounter, 2)
   })
+
+  it('should allow fetching jobs that have a start_after in the future', async function () {
+    const boss = this.test.boss = await helper.start(this.test.bossConfig)
+    const queue = this.test.bossConfig.schema
+
+    await boss.send(queue, { startAfter: new Date(Date.now() + 1000) })
+    const db = await helper.getDb()
+    const sqlStatements = []
+    const options = {
+      db: {
+        async executeSql (sql, values) {
+          sqlStatements.push(sql)
+          return db.pool.query(sql, values)
+        }
+      }
+    }
+
+    const jobs = await boss.fetch(queue, { ...options, skipStartAfterNow: true })
+    assert(jobs.length === 1)
+    assert(sqlStatements.length === 1)
+    assert(!sqlStatements[0].includes('start_after < now()'))
+  })
 })


### PR DESCRIPTION
Hi!

Here's a PR to solve #545. Includes tests and doc (the test doesn't reproduce my use case, it just checks the SQL is correct).

The way it works is that `fetch(queue, {skipStartAfterNow: true})` will allow fetching jobs that failed previously and were waiting to be tried again, but before their `start_after`. Without this flag, `fetch` will only return jobs if it's time for them to be retried (then a worker would have picked them, potentially failing).

Hope you'll merge it!