### PR TITLE
chore: docs update default retention value

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -77,7 +77,7 @@ Available in constructor as a default, or overridden in send.
 
     How many days a job may be in created or retry state before it's archived. Must be >=1
 
-* Default: 30 days
+* Default: 14 days
 
   > When a higher unit is is specified, lower unit configuration settings are ignored.
 


### PR DESCRIPTION
Because the default value in sql is 14 days
https://github.com/timgit/pg-boss/blob/master/src/plans.js#L194
![image](https://github.com/user-attachments/assets/85fd0f9f-23e8-4cf6-ac47-8a5f23823042)
