### PR TITLE
[typescript] Ensure __test__enableSpies PgBoss constructor option is publicly visible

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,6 @@ export interface ConstructorOptions extends DatabaseOptions, SchedulingOptions, 
   __test__force_clock_skew_warning?: string;
   /** @internal */
   __test__force_clock_monitoring_error?: string;
-  /** @internal */
   __test__enableSpies?: boolean;
   /** @internal */
   migrations?: Migration[];


### PR DESCRIPTION
The `__test__enableSpies` option to the `PgBoss()` constructor is [documented publicly](https://timgit.github.io/pg-boss/#/./api/testing).

However, since it's marked as `@internal`, it's not available to TypeScript clients without type-punning via `as unknown as any` or similar.

This removes the `@internal` annotation so `__test__enableSpies` is available publicly to TypeScript clients.
