### PR TITLE
Add generic return type to WorkHandler and work method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,9 +191,9 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this.#manager.fetch<T>(name, options)
   }
 
-  work<ReqData>(name: string, handler: types.WorkHandler<ReqData>): Promise<string>
-  work<ReqData>(name: string, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData>): Promise<string>
-  work<ReqData>(name: string, options: types.WorkOptions, handler: types.WorkHandler<ReqData>): Promise<string>
+  work<ReqData, ResData = any>(name: string, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
+  work<ReqData, ResData = any>(name: string, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData, ResData>): Promise<string>
+  work<ReqData, ResData = any>(name: string, options: types.WorkOptions, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
   work (...args: any[]): Promise<string> {
     return this.#manager.work(...args as Parameters<Manager['work']>)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,12 +157,12 @@ export interface ResolvedWorkOptions extends WorkOptions {
   pollingInterval: number;
 }
 
-export interface WorkHandler<ReqData> {
-  (job: Job<ReqData>[]): Promise<any>;
+export interface WorkHandler<ReqData, ResData = any> {
+  (job: Job<ReqData>[]): Promise<ResData>;
 }
 
-export interface WorkWithMetadataHandler<ReqData> {
-  (job: JobWithMetadata<ReqData>[]): Promise<any>;
+export interface WorkWithMetadataHandler<ReqData, ResData = any> {
+  (job: JobWithMetadata<ReqData>[]): Promise<ResData>;
 }
 
 export interface Request {


### PR DESCRIPTION
This allows one to set the expected return type on a WorkHandler function so the return value can be typed checked too. 