### PR TITLE
fix: handle bigint expireIn parameter in insertJob and insertJobs for custom db adapters

### DIFF
--- a/src/plans.js
+++ b/src/plans.js
@@ -792,9 +792,9 @@ function insertJob (schema) {
       singleton_on,
       COALESCE(j.dead_letter, q.dead_letter) as dead_letter,
       CASE
-        WHEN expire_in IS NOT NULL THEN CAST(expire_in as interval)
+        WHEN expire_in IS NOT NULL THEN expire_in::numeric * interval '1s'
         WHEN q.expire_seconds IS NOT NULL THEN q.expire_seconds * interval '1s'
-        WHEN expire_in_default IS NOT NULL THEN CAST(expire_in_default as interval)
+        WHEN expire_in_default IS NOT NULL THEN expire_in_default::numeric * interval '1s'
         ELSE interval '15 minutes'
         END as expire_in,
       CASE
@@ -880,9 +880,9 @@ function insertJobs (schema) {
         END as singleton_on,
       COALESCE("deadLetter", q.dead_letter) as dead_letter,
       CASE
-        WHEN "expireInSeconds" IS NOT NULL THEN "expireInSeconds" *  interval '1s'
+        WHEN "expireInSeconds" IS NOT NULL THEN "expireInSeconds"::numeric * interval '1s'
         WHEN q.expire_seconds IS NOT NULL THEN q.expire_seconds * interval '1s'
-        WHEN defaults.expire_in IS NOT NULL THEN CAST(defaults.expire_in as interval)
+        WHEN defaults.expire_in IS NOT NULL THEN defaults.expire_in::numeric * interval '1s'
         ELSE interval '15 minutes'
         END as expire_in,
       CASE


### PR DESCRIPTION
## Summary

Fixes SQL cast error when using custom database adapters (like Prisma) with `expireInSeconds`.

## Problem

When using the `db` option with adapters that send typed parameters (e.g., Prisma's `$queryRawUnsafe` sends integers as INT8/bigint), the `insertJob` and `insertJobs` SQL functions fail with:

```
ERROR: cannot cast type bigint to interval
SQLSTATE: 42846
```

## Root Cause

The job insertion functions use patterns like `CAST(expire_in as interval)` or `expire_in * interval` which:
- ✅ Works with native pg (sends as text, PostgreSQL parses `'300'` as interval)
- ❌ Fails with Prisma (sends as bigint, PostgreSQL has no bigint→interval cast)

## The Fix

Change all affected lines in `src/plans.js` to cast to numeric first:

```diff
# insertJob function (line 795)
-WHEN expire_in IS NOT NULL THEN CAST(expire_in as interval)
+WHEN expire_in IS NOT NULL THEN expire_in::numeric * interval '1s'

# insertJob function (line 797)
-WHEN expire_in_default IS NOT NULL THEN CAST(expire_in_default as interval)
+WHEN expire_in_default IS NOT NULL THEN expire_in_default::numeric * interval '1s'

# insertJobs function (line 883)
-WHEN "expireInSeconds" IS NOT NULL THEN "expireInSeconds" *  interval '1s'
+WHEN "expireInSeconds" IS NOT NULL THEN "expireInSeconds"::numeric * interval '1s'

# insertJobs function (line 885)
-WHEN defaults.expire_in IS NOT NULL THEN CAST(defaults.expire_in as interval)
+WHEN defaults.expire_in IS NOT NULL THEN defaults.expire_in::numeric * interval '1s'
```

This handles both parameter formats:
- `'300'::numeric * interval '1s'` → works (native pg text)
- `300::bigint::numeric * interval '1s'` → works (Prisma bigint)

## Testing

- All 191 existing tests pass
- 100% line coverage maintained
- PostgreSQL verified both type paths produce identical results

## Impact

- **Affected**: Users of custom `db` adapters (Prisma, Drizzle, etc.) with `expireInSeconds`
- **Backward compatible**: No change for native pg library users

**Note:** This PR targets the v10 branch. The same fix may be applicable to master.