### PR TITLE
Pass AbortSignal with Job that aborts with expireInSeconds

### DIFF
--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -45,6 +45,7 @@ The jobs argument is an array of jobs with the following properties.
 |`id`| string, uuid |
 |`name`| string |
 |`data`| object |
+|`signal`| AbortSignal |
 
 
 An example of a worker that checks for a job every 10 seconds.
@@ -75,6 +76,14 @@ const queue = 'email-welcome'
 await boss.work(queue, async ([ job ]) => {
   await emailer.sendWelcomeEmail(job.data)
   await boss.deleteJob(queue, job.id)
+})
+```
+
+work() with abort signal
+
+```js
+await boss.work('process-video', async ([ job ]) => {
+  const result = await fetch('https://api.example.com/process', { signal: job.signal })
 })
 ```
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -172,9 +172,11 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
       const maxExpiration = jobs.reduce((acc, i) => Math.max(acc, i.expireInSeconds), 0)
       const jobIds = jobs.map(job => job.id)
+      const ac = new AbortController()
+      jobs.forEach(job => { job.signal = ac.signal })
 
       try {
-        const result = await resolveWithinSeconds(callback(jobs), maxExpiration, `handler execution exceeded ${maxExpiration}s`)
+        const result = await resolveWithinSeconds(callback(jobs), maxExpiration, `handler execution exceeded ${maxExpiration}s`, ac)
         await this.complete(name, jobIds, jobIds.length === 1 ? result : undefined)
       } catch (err: any) {
         await this.fail(name, jobIds, err)

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -16,8 +16,8 @@ export interface AbortablePromise<T> extends Promise<T> {
   abort: () => void
 }
 
-function delay (ms: number, error?: string): AbortablePromise<void> {
-  const ac = new AbortController()
+function delay (ms: number, error?: string, abortController?: AbortController): AbortablePromise<void> {
+  const ac = abortController || new AbortController()
 
   const promise = new Promise<void>((resolve, reject) => {
     setTimeout(ms, null, { signal: ac.signal })
@@ -40,9 +40,9 @@ function delay (ms: number, error?: string): AbortablePromise<void> {
   return promise
 }
 
-async function resolveWithinSeconds<T> (promise: Promise<T>, seconds: number, message?: string): Promise<T | void> {
+async function resolveWithinSeconds<T> (promise: Promise<T>, seconds: number, message?: string, abortController?: AbortController): Promise<T | void> {
   const timeout = Math.max(1, seconds) * 1000
-  const reject = delay(timeout, message)
+  const reject = delay(timeout, message, abortController)
 
   let result
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,7 @@ export interface Job<T = object> {
   name: string;
   data: T;
   expireInSeconds: number;
+  signal: AbortSignal;
 }
 
 export interface JobWithMetadata<T = object> extends Job<T> {

--- a/test/workTest.ts
+++ b/test/workTest.ts
@@ -52,6 +52,22 @@ describe('work', function () {
     assert.strictEqual(processCount, timeout / 1000 / pollingIntervalSeconds)
   })
 
+  it('should provide abort signal to job handler', async function () {
+    this.boss = await helper.start(this.bossConfig)
+
+    let receivedSignal
+
+    await this.boss.send(this.schema)
+
+    await this.boss.work(this.schema, async ([job]) => {
+      receivedSignal = job.signal
+    })
+
+    await delay(1000)
+
+    assert(receivedSignal instanceof AbortSignal)
+  })
+
   it('should honor when a worker is notified', async function () {
     this.boss = await helper.start(this.bossConfig)
 


### PR DESCRIPTION
Closes https://github.com/timgit/pg-boss/issues/555

I took a stab at implementing an abort signal passed to jobs. They all tie back to a single `AbortController` per batch. This lets work functions that may have long running retries tie any sleeps to an AbortSignal and abort early in sync with `expireInSeconds`, rather than keep running after the scheduler marks the job as failed/expired. 

I updated the type and add a couple tests and added an example to the docs.

Feel free to change anything about this or provide feedback for refinement. 