### PR TITLE
added ignoreStartAfter in types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -129,6 +129,7 @@ declare namespace PgBoss {
     includeMetadata?: boolean;
     priority?: boolean;
     batchSize?: number;
+    ignoreStartAfter?: boolean;
   }
 
   type WorkOptions = JobFetchOptions & JobPollingOptions


### PR DESCRIPTION
I have forgotten to add ignoreStartAfter in the typescript types.d.ts file! 

🧠  _I should have thought about that, since I'm using pg-boss in a TS project, but I'm also used to having the d.ts files generated for me_