### PR TITLE
Abort jobs after graceful shutdown period expires

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -38,6 +38,7 @@ class Worker<T = unknown> {
   lastErrorOn: number | null = null
   stopping = false
   stopped = false
+  abortController: AbortController | null = null
   private loopDelayPromise: AbortablePromise<void> | null = null
   private beenNotified = false
   private runPromise: Promise<void> | null = null
@@ -121,6 +122,12 @@ class Worker<T = unknown> {
     }
 
     await this.runPromise
+  }
+
+  abort (): void {
+    if (this.abortController && !this.abortController.signal.aborted) {
+      this.abortController.abort()
+    }
   }
 
   toWipData (): types.WipData {


### PR DESCRIPTION
When jobs exceed their maxExpiration, the abort signal passed into the job will abort. Similarly, when pg boss shuts down, it will wait for a grace period before marking the wip jobs as failed. The intention here as well is: times up! Time to stop working if you are still working. 

Currently, the abort controller in the job does not notify of shutdown (only maxExpiration), but it should, because we are going to fail the job and it might start up somewhere else, and the worker should stop working (if it still is)!

This adds a slot on workers to keep track of the currently active job abortController. In the manager, a workerRef is used to populate and clear the currently active abortController onto the worker, as it fetches jobs. When failWip is called, any workers with abortControllers are aborted, right before the job is marked as failed. 