### PR TITLE
reenstate deadletter property so that it can be passed as option when creating a job

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -529,7 +529,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
       retryDelay,
       retryBackoff,
       retryDelayMax,
-      group
+      group,
+      deadLetter = null
     } = options
 
     const job = {
@@ -550,7 +551,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
       retryLimit,
       retryDelay,
       retryBackoff,
-      retryDelayMax
+      retryDelayMax,
+      deadLetter
     }
 
     const db = wrapper || this.db

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -976,7 +976,7 @@ function insertJobs (schema: string, { table, name, returnId = true }: InsertJob
       COALESCE("retryBackoff", q.retry_backoff, false) as retry_backoff,
       COALESCE("retryDelayMax", q.retry_delay_max) as retry_delay_max,
       q.policy,
-      q.dead_letter
+      COALESCE("deadLetter", q.dead_letter) as dead_letter
     FROM (
       SELECT *,
         CASE
@@ -999,7 +999,8 @@ function insertJobs (schema: string, { table, name, returnId = true }: InsertJob
         "groupTier" text,
         "expireInSeconds" integer,
         "deleteAfterSeconds" integer,
-        "retentionSeconds" integer
+        "retentionSeconds" integer,
+        "deadLetter" text
       )
     ) j
     JOIN ${schema}.queue q ON q.name = '${name}'

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ export interface JobOptions {
   singletonNextSlot?: boolean;
   keepUntil?: number | string | Date;
   group?: GroupOptions;
+  deadLetter?: string;
 }
 
 export interface ConnectionOptions {
@@ -278,6 +279,7 @@ export interface JobInsert<T = object> {
   deleteAfterSeconds?: number;
   retentionSeconds?: number;
   group?: GroupOptions;
+  deadLetter?: string;
 }
 
 export type WorkerState = 'created' | 'active' | 'stopping' | 'stopped'


### PR DESCRIPTION
What this PR does:

When migrating from version 10 to 11 the deadLetter property was removed from the JobOptions so it was not possible to pass as parameter the deadletter queue that we wanted to introduce to the job.

With this PR if an explicit deadLetter queue is passed as parameter it will have priority over the queue's default deadLetter one. 

Also we might have a case that the deadLetter property in the queue is empty and we want to add one in the job creation.

This PR handles these cases

