### PR TITLE
feat: Allow disabling created_on sorting in job fetch

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -209,6 +209,10 @@ Returns an array of jobs from a queue
 
     If true, allow jobs with a higher priority to be fetched before jobs with lower or no priority
 
+  * `orderByCreatedOn`, bool, *default: true*
+
+    If true, jobs are fetched in the order they were created. Set to false to disable this sorting for improved performance when order doesn't matter.
+
   * `includeMetadata`, bool, *default: false*
 
     If `true`, all job metadata will be returned on the job object.

--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -29,6 +29,10 @@ The default options for `work()` is 1 job every 2 seconds.
 
   Same as in [`fetch()`](#fetch)
 
+* **orderByCreatedOn**, bool, *(default=true)*
+
+  Same as in [`fetch()`](#fetch)
+
 * **pollingIntervalSeconds**, int, *(default=2)*
 
   Interval to check for new jobs in seconds, must be >=0.5 (500ms)

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -296,7 +296,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
       priority = true,
       localConcurrency = 1,
       localGroupConcurrency,
-      groupConcurrency
+      groupConcurrency,
+      orderByCreatedOn = true
     } = options
 
     if (localGroupConcurrency != null) {

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -596,6 +596,7 @@ interface FetchJobOptions {
   limit: number
   includeMetadata?: boolean
   priority?: boolean
+  orderByCreatedOn?: boolean
   ignoreStartAfter?: boolean
   ignoreSingletons: string[] | null
   ignoreGroups?: string[] | null
@@ -655,7 +656,7 @@ function buildFetchParams (options: FetchJobOptions): FetchQueryParams {
 }
 
 function fetchNextJob (options: FetchJobOptions): SqlQuery {
-  const { schema, table, name, policy, limit, includeMetadata, priority = true, ignoreStartAfter = false, groupConcurrency } = options
+  const { schema, table, name, policy, limit, includeMetadata, priority = true, orderByCreatedOn = true, ignoreStartAfter = false, groupConcurrency } = options
 
   const singletonFetch = limit > 1 && (policy === QUEUE_POLICIES.singleton || policy === QUEUE_POLICIES.stately)
   const hasIgnoreSingletons = options.ignoreSingletons != null && options.ignoreSingletons.length > 0
@@ -696,7 +697,7 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
         SELECT ${selectCols}
         FROM ${schema}.${table}
         WHERE ${whereConditions}
-        ORDER BY ${priority ? 'priority desc, ' : ''}created_on, id
+        ORDER BY ${priority ? 'priority desc, ' : ''}${orderByCreatedOn ? 'created_on, ' : ''}id
         LIMIT ${limit}
         FOR UPDATE SKIP LOCKED
       )`

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,7 @@ export interface JobPollingOptions {
 export interface JobFetchOptions {
   includeMetadata?: boolean;
   priority?: boolean;
+  orderByCreatedOn?: boolean;
   batchSize?: number;
   ignoreStartAfter?: boolean;
 }


### PR DESCRIPTION
for improved performance when the order doesn't matter.

closes https://github.com/timgit/pg-boss/issues/674