### PR TITLE
Make unbundle: true work

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,6 +5,5 @@ export default defineConfig({
   format: 'es',
   dts: true,
   exports: true,
-  noExternal: ['serialize-error'],
   unbundle: true
 })


### PR DESCRIPTION
This PR is one option to address the following errors

- https://github.com/timgit/pg-boss/pull/638 - jest not supporting require(esm)
- https://github.com/timgit/pg-boss/issues/645 - pg-boss missing `tsdown` unbundled deps in bundled vinxi output.

It seemed like there was some interest in trying to get the `unbundle` in `tsdown` working, where `tsdown` strips types and retains the overall source structure of the output. 

By removing `noExternal: ['serialize-error'],` but keeping `unbundle: true` tsdown type strips ts syntax without making one giant bundle which provides better stack traces to callers and makes applying downstream patches easier and more straight forward. It also removes some undefined behavior around output artifacts allowing code bundled by `vinxi` and others to work.

It seems as though the point of `tsdown` IS to bundle the published artifact and we are still outputting esm only either way, so it makes me wonder if just sticking with the bundled artifact is the preferable arrangement when using `tsdown`. Jest still requires downstream workaround either way, and un-bundling `serialize-error` and letting the jest callers figure that one out on their own is the better solution if we are sticking with esm only.  I offered some solutions in the jest thread related to that issue. 

I have another solution I will propose in another PR.