### PR TITLE
feat: allow jobs to never be removed

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -57,7 +57,7 @@ Creates a new job and returns the job id.
 
 * **deleteAfterSeconds**, int
 
-  Default: 7 days. How long a job should be retained in the database after it's completed.
+  Default: 7 days. How long a job should be retained in the database after it's completed. Set to 0 to never delete completed jobs.
 
 
 All retry, expiration, and retention options can also be set on the queue and will be inheritied for each job, unless they are overridden.

--- a/docs/api/queues.md
+++ b/docs/api/queues.md
@@ -70,7 +70,7 @@ Allowed policy values:
 
 * **deleteAfterSeconds**, int
 
-  Default: 7 days. How long a job should be retained in the database after it's completed.
+  Default: 7 days. How long a job should be retained in the database after it's completed. Set to 0 to never delete completed jobs.
 
 * All retry, expiration, and retention options set on the queue will be inheritied for each job, unless they are overridden.
 

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -300,8 +300,8 @@ function applyOpsConfig (config: any) {
 }
 
 function validateDeletionConfig (config: any) {
-  assert(!('deleteAfterSeconds' in config) || config.deleteAfterSeconds >= 1,
-    'configuration assert: deleteAfterSeconds must be at least every second')
+  assert(!('deleteAfterSeconds' in config) || config.deleteAfterSeconds >= 0,
+    'configuration assert: deleteAfterSeconds must be at least 0 (0 disables deletion)')
 }
 
 function applyScheduleConfig (config: any) {

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1073,7 +1073,7 @@ function deletion (schema: string, table: string, queues: string[]): string {
     WHERE name = ANY(${serializeArrayParam(queues)})
       AND
       (
-        completed_on + deletion_seconds * interval '1s' < now()
+        (deletion_seconds > 0 AND completed_on + deletion_seconds * interval '1s' < now())
         OR
         (state < '${JOB_STATES.active}' AND keep_until < now())
       )

--- a/test/deleteTest.ts
+++ b/test/deleteTest.ts
@@ -73,4 +73,58 @@ describe('delete', function () {
 
     expect(job).toBeFalsy()
   })
+
+  it('should never delete a completed job when deleteAfterSeconds is 0', async function () {
+    const config = {
+      ...ctx.bossConfig,
+      maintenanceIntervalSeconds: 1
+    }
+
+    ctx.boss = await helper.start(config)
+
+    const jobId = await ctx.boss.send(ctx.schema, null, { deleteAfterSeconds: 0 })
+
+    expect(jobId).toBeTruthy()
+
+    await ctx.boss.fetch(ctx.schema)
+    assertTruthy(jobId)
+    await ctx.boss.complete(ctx.schema, jobId)
+
+    await delay(2000)
+
+    await ctx.boss.supervise(ctx.schema)
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+
+    expect(job).toBeTruthy()
+    expect(job?.state).toBe('completed')
+  })
+
+  it('should never delete a completed job when deleteAfterSeconds is 0 - cascade config from queue', async function () {
+    const config = {
+      ...ctx.bossConfig,
+      maintenanceIntervalSeconds: 1,
+      noDefault: true
+    }
+
+    ctx.boss = await helper.start(config)
+
+    await ctx.boss.createQueue(ctx.schema, { deleteAfterSeconds: 0 })
+
+    const jobId = await ctx.boss.send(ctx.schema)
+    expect(jobId).toBeTruthy()
+    await ctx.boss.fetch(ctx.schema)
+    assertTruthy(jobId)
+    await ctx.boss.complete(ctx.schema, jobId)
+
+    await delay(2000)
+
+    await ctx.boss.supervise(ctx.schema)
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+
+    expect(job).toBeTruthy()
+    expect(job?.state).toBe('completed')
+  })
+
 })


### PR DESCRIPTION
In our system we'd like to never delete completed jobs (to maintain the full job log).
This change allows setting `deleteAfterSeconds` to `0`, which will omit deletion.