### PR TITLE
Bundle serliaze-error so that CJS projects can work in edge cases

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,6 +5,5 @@ export default defineConfig({
   format: 'es',
   dts: true,
   exports: true,
-  clean: false,
   noExternal: ['serialize-error'],
 })


### PR DESCRIPTION
This PR makes pg-boss available as both an ESM module and a CJS module depending on which you need.

Rationale: I've had a ton of problems with pg-boss in jest and nest.js and tried every which way to fix it, but the ultimate issue is that CJS projects don't play well with ESM modules.

This is a simple fix to that problem.