### PR TITLE
fix: delete jobs by queue name

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -637,11 +637,11 @@ class Manager extends EventEmitter {
     const { table, partition } = await this.getQueueCache(name)
 
     if (partition) {
-      const sql = plans.deleteAllJobs(this.config.schema, table)
-      await this.db.executeSql(sql, [name])
-    } else {
       const sql = plans.truncateTable(this.config.schema, table)
       await this.db.executeSql(sql)
+    } else {
+      const sql = plans.deleteAllJobs(this.config.schema, table)
+      await this.db.executeSql(sql, [name])
     }
   }
 


### PR DESCRIPTION
bug: when calling `deleteAllJobs` on a non partitioned queue it will delete all jobs in job_common table 

Will help solve https://github.com/timgit/pg-boss/issues/593