### PR TITLE
feat: allow returning ids with spies disabled

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -146,18 +146,17 @@ Like, `sendThrottled()`, but instead of rejecting if a job is already sent in th
 
 This is a convenience version of `send()` with the `singletonSeconds`, `singletonKey` and `singletonNextSlot` option assigned. The `key` argument is optional.
 
-### `insert(name, Job[])`
+### `insert(name, Job[], options)`
 
 Create multiple jobs in one request with an array of objects.
 
-The contract and supported features are slightly different than `send()`, which is why this function is named independently.  For example, debouncing is not supported.
+The contract and supported features are slightly different than `send()`, which is why this function is named independently. For example, debouncing is not supported, and it doesn't return job IDs unless spies are enabled or `options.returnId` is set to `true`.
 
-The following contract is a typescript defintion of the expected object. Only `name` is required, but most other properties can be set. This will likely be enhanced later with more support for deferral and retention by an offset. For now, calculate any desired timestamps for these features before insertion.
+The following contract is a typescript defintion of the expected object. This will likely be enhanced later with more support for deferral and retention by an offset. For now, calculate any desired timestamps for these features before insertion.
 
 ```ts
 interface JobInsert<T = object> {
   id?: string,
-  name: string;
   data?: T;
   priority?: number;
   retryLimit?: number;

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -409,7 +409,11 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return null
   }
 
-  async insert (name: string, jobs: types.JobInsert[], options: types.InsertOptions = {}) {
+  async insert (
+    name: string,
+    jobs: types.JobInsert[],
+    options: types.InsertOptions & { returnId?: boolean } = {}
+  ) {
     assert(Array.isArray(jobs), 'jobs argument should be an array')
 
     const { table } = await this.getQueueCache(name)
@@ -419,7 +423,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     const spy = this.config.__test__enableSpies ? this.#spies.get(name) : undefined
 
     // Return IDs if spy is active for this queue (needed for job tracking)
-    const returnId = !!spy
+    const returnId = !!spy || !!options.returnId
 
     const sql = plans.insertJobs(this.config.schema, { table, name, returnId })
 


### PR DESCRIPTION
`boss.insert` doesn't return job IDs unless spies are enabled. Not sure why is not true by default, but to keep that behavior, it can now be enabled with an option