### PR TITLE
allow queued jobs to be marked complete

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -322,13 +322,26 @@ Retries a set of failed jobs.
 
 ### `complete(name, id, data, options)`
 
-Completes an active job. This would likely only be used with `fetch()`. Accepts an optional `data` argument.
+Completes an active job. This would likely only be used with `fetch()`. Accepts an optional `data` argument for job output and an optional `options` object.
+
+**options**
+
+* **includeQueued**, bool
+
+  Default: false. When false (default), only jobs in `active` state can be completed. When true, jobs in `created`, `retry`, or `active` states can be completed. This is useful for completing jobs that haven't been fetched yet, or for marking failed jobs as complete without retrying them.
+
+  ```js
+  // Complete a job without fetching it first
+  await boss.complete('my-queue', jobId, { result: 'done' }, { includeQueued: true })
+  ```
+
+* **db**, object, see notes in `send()`
 
 The promise will resolve on a successful completion, or reject if the job could not be completed.
 
 ### `complete(name, [ids], options)`
 
-Completes a set of active jobs.
+Completes a set of active jobs (or queued jobs when `includeQueued: true` is specified).
 
 The promise will resolve on a successful completion, or reject if not all of the requested jobs could not be marked as completed.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this.#manager.deleteAllJobs(name)
   }
 
-  complete (name: string, id: string | string[], data?: object | null, options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  complete (name: string, id: string | string[], data?: object | null, options?: types.CompleteOptions): Promise<types.CommandResponse> {
     return this.#manager.complete(name, id, data, options)
   }
 
@@ -364,6 +364,7 @@ export type {
   BamEntry,
   BamEvent,
   BamStatusSummary,
+  CompleteOptions,
   ConnectionOptions,
   ConstructorOptions,
   FetchOptions,

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -706,12 +706,12 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  async complete (name: string, id: string | string[], data?: object | null, options: types.ConnectionOptions = {}) {
+  async complete (name: string, id: string | string[], data?: object | null, options: types.CompleteOptions = {}) {
     Attorney.assertQueueName(name)
     const db = this.assertDb(options)
     const ids = this.mapCompletionIdArg(id, 'complete')
     const { table } = await this.getQueueCache(name)
-    const sql = plans.completeJobs(this.config.schema, table)
+    const sql = plans.completeJobs(this.config.schema, table, options.includeQueued)
     const result = await db.executeSql(sql, [name, ids, this.mapCompletionDataArg(data)])
     return this.mapCommandResponse(ids, result)
   }

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -872,7 +872,11 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
   }
 }
 
-function completeJobs (schema: string, table: string) {
+function completeJobs (schema: string, table: string, includeQueued?: boolean) {
+  const stateFilter = includeQueued
+    ? `state < '${JOB_STATES.completed}'`
+    : `state = '${JOB_STATES.active}'`
+
   return `
     WITH results AS (
       UPDATE ${schema}.${table}
@@ -881,7 +885,7 @@ function completeJobs (schema: string, table: string) {
         output = $3::jsonb
       WHERE name = $1
         AND id IN (SELECT UNNEST($2::uuid[]))
-        AND state = '${JOB_STATES.active}'
+        AND ${stateFilter}
       RETURNING *
     )
     SELECT COUNT(*) FROM results

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,10 @@ export interface ConnectionOptions {
   db?: IDatabase;
 }
 
+export interface CompleteOptions extends ConnectionOptions {
+  includeQueued?: boolean;
+}
+
 export interface FindJobsOptions extends ConnectionOptions {
   id?: string;
   key?: string;


### PR DESCRIPTION
This allows marking a job complete when there is no worker/fetch, for example when using `findJobs`