### PR TITLE
fix: expose getDb in types (issue #552)

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -370,6 +370,8 @@ declare class PgBoss extends EventEmitter {
   schedule(name: string, cron: string, data?: object, options?: PgBoss.ScheduleOptions): Promise<void>;
   unschedule(name: string): Promise<void>;
   getSchedules(): Promise<PgBoss.Schedule[]>;
+
+  getDb(): PgBoss.Db;
 }
 
 export = PgBoss;


### PR DESCRIPTION
Closes https://github.com/timgit/pg-boss/issues/552

Exposes `getDb()` to allow making queries in the same connection, without requiring a custom `Db` implementation

@timgit the Typescript definition for `Db` does not declare it as extending `EventEmitter`, nor includes `open()` and `close()`. Adding these to the typings may be a breaking change for people implementing custom `Db`s in the `options` argument

It's possible to expose a different interface for this specific implementation, and only depend on the base interface with `executeSql()` externally