### PR TITLE
Fix support for executeSql

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -682,7 +682,7 @@ class Manager extends EventEmitter {
 
     // Custom db objects (without _pgbdb flag) are assumed to be ready
     // Only check opened flag for pg-boss managed db instances
-    assert(!this.db._pgbdb || this.db.opened, 'Database connection is not opened')
+    assert(!this.db._pgbdb || (this.db._pgbdb && this.db.opened), 'Database connection is not opened')
 
     return this.db
   }


### PR DESCRIPTION
Potential fix for https://github.com/timgit/pg-boss/issues/602

The main issue being, _pgbdb or db.opened wont exist when utilizing executeSql, and thus this assertion fails.