### PR TITLE
(feat) add support for password as callback

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -25,7 +25,7 @@ declare namespace PgBoss {
     application_name?: string;
     database?: string;
     user?: string;
-    password?: string;
+    password?: string | (() => string) | (() => Promise<string>);
     host?: string;
     port?: number;
     schema?: string;


### PR DESCRIPTION
This PR updates the password type to allow support for password as callback. This is already supported in node-postgres (see here https://github.com/brianc/node-postgres/pull/1926), so it should not be a breaking change.