### PR TITLE
fix: exports SendOptions type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -342,6 +342,7 @@ export type {
   Schedule,
   ScheduleOptions,
   SchedulingOptions,
+  SendOptions,
   StopOptions,
   WipData,
   WorkHandler,


### PR DESCRIPTION
Exporting `SendOptions` type. I have a wrapper around `.send` and `.sendDebounced` and need the `SendOptions` type.
Hopefully, it wasn’t omitted intentionally.