### PR TITLE
Stricter typing on data passed to worker

### DIFF
--- a/examples/load/index.ts
+++ b/examples/load/index.ts
@@ -110,8 +110,8 @@ async function typedInit (schema: string) {
     console.log(`${schema}: sending a job to each one: ${new Date()}`)
 
     await Promise.all(queues.map(async queue => {
-      // await boss.send(queue) <-- fails since input-type does not allow `undefined`.
-      // await boss.schedule(queue, '* * * * *') <-- fails since input-type does not allow `undefined`.
+      // await boss.send(queue) // <-- fails since input-type does not allow `undefined`.
+      // await boss.schedule(queue, '* * * * *') // <-- fails since input-type does not allow `undefined`.
       await boss.send('queue4')
       await boss.fetch(queue)
     }))

--- a/examples/load/index.ts
+++ b/examples/load/index.ts
@@ -58,7 +58,7 @@ async function typedInit (schema: string) {
     queue1: { input: { arg1: string }, output: { completed: { result: string } } }
     queue2: { input: { arg2: number }, output: { completed: { result: number } } }
     queue3: { input: { arg3: object }, output: { completed: { result: object } } }
-    queue4: { input: undefined, output: { completed: { result: object } } }
+    queue4: { input: undefined }
   }>({ ...config, schema, supervise: false, schedule: false })
 
   boss.on('error', console.error)
@@ -93,6 +93,16 @@ async function typedInit (schema: string) {
       break
     case 'failed':
       console.log(job.output)
+      break
+  }
+
+  const job4 = (await boss.findJobs('queue4'))[0]!
+  switch (job4.state) {
+    case 'completed':
+      console.log(job4.output)
+      break
+    case 'failed':
+      console.log(job4.output)
       break
   }
 

--- a/examples/load/interface.ts
+++ b/examples/load/interface.ts
@@ -1,0 +1,18 @@
+import { PgBoss } from '../../src'
+
+interface JobsSchema {
+  'queue-a': { input: { a: string; b: number } };
+  // foo: { bar: string }; // <-- This line will fail because its not a valid job definition.
+}
+
+interface JobsSchema {
+  'queue-b': { input: { a: string; b: number } };
+}
+
+export const boss = new PgBoss<{
+  [S in keyof JobsSchema]: JobsSchema[S];
+}>({})
+
+// Code completion work as expected
+boss.send('queue-a', { a: 'a', b: 42 })
+// boss.send('queue-c', { foo: 'bar' }) // <-- This line will fail because the job-type is not defined.

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -25,7 +25,7 @@ function validateQueueArgs (config: any = {}) {
   validateDeletionConfig(config)
 }
 
-function checkSendArgs (args: any): types.Request {
+function checkSendArgs<C extends types.JobsConfig, N extends types.JobNames<C>> (args: any): types.Request<N> {
   let name, data, options
 
   if (typeof args[0] === 'string') {
@@ -139,7 +139,7 @@ function validateLocalGroupConcurrencyLimit (localGroupConcurrency: any, localCo
   }
 }
 
-function checkWorkArgs (name: string, args: any[]): {
+function checkWorkArgs<C extends types.JobsConfig, N extends types.JobNames<C>> (name: N, args: any[]): {
   options: types.ResolvedWorkOptions
   callback: types.WorkHandler<any>
 } {

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -25,7 +25,7 @@ function validateQueueArgs (config: any = {}) {
   validateDeletionConfig(config)
 }
 
-function checkSendArgs<C extends types.JobsConfig, N extends types.JobNames<C>> (args: any): types.Request<N> {
+function checkSendArgs<C extends types.JobsConfig, N extends types.JobNames<C>> (args: any): types.Request<C, N> {
   let name, data, options
 
   if (typeof args[0] === 'string') {
@@ -141,7 +141,7 @@ function validateLocalGroupConcurrencyLimit (localGroupConcurrency: any, localCo
 
 function checkWorkArgs<C extends types.JobsConfig, N extends types.JobNames<C>> (name: N, args: any[]): {
   options: types.ResolvedWorkOptions
-  callback: types.WorkHandler<any>
+  callback: types.WorkHandler<C, N>
 } {
   let options, callback
 

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -15,20 +15,20 @@ const WARNINGS = {
   LARGE_QUEUE: { size: 10_000, message: 'Warning: large queue backlog. Your queue should be reviewed' }
 }
 
-class Boss<C extends types.JobsConfig & TimekeeperJobConfig> extends EventEmitter implements types.EventsMixin {
+class Boss<C extends types.JobsConfig & TimekeeperJobConfig, EC extends types.EventConfig<C>> extends EventEmitter implements types.EventsMixin {
   #stopped: boolean
   #stopping: boolean
   #maintaining: boolean | undefined
   #superviseInterval: NodeJS.Timeout | undefined
   #db: types.IDatabase
   #config: types.ResolvedConstructorOptions
-  #manager: Manager<C>
+  #manager: Manager<C, EC>
 
   events = events
 
   constructor (
     db: types.IDatabase,
-    manager: Manager<C>,
+    manager: Manager<C, EC>,
     config: types.ResolvedConstructorOptions
   ) {
     super()

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -3,6 +3,7 @@ import type Manager from './manager.ts'
 import * as plans from './plans.ts'
 import { unwrapSQLResult } from './tools.ts'
 import * as types from './types.ts'
+import { type JobConfig as TimekeeperJobConfig } from './timekeeper.ts'
 
 const events = {
   error: 'error',
@@ -14,20 +15,20 @@ const WARNINGS = {
   LARGE_QUEUE: { size: 10_000, message: 'Warning: large queue backlog. Your queue should be reviewed' }
 }
 
-class Boss extends EventEmitter implements types.EventsMixin {
+class Boss<C extends types.JobsConfig & TimekeeperJobConfig> extends EventEmitter implements types.EventsMixin {
   #stopped: boolean
   #stopping: boolean
   #maintaining: boolean | undefined
   #superviseInterval: NodeJS.Timeout | undefined
   #db: types.IDatabase
   #config: types.ResolvedConstructorOptions
-  #manager: Manager
+  #manager: Manager<C>
 
   events = events
 
   constructor (
     db: types.IDatabase,
-    manager: Manager,
+    manager: Manager<C>,
     config: types.ResolvedConstructorOptions
   ) {
     super()
@@ -124,8 +125,8 @@ class Boss extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  async supervise (value?: string | types.QueueResult[]) {
-    let queues: types.QueueResult[]
+  async supervise<N extends types.JobNames<C>>(value?: N | types.QueueResult<N>[]) {
+    let queues: types.QueueResult<N>[]
 
     if (Array.isArray(value)) {
       queues = value
@@ -134,7 +135,7 @@ class Boss extends EventEmitter implements types.EventsMixin {
     }
 
     const queueGroups = queues.reduce<
-      Record<string, { table: string; queues: types.Queue[] }>
+      Record<string, { table: string; queues: types.Queue<N>[] }>
     >((acc, q) => {
       const { table } = q
       acc[table] = acc[table] || { table, queues: [] }

--- a/src/index.ts
+++ b/src/index.ts
@@ -334,7 +334,7 @@ export class PgBoss<
     return this.#timekeeper.unschedule(name, key)
   }
 
-  getSchedules<N extends types.JobNames<C>>(name?: N, key?: string): Promise<types.Schedule[]> {
+  getSchedules<N extends types.JobNames<C>>(name?: N, key?: string): Promise<types.Schedule<N>[]> {
     return this.#timekeeper.getSchedules(name, key)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,8 +205,8 @@ export class PgBoss<
   }
 
   fetch<N extends types.JobNames<C>>(name: N, options: types.FetchOptions & { includeMetadata: true }): Promise<types.JobWithMetadata<C, N>[]>
-  fetch<N extends types.JobNames<C>>(name: N, options?: types.FetchOptions): Promise<types.Job<types.JobInput<C, N>>[]>
-  fetch<N extends types.JobNames<C>>(name: N, options: types.FetchOptions = {}): Promise<types.Job<types.JobInput<C, N>>[] | types.JobWithMetadata<C, N>[]> {
+  fetch<N extends types.JobNames<C>>(name: N, options?: types.FetchOptions): Promise<types.Job<C, N>[]>
+  fetch<N extends types.JobNames<C>>(name: N, options: types.FetchOptions = {}): Promise<types.Job<C, N>[] | types.JobWithMetadata<C, N>[]> {
     return this.#manager.fetch<N>(name, options)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,8 +311,8 @@ export class PgBoss<
     return this.#boss.supervise(name)
   }
 
-  getSpy<N extends types.JobNames<C>, T = object> (name: N): JobSpyInterface<T> {
-    return this.#manager.getSpy<T>(name)
+  getSpy<N extends types.JobNames<C>> (name: N): JobSpyInterface<types.JobInput<C, N>> {
+    return this.#manager.getSpy<types.JobInput<C, N>>(name)
   }
 
   clearSpies (): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,24 +178,24 @@ export class PgBoss<
     await shutdown()
   }
 
-  send<N extends types.JobNames<C>>(request: types.Request<N>): Promise<string | null>
-  send<N extends types.JobNames<C>>(name: N, data?: object | null, options?: types.SendOptions): Promise<string | null>
+  send<N extends types.JobNames<C>>(request: types.Request<C, N>): Promise<string | null>
+  send<N extends types.JobNames<C>>(name: N, data?: types.JobInput<C, N>, options?: types.SendOptions): Promise<string | null>
   async send (...args: any[]): Promise<string | null> {
     return await this.#manager.send(...args as Parameters<Manager<C, EC>['send']>)
   }
 
-  sendAfter<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, date: Date): Promise<string | null>
-  sendAfter<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, dateString: string): Promise<string | null>
-  sendAfter<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, seconds: number): Promise<string | null>
-  async sendAfter<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, after: Date | string | number): Promise<string | null> {
+  sendAfter<N extends types.JobNames<C>>(name: N, data: types.JobInput<C, N>, options: types.SendOptions | null, date: Date): Promise<string | null>
+  sendAfter<N extends types.JobNames<C>>(name: N, data: types.JobInput<C, N>, options: types.SendOptions | null, dateString: string): Promise<string | null>
+  sendAfter<N extends types.JobNames<C>>(name: N, data: types.JobInput<C, N>, options: types.SendOptions | null, seconds: number): Promise<string | null>
+  async sendAfter<N extends types.JobNames<C>>(name: N, data: types.JobInput<C, N>, options: types.SendOptions | null, after: Date | string | number): Promise<string | null> {
     return this.#manager.sendAfter(name, data, options, after)
   }
 
-  sendThrottled<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
+  sendThrottled<N extends types.JobNames<C>>(name: N, data: types.JobInput<C, N>, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
     return this.#manager.sendThrottled(name, data, options, seconds, key)
   }
 
-  sendDebounced<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
+  sendDebounced<N extends types.JobNames<C>>(name: N, data: types.JobInput<C, N>, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
     return this.#manager.sendDebounced(name, data, options, seconds, key)
   }
 
@@ -209,9 +209,9 @@ export class PgBoss<
     return this.#manager.fetch<N, T>(name, options)
   }
 
-  work<N extends types.JobNames<C>, ReqData, ResData = any>(name: N, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
-  work<N extends types.JobNames<C>, ReqData, ResData = any>(name: N, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData, ResData>): Promise<string>
-  work<N extends types.JobNames<C>, ReqData, ResData = any>(name: N, options: types.WorkOptions, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
+  work<N extends types.JobNames<C>, ResData = any>(name: N, handler: types.WorkHandler<C, N, ResData>): Promise<string>
+  work<N extends types.JobNames<C>, ResData = any>(name: N, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<C, N, ResData>): Promise<string>
+  work<N extends types.JobNames<C>, ResData = any>(name: N, options: types.WorkOptions, handler: types.WorkHandler<C, N, ResData>): Promise<string>
   work (...args: any[]): Promise<string> {
     return this.#manager.work(...args as Parameters<Manager<C, EC>['work']>)
   }
@@ -232,7 +232,7 @@ export class PgBoss<
     return this.#manager.unsubscribe(event, name)
   }
 
-  publish<EventName extends types.EventNames<C, EC>>(event: EventName, data?: object, options?: types.SendOptions): Promise<void> {
+  publish<EventName extends types.EventNames<C, EC>>(event: EventName, data?: types.JobInput<C, EC[EventName]>, options?: types.SendOptions): Promise<void> {
     return this.#manager.publish(event, data, options)
   }
 
@@ -279,7 +279,7 @@ export class PgBoss<
     return this.#manager.getJobById<N, T>(name, id, options)
   }
 
-  findJobs<N extends types.JobNames<C>, T = any>(name: N, options?: types.FindJobsOptions): Promise<types.JobWithMetadata<T>[]> {
+  findJobs<N extends types.JobNames<C>, T = any>(name: N, options?: types.FindJobsOptions<NonNullable<types.JobInput<C, N>>>): Promise<types.JobWithMetadata<T>[]> {
     return this.#manager.findJobs<N, T>(name, options)
   }
 
@@ -327,7 +327,7 @@ export class PgBoss<
     return this.#contractor.schemaVersion()
   }
 
-  schedule<N extends types.JobNames<C>>(name: N, cron: string, data?: object | null, options?: types.ScheduleOptions): Promise<void> {
+  schedule<N extends types.JobNames<C>>(name: N, cron: string, data?: types.JobInput<C, N>, options?: types.ScheduleOptions): Promise<void> {
     return this.#timekeeper.schedule(name, cron, data, options)
   }
 
@@ -335,7 +335,7 @@ export class PgBoss<
     return this.#timekeeper.unschedule(name, key)
   }
 
-  getSchedules<N extends types.JobNames<C>>(name?: N, key?: string): Promise<types.Schedule<N>[]> {
+  getSchedules<N extends types.JobNames<C>>(name?: N, key?: string): Promise<types.Schedule<C, N>[]> {
     return this.#timekeeper.getSchedules(name, key)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,8 @@ export class PgBoss<
   }
 
   send<N extends types.JobNames<C>>(request: types.Request<C, N>): Promise<string | null>
-  send<N extends types.JobNames<C>>(name: N, data?: types.JobInput<C, N>, options?: types.SendOptions): Promise<string | null>
+  send<N extends types.JobNames<C>>(name: undefined extends types.JobInput<C, N> ? N : never, options?: types.SendOptions): Promise<string | null> // Type override for data possibly being undefined.
+  send<N extends types.JobNames<C>>(name: N, data: Exclude<types.JobInput<C, N>, undefined>, options?: types.SendOptions): Promise<string | null> // Type override for required data.
   async send (...args: any[]): Promise<string | null> {
     return await this.#manager.send(...args as Parameters<Manager<C, EC>['send']>)
   }
@@ -232,6 +233,8 @@ export class PgBoss<
     return this.#manager.unsubscribe(event, name)
   }
 
+  publish<EventName extends types.EventNames<C, EC>>(event: undefined extends types.JobInput<C, EC[EventName]> ? EventName : never, options?: types.SendOptions): Promise<void> // Type override for data possibly being undefined.
+  publish<EventName extends types.EventNames<C, EC>>(event: EventName, data: Exclude<types.JobInput<C, EC[EventName]>, undefined>, options?: types.SendOptions): Promise<void> // Type override for required data.
   publish<EventName extends types.EventNames<C, EC>>(event: EventName, data?: types.JobInput<C, EC[EventName]>, options?: types.SendOptions): Promise<void> {
     return this.#manager.publish(event, data, options)
   }
@@ -264,10 +267,14 @@ export class PgBoss<
     return this.#manager.deleteAllJobs(name)
   }
 
+  complete<N extends types.JobNames<C>>(name: undefined extends types.JobOutput<C, N, 'completed'> | Error ? N : never, id: string | string[], data?: undefined, options?: types.CompleteOptions): Promise<types.CommandResponse> // Type override for data possibly being undefined.
+  complete<N extends types.JobNames<C>>(name: N, id: string | string[], data: Exclude<types.JobOutput<C, N, 'completed'> | Error, undefined>, options?: types.CompleteOptions): Promise<types.CommandResponse> // Type override for required data.
   complete<N extends types.JobNames<C>>(name: N, id: string | string[], data?: types.JobOutput<C, N, 'completed'> | Error, options?: types.CompleteOptions): Promise<types.CommandResponse> {
     return this.#manager.complete(name, id, data, options)
   }
 
+  fail<N extends types.JobNames<C>>(name: undefined extends types.JobOutput<C, N, 'failed'> ? N : never, id: string | string[], data?: undefined, options?: types.ConnectionOptions): Promise<types.CommandResponse> // Type override for data possibly being undefined.
+  fail<N extends types.JobNames<C>>(name: N, id: string | string[], data: Exclude<types.JobOutput<C, N, 'failed'>, undefined>, options?: types.ConnectionOptions): Promise<types.CommandResponse> // Type override for required data.
   fail<N extends types.JobNames<C>>(name: N, id: string | string[], data?: types.JobOutput<C, N, 'failed'> | Error, options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.fail(name, id, data, options)
   }
@@ -327,6 +334,8 @@ export class PgBoss<
     return this.#contractor.schemaVersion()
   }
 
+  schedule<N extends types.JobNames<C>>(name: undefined extends types.JobInput<C, N> ? N : never, cron: string): Promise<void> // Type override for data possibly being undefined.
+  schedule<N extends types.JobNames<C>>(name: N, cron: string, data: types.JobInput<C, N>, options?: types.ScheduleOptions): Promise<void> // Type override for required data.
   schedule<N extends types.JobNames<C>>(name: N, cron: string, data?: types.JobInput<C, N>, options?: types.ScheduleOptions): Promise<void> {
     return this.#timekeeper.schedule(name, cron, data, options)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ export class PgBoss<
     return this.#manager.sendDebounced(name, data, options, seconds, key)
   }
 
-  insert<N extends types.JobNames<C>>(name: N, jobs: types.JobInsert[], options?: types.InsertOptions): Promise<string[] | null> {
+  insert<N extends types.JobNames<C>>(name: N, jobs: types.JobInsert<types.JobInput<C, N>>[], options?: types.InsertOptions): Promise<string[] | null> {
     return this.#manager.insert(name, jobs, options)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ export class PgBoss<
     return this.#manager.sendDebounced(name, data, options, seconds, key)
   }
 
-  insert<N extends types.JobNames<C>>(name: N, jobs: types.JobInsert<types.JobInput<C, N>>[], options?: types.InsertOptions): Promise<string[] | null> {
+  insert<N extends types.JobNames<C>>(name: N, jobs: types.JobInsert<C, N>[], options?: types.InsertOptions): Promise<string[] | null> {
     return this.#manager.insert(name, jobs, options)
   }
 
@@ -286,7 +286,7 @@ export class PgBoss<
     return this.#manager.getJobById<N>(name, id, options)
   }
 
-  findJobs<N extends types.JobNames<C>>(name: N, options?: types.FindJobsOptions<NonNullable<types.JobInput<C, N>>>): Promise<types.JobWithMetadata<C, N>[]> {
+  findJobs<N extends types.JobNames<C>>(name: N, options?: types.FindJobsOptions<C, N>): Promise<types.JobWithMetadata<C, N>[]> {
     return this.#manager.findJobs<N>(name, options)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,15 +203,15 @@ export class PgBoss<
     return this.#manager.insert(name, jobs, options)
   }
 
-  fetch<N extends types.JobNames<C>, T>(name: N, options: types.FetchOptions & { includeMetadata: true }): Promise<types.JobWithMetadata<T>[]>
-  fetch<N extends types.JobNames<C>, T>(name: N, options?: types.FetchOptions): Promise<types.Job<T>[]>
-  fetch<N extends types.JobNames<C>, T>(name: N, options: types.FetchOptions = {}): Promise<types.Job<T>[] | types.JobWithMetadata<T>[]> {
-    return this.#manager.fetch<N, T>(name, options)
+  fetch<N extends types.JobNames<C>>(name: N, options: types.FetchOptions & { includeMetadata: true }): Promise<types.JobWithMetadata<C, N>[]>
+  fetch<N extends types.JobNames<C>>(name: N, options?: types.FetchOptions): Promise<types.Job<types.JobInput<C, N>>[]>
+  fetch<N extends types.JobNames<C>>(name: N, options: types.FetchOptions = {}): Promise<types.Job<types.JobInput<C, N>>[] | types.JobWithMetadata<C, N>[]> {
+    return this.#manager.fetch<N>(name, options)
   }
 
-  work<N extends types.JobNames<C>, ResData = any>(name: N, handler: types.WorkHandler<C, N, ResData>): Promise<string>
-  work<N extends types.JobNames<C>, ResData = any>(name: N, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<C, N, ResData>): Promise<string>
-  work<N extends types.JobNames<C>, ResData = any>(name: N, options: types.WorkOptions, handler: types.WorkHandler<C, N, ResData>): Promise<string>
+  work<N extends types.JobNames<C>>(name: N, handler: types.WorkHandler<C, N>): Promise<string>
+  work<N extends types.JobNames<C>>(name: N, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<C, N>): Promise<string>
+  work<N extends types.JobNames<C>>(name: N, options: types.WorkOptions, handler: types.WorkHandler<C, N>): Promise<string>
   work (...args: any[]): Promise<string> {
     return this.#manager.work(...args as Parameters<Manager<C, EC>['work']>)
   }
@@ -264,23 +264,23 @@ export class PgBoss<
     return this.#manager.deleteAllJobs(name)
   }
 
-  complete<N extends types.JobNames<C>>(name: N, id: string | string[], data?: object | null, options?: types.CompleteOptions): Promise<types.CommandResponse> {
+  complete<N extends types.JobNames<C>>(name: N, id: string | string[], data?: types.JobOutput<C, N, 'completed'> | Error, options?: types.CompleteOptions): Promise<types.CommandResponse> {
     return this.#manager.complete(name, id, data, options)
   }
 
-  fail<N extends types.JobNames<C>>(name: N, id: string | string[], data?: object | null, options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  fail<N extends types.JobNames<C>>(name: N, id: string | string[], data?: types.JobOutput<C, N, 'failed'> | Error, options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.fail(name, id, data, options)
   }
 
   /**
    * @deprecated Use findJobs() instead
    */
-  getJobById<N extends types.JobNames<C>, T>(name: N, id: string, options?: types.ConnectionOptions): Promise<types.JobWithMetadata<T> | null> {
-    return this.#manager.getJobById<N, T>(name, id, options)
+  getJobById<N extends types.JobNames<C>>(name: N, id: string, options?: types.ConnectionOptions): Promise<types.JobWithMetadata<C, N> | null> {
+    return this.#manager.getJobById<N>(name, id, options)
   }
 
-  findJobs<N extends types.JobNames<C>, T = any>(name: N, options?: types.FindJobsOptions<NonNullable<types.JobInput<C, N>>>): Promise<types.JobWithMetadata<T>[]> {
-    return this.#manager.findJobs<N, T>(name, options)
+  findJobs<N extends types.JobNames<C>>(name: N, options?: types.FindJobsOptions<NonNullable<types.JobInput<C, N>>>): Promise<types.JobWithMetadata<C, N>[]> {
+    return this.#manager.findJobs<N>(name, options)
   }
 
   createQueue<N extends types.JobNames<C>>(name: N, options?: Omit<types.Queue<N>, 'name'>): Promise<void> {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -602,7 +602,7 @@ class Manager<C extends types.JobsConfig & timekeeper.JobConfig, EC extends type
 
   async insert<N extends types.JobNames<C>>(
     name: N,
-    jobs: types.JobInsert<types.JobInput<C, N>>[],
+    jobs: types.JobInsert<C, N>[],
     options: types.InsertOptions = {}
   ) {
     assert(Array.isArray(jobs), 'jobs argument should be an array')
@@ -930,7 +930,7 @@ class Manager<C extends types.JobsConfig & timekeeper.JobConfig, EC extends type
     }
   }
 
-  async findJobs<N extends types.JobNames<C>>(name: N, options: types.FindJobsOptions<NonNullable<types.JobInput<C, N>>> = {}): Promise<types.JobWithMetadata<C, N>[]> {
+  async findJobs<N extends types.JobNames<C>>(name: N, options: types.FindJobsOptions<C, N> = {}): Promise<types.JobWithMetadata<C, N>[]> {
     Attorney.assertQueueName(name)
 
     const db = this.assertDb(options)

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -19,7 +19,11 @@ const events = {
   wip: 'wip'
 }
 
-class Manager extends EventEmitter implements types.EventsMixin {
+type QueuesRecord<C extends types.JobsConfig> = {
+  [N in types.JobNames<C>]: Record<N, types.QueueResult<N>>;
+}[types.JobNames<C>]
+
+class Manager<C extends types.JobsConfig & timekeeper.JobConfig> extends EventEmitter implements types.EventsMixin {
   events = events
   db: (types.IDatabase & { _pgbdb?: false }) | Db
   config: types.ResolvedConstructorOptions
@@ -27,8 +31,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
   workers: Map<string, Worker>
   stopped: boolean | undefined
   queueCacheInterval: NodeJS.Timeout | undefined
-  timekeeper: Timekeeper | undefined
-  queues: Record<string, types.QueueResult> | null
+  timekeeper: Timekeeper<C> | undefined
+  queues: QueuesRecord<C> | null
   pendingOffWorkCleanups: Set<Promise<any>>
   #spies: Map<string, JobSpy>
   #localGroupActive: Map<string, Map<string, number>>
@@ -198,8 +202,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  async #processJobs<T> (
-    name: string,
+  async #processJobs<N extends types.JobNames<C>, T> (
+    name: N,
     jobs: types.Job<T>[],
     callback: types.WorkHandler<T>,
     worker?: Worker<T>
@@ -239,19 +243,19 @@ class Manager extends EventEmitter implements types.EventsMixin {
     try {
       assert(!this.config.__test__throw_queueCache, 'test error')
       const queues = await this.getQueues()
-      this.queues = queues.reduce<Record<string, types.QueueResult>>((acc, i) => { acc[i.name] = i; return acc }, {})
+      this.queues = queues.reduce<Record<string, types.QueueResult<types.JobNames<C>>>>((acc, i) => { acc[i.name] = i; return acc }, {})
     } catch (error: any) {
       emit && this.emit(events.error, { ...error, message: error.message, stack: error.stack })
     }
   }
 
-  async getQueueCache (name: string): Promise<types.QueueResult> {
+  async getQueueCache<N extends types.JobNames<C>>(name: N): Promise<types.QueueResult<N>> {
     assert(this.queues, 'Queue cache is not initialized')
 
     let queue = this.queues[name]
 
     if (queue) {
-      return queue
+      return queue as types.QueueResult<N>
     }
 
     queue = await this.getQueue(name)
@@ -262,7 +266,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
     this.queues[name] = queue
 
-    return queue
+    return queue as types.QueueResult<N>
   }
 
   async stop () {
@@ -291,10 +295,10 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  work<ReqData>(name: string, handler: types.WorkHandler<ReqData>): Promise<string>
-  work<ReqData>(name: string, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData>): Promise<string>
-  work<ReqData>(name: string, options: types.WorkOptions, handler: types.WorkHandler<ReqData>): Promise<string>
-  async work<ReqData> (name: string, ...args: unknown[]): Promise<string> {
+  work<N extends types.JobNames<C>, ReqData>(name: N, handler: types.WorkHandler<ReqData>): Promise<string>
+  work<N extends types.JobNames<C>, ReqData>(name: N, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData>): Promise<string>
+  work<N extends types.JobNames<C>, ReqData>(name: N, options: types.WorkOptions, handler: types.WorkHandler<ReqData>): Promise<string>
+  async work<N extends types.JobNames<C>, ReqData> (name: N, ...args: unknown[]): Promise<string> {
     const { options, callback } = Attorney.checkWorkArgs(name, args)
 
     if (this.stopped) {
@@ -323,7 +327,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
         const ignoreGroups = localGroupConcurrency != null
           ? this.#getGroupsAtLocalCapacity(name)
           : undefined
-        return this.fetch<ReqData>(name, { batchSize, includeMetadata, priority, orderByCreatedOn, groupConcurrency, ignoreGroups })
+        return this.fetch<N, ReqData>(name, { batchSize, includeMetadata, priority, orderByCreatedOn, groupConcurrency, ignoreGroups })
       }
 
       const onFetch = async (jobs: types.Job<ReqData>[]) => {
@@ -415,7 +419,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return this.pendingOffWorkCleanups.size > 0
   }
 
-  async offWork (name: string, options: types.OffWorkOptions = { wait: true }): Promise<void> {
+  async offWork<N extends types.JobNames<C>>(name: N, options: types.OffWorkOptions = { wait: true }): Promise<void> {
     assert(name, 'queue name is required')
     assert(typeof name === 'string', 'queue name must be a string')
 
@@ -449,14 +453,14 @@ class Manager extends EventEmitter implements types.EventsMixin {
     this.workers.get(workerId)?.notify()
   }
 
-  async subscribe (event: string, name: string): Promise<void> {
+  async subscribe<N extends types.JobNames<C>>(event: string, name: N): Promise<void> {
     assert(event, 'Missing required argument')
     assert(name, 'Missing required argument')
     const sql = plans.subscribe(this.config.schema)
     await this.db.executeSql(sql, [event, name])
   }
 
-  async unsubscribe (event: string, name: string): Promise<void> {
+  async unsubscribe<N extends types.JobNames<C>>(event: string, name: N): Promise<void> {
     assert(event, 'Missing required argument')
     assert(name, 'Missing required argument')
     const sql = plans.unsubscribe(this.config.schema)
@@ -472,15 +476,15 @@ class Manager extends EventEmitter implements types.EventsMixin {
     await Promise.allSettled(rows.map(({ name }) => this.send(name, data, options)))
   }
 
-  send (request: types.Request): Promise<string | null>
-  send (name: string, data?: object | null, options?: types.SendOptions | null): Promise<string | null>
+  send<N extends types.JobNames<C>>(request: types.Request<N>): Promise<string | null>
+  send<N extends types.JobNames<C>>(name: N, data?: object | null, options?: types.SendOptions | null): Promise<string | null>
   async send (...args: any[]): Promise<string | null> {
     const result = Attorney.checkSendArgs(args)
 
     return await this.createJob(result)
   }
 
-  async sendAfter (name: string, data: object | null, options: types.SendOptions | null, after: Date | string | number): Promise<string | null> {
+  async sendAfter<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, after: Date | string | number): Promise<string | null> {
     options = options ? { ...options } : {}
     options.startAfter = after
 
@@ -489,7 +493,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return await this.createJob(result)
   }
 
-  async sendThrottled (name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
+  async sendThrottled<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
     options = options ? { ...options } : {}
     options.singletonSeconds = seconds
     options.singletonNextSlot = false
@@ -500,7 +504,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return await this.createJob(result)
   }
 
-  async sendDebounced (name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
+  async sendDebounced<N extends types.JobNames<C>>(name: N, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
     options = options ? { ...options } : {}
     options.singletonSeconds = seconds
     options.singletonNextSlot = true
@@ -511,7 +515,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return await this.createJob(result)
   }
 
-  async createJob (request: types.Request): Promise<string | null> {
+  async createJob<N extends types.JobNames<C>>(request: types.Request<N>): Promise<string | null> {
     const { name, data = null, options = {} } = request
     const {
       id = null,
@@ -596,8 +600,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return null
   }
 
-  async insert (
-    name: string,
+  async insert<N extends types.JobNames<C>>(
+    name: N,
     jobs: types.JobInsert[],
     options: types.InsertOptions = {}
   ) {
@@ -645,10 +649,10 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return startAfter
   }
 
-  fetch<T>(name: string): Promise<types.Job<T>[]>
-  fetch<T>(name: string, options: types.FetchOptions & { includeMetadata: true }): Promise<types.JobWithMetadata<T>[]>
-  fetch<T>(name: string, options: types.FetchOptions): Promise<types.Job<T>[]>
-  async fetch (name: string, options: types.FetchOptions = {}) {
+  fetch<N extends types.JobNames<C>, T>(name: N): Promise<types.Job<T>[]>
+  fetch<N extends types.JobNames<C>, T>(name: N, options: types.FetchOptions & { includeMetadata: true }): Promise<types.JobWithMetadata<T>[]>
+  fetch<N extends types.JobNames<C>, T>(name: N, options: types.FetchOptions): Promise<types.Job<T>[]>
+  async fetch<N extends types.JobNames<C>>(name: N, options: types.FetchOptions = {}) {
     Attorney.checkFetchArgs(name, options)
 
     const db = this.assertDb(options)
@@ -708,7 +712,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  async complete (name: string, id: string | string[], data?: object | null, options: types.CompleteOptions = {}) {
+  async complete<N extends types.JobNames<C>>(name: N, id: string | string[], data?: object | null, options: types.CompleteOptions = {}) {
     Attorney.assertQueueName(name)
     const db = this.assertDb(options)
     const ids = this.mapCompletionIdArg(id, 'complete')
@@ -718,7 +722,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return this.mapCommandResponse(ids, result)
   }
 
-  async fail (name: string, id: string | string[], data?: any, options: types.ConnectionOptions = {}) {
+  async fail<N extends types.JobNames<C>>(name: N, id: string | string[], data?: any, options: types.ConnectionOptions = {}) {
     Attorney.assertQueueName(name)
     const db = this.assertDb(options)
     const ids = this.mapCompletionIdArg(id, 'fail')
@@ -728,7 +732,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return this.mapCommandResponse(ids, result)
   }
 
-  async deleteJob (name: string, id: string | string[], options: types.ConnectionOptions = {}) {
+  async deleteJob<N extends types.JobNames<C>>(name: N, id: string | string[], options: types.ConnectionOptions = {}) {
     Attorney.assertQueueName(name)
     const db = this.assertDb(options)
     const ids = this.mapCompletionIdArg(id, 'deleteJob')
@@ -738,7 +742,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return this.mapCommandResponse(ids, result)
   }
 
-  async cancel (name: string, id: string | string[], options: types.ConnectionOptions = {}) {
+  async cancel<N extends types.JobNames<C>>(name: N, id: string | string[], options: types.ConnectionOptions = {}) {
     Attorney.assertQueueName(name)
     const db = this.assertDb(options)
     const ids = this.mapCompletionIdArg(id, 'cancel')
@@ -748,7 +752,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return this.mapCommandResponse(ids, result)
   }
 
-  async resume (name: string, id: string | string[], options: types.ConnectionOptions = {}) {
+  async resume<N extends types.JobNames<C>>(name: N, id: string | string[], options: types.ConnectionOptions = {}) {
     Attorney.assertQueueName(name)
     const db = this.assertDb(options)
     const ids = this.mapCompletionIdArg(id, 'resume')
@@ -758,7 +762,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return this.mapCommandResponse(ids, result)
   }
 
-  async restore (name: string, id: string | string[], options: types.ConnectionOptions = {}) {
+  async restore<N extends types.JobNames<C>>(name: N, id: string | string[], options: types.ConnectionOptions = {}) {
     Attorney.assertQueueName(name)
     const db = this.assertDb(options)
     const ids = this.mapCompletionIdArg(id, 'restore')
@@ -767,7 +771,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     await db.executeSql(sql, [name, ids])
   }
 
-  async retry (name: string, id: string | string[], options: types.ConnectionOptions = {}) {
+  async retry<N extends types.JobNames<C>>(name: N, id: string | string[], options: types.ConnectionOptions = {}) {
     Attorney.assertQueueName(name)
     const db = options.db || this.db
     const ids = this.mapCompletionIdArg(id, 'retry')
@@ -777,7 +781,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return this.mapCommandResponse(ids, result)
   }
 
-  async createQueue (name: string, options: Omit<types.Queue, 'name'> & { name?: string } = {}) {
+  async createQueue<N extends types.JobNames<C>>(name: N, options: Omit<types.Queue<N>, 'name'> & { name?: N } = {}) {
     name = name || options.name!
 
     Attorney.assertQueueName(name)
@@ -798,7 +802,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     await this.db.executeSql(sql)
   }
 
-  async getQueues (names?: string | string[]): Promise<types.QueueResult[]> {
+  async getQueues<N extends types.JobNames<C>>(names?: N | N[]): Promise<types.QueueResult<N>[]> {
     names = Array.isArray(names) ? names : typeof names === 'string' ? [names] : undefined
     if (names) {
       for (const name of names) {
@@ -811,7 +815,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return rows
   }
 
-  async updateQueue (name: string, options: types.UpdateQueueOptions = {}) {
+  async updateQueue<N extends types.JobNames<C>>(name: N, options: types.UpdateQueueOptions = {}) {
     Attorney.assertQueueName(name)
 
     assert(Object.keys(options).length > 0, 'no properties found to update')
@@ -837,7 +841,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     await this.db.executeSql(sql, [name, options])
   }
 
-  async getQueue (name: string) {
+  async getQueue<N extends types.JobNames<C>>(name: N) {
     Attorney.assertQueueName(name)
 
     const query = plans.getQueues(this.config.schema, [name])
@@ -846,7 +850,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return rows[0] || null
   }
 
-  async deleteQueue (name: string) {
+  async deleteQueue<N extends types.JobNames<C>>(name: N) {
     Attorney.assertQueueName(name)
 
     try {
@@ -856,21 +860,21 @@ class Manager extends EventEmitter implements types.EventsMixin {
     } catch { }
   }
 
-  async deleteQueuedJobs (name: string) {
+  async deleteQueuedJobs<N extends types.JobNames<C>>(name: N) {
     Attorney.assertQueueName(name)
     const { table } = await this.getQueueCache(name)
     const sql = plans.deleteQueuedJobs(this.config.schema, table)
     await this.db.executeSql(sql, [name])
   }
 
-  async deleteStoredJobs (name: string) {
+  async deleteStoredJobs<N extends types.JobNames<C>>(name: N) {
     Attorney.assertQueueName(name)
     const { table } = await this.getQueueCache(name)
     const sql = plans.deleteStoredJobs(this.config.schema, table)
     await this.db.executeSql(sql, [name])
   }
 
-  async deleteAllJobs (name?: string) {
+  async deleteAllJobs<N extends types.JobNames<C>>(name?: N) {
     if (!name) {
       const sql = plans.truncateTable(this.config.schema, 'job')
       await this.db.executeSql(sql)
@@ -889,7 +893,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  async getQueueStats (name: string) {
+  async getQueueStats<N extends types.JobNames<C>>(name: N) {
     Attorney.assertQueueName(name)
 
     const queue = await this.getQueueCache(name)
@@ -908,7 +912,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     )
   }
 
-  async getJobById<T>(name: string, id: string, options: types.ConnectionOptions = {}): Promise<types.JobWithMetadata<T> | null> {
+  async getJobById<N extends types.JobNames<C>, T>(name: N, id: string, options: types.ConnectionOptions = {}): Promise<types.JobWithMetadata<T> | null> {
     Attorney.assertQueueName(name)
 
     const db = this.assertDb(options)
@@ -926,7 +930,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  async findJobs<T>(name: string, options: types.FindJobsOptions = {}): Promise<types.JobWithMetadata<T>[]> {
+  async findJobs<N extends types.JobNames<C>, T>(name: N, options: types.FindJobsOptions = {}): Promise<types.JobWithMetadata<T>[]> {
     Attorney.assertQueueName(name)
 
     const db = this.assertDb(options)

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -602,7 +602,7 @@ class Manager<C extends types.JobsConfig & timekeeper.JobConfig, EC extends type
 
   async insert<N extends types.JobNames<C>>(
     name: N,
-    jobs: types.JobInsert[],
+    jobs: types.JobInsert<types.JobInput<C, N>>[],
     options: types.InsertOptions = {}
   ) {
     assert(Array.isArray(jobs), 'jobs argument should be an array')

--- a/src/timekeeper.ts
+++ b/src/timekeeper.ts
@@ -169,7 +169,7 @@ class Timekeeper<C extends types.JobsConfig & JobConfig> extends EventEmitter im
     await Promise.allSettled(jobs.map(({ data }) => this.manager.send(data)))
   }
 
-  async getSchedules (name?: string, key = '') : Promise<types.Schedule[]> {
+  async getSchedules<N extends types.JobNames<C>>(name?: N, key = '') : Promise<types.Schedule<N>[]> {
     let sql = plans.getSchedules(this.config.schema)
     let params: unknown[] = []
 
@@ -183,7 +183,7 @@ class Timekeeper<C extends types.JobsConfig & JobConfig> extends EventEmitter im
     return rows
   }
 
-  async schedule (name: string, cron: string, data?: unknown, options: types.ScheduleOptions = {}): Promise<void> {
+  async schedule<N extends types.JobNames<C>>(name: N, cron: string, data?: unknown, options: types.ScheduleOptions = {}): Promise<void> {
     const { tz = 'UTC', key = '', ...rest } = options
 
     CronExpressionParser.parse(cron, { tz, strict: false })
@@ -203,7 +203,7 @@ class Timekeeper<C extends types.JobsConfig & JobConfig> extends EventEmitter im
     }
   }
 
-  async unschedule (name: string, key = ''): Promise<void> {
+  async unschedule<N extends types.JobNames<C>>(name: N, key = ''): Promise<void> {
     const sql = plans.unschedule(this.config.schema)
     await this.db.executeSql(sql, [name, key])
   }

--- a/src/timekeeper.ts
+++ b/src/timekeeper.ts
@@ -25,6 +25,14 @@ const WARNINGS = {
 export type JobConfig = {
   [QUEUES.SEND_IT]: {
     input: types.Request<types.JobsConfig, string>
+    output: {
+      created: void;
+      retry: void;
+      active: void;
+      completed: void;
+      cancelled: void;
+      failed: void;
+    }
   }
 }
 

--- a/src/timekeeper.ts
+++ b/src/timekeeper.ts
@@ -155,7 +155,7 @@ class Timekeeper<C extends types.JobsConfig & JobConfig, EC extends types.EventC
 
     const scheduled = schedules
       .filter(i => this.shouldSendIt(i.cron, i.timezone))
-      .map(({ name, key, data, options }): types.JobInsert<NonNullable<types.JobInput<C, typeof QUEUES.SEND_IT>>> => ({ data: { name, data, options }, singletonKey: `${name}__${key}`, singletonSeconds: 60 }))
+      .map(({ name, key, data, options }): types.JobInsert<C, typeof QUEUES.SEND_IT> => ({ data: { name, data, options }, singletonKey: `${name}__${key}`, singletonSeconds: 60 }))
 
     if (scheduled.length > 0 && !this.stopped) {
       await this.manager.insert(QUEUES.SEND_IT, scheduled)

--- a/src/timekeeper.ts
+++ b/src/timekeeper.ts
@@ -174,8 +174,8 @@ class Timekeeper<C extends types.JobsConfig & JobConfig, EC extends types.EventC
     return prevDiff < 60
   }
 
-  private async onSendIt (jobs: types.Job<types.Request<types.JobsConfig, string>>[]): Promise<void> {
-    await Promise.allSettled(jobs.map(({ data }) => this.manager.send(data as types.Job<types.Request<types.JobsConfig, string>>))) // The type safety is partially ensured at the `schedule` function. The developer using this library will have to ensure that types are backwards compatible.
+  private async onSendIt (jobs: types.Job<C, string>[]): Promise<void> {
+    await Promise.allSettled(jobs.map(({ data }) => this.manager.send(data as types.Job<C, string>))) // The type safety is partially ensured at the `schedule` function. The developer using this library will have to ensure that types are backwards compatible.
   }
 
   async getSchedules<N extends types.JobNames<C>>(name?: N, key = '') : Promise<types.Schedule<C, N>[]> {

--- a/src/timekeeper.ts
+++ b/src/timekeeper.ts
@@ -27,10 +27,10 @@ export type JobConfig = {
   }
 }
 
-class Timekeeper<C extends types.JobsConfig & JobConfig> extends EventEmitter implements types.EventsMixin {
+class Timekeeper<C extends types.JobsConfig & JobConfig, EC extends types.EventConfig<C>> extends EventEmitter implements types.EventsMixin {
   db: types.IDatabase
   config: types.ResolvedConstructorOptions
-  manager: Manager<C>
+  manager: Manager<C, EC>
 
   private stopped = true
   private cronMonitorInterval: NodeJS.Timeout | null | undefined
@@ -40,7 +40,7 @@ class Timekeeper<C extends types.JobsConfig & JobConfig> extends EventEmitter im
   clockSkew = 0
   events = EVENTS
 
-  constructor (db: types.IDatabase, manager: Manager<C>, config: types.ResolvedConstructorOptions) {
+  constructor (db: types.IDatabase, manager: Manager<C, EC>, config: types.ResolvedConstructorOptions) {
     super()
 
     this.db = db

--- a/src/timekeeper.ts
+++ b/src/timekeeper.ts
@@ -155,7 +155,7 @@ class Timekeeper<C extends types.JobsConfig & JobConfig, EC extends types.EventC
 
     const scheduled = schedules
       .filter(i => this.shouldSendIt(i.cron, i.timezone))
-      .map(({ name, key, data, options }): types.JobInsert => ({ data: { name, data, options }, singletonKey: `${name}__${key}`, singletonSeconds: 60 }))
+      .map(({ name, key, data, options }): types.JobInsert<NonNullable<types.JobInput<C, typeof QUEUES.SEND_IT>>> => ({ data: { name, data, options }, singletonKey: `${name}__${key}`, singletonSeconds: 60 }))
 
     if (scheduled.length > 0 && !this.stopped) {
       await this.manager.insert(QUEUES.SEND_IT, scheduled)

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -40,7 +40,7 @@ function delay (ms: number, error?: string, abortController?: AbortController): 
   return promise
 }
 
-async function resolveWithinSeconds<T> (promise: Promise<T>, seconds: number, message?: string, abortController?: AbortController): Promise<T | void> {
+async function resolveWithinSeconds<T, M extends string | undefined> (promise: Promise<T> | T, seconds: number, message?: M, abortController?: AbortController): Promise<M extends string ? T : T | undefined> {
   const timeout = Math.max(1, seconds) * 1000
   const reject = delay(timeout, message, abortController)
 
@@ -52,7 +52,8 @@ async function resolveWithinSeconds<T> (promise: Promise<T>, seconds: number, me
     reject.abort()
   }
 
-  return result
+  // The type assertion is justified by the implementation above. If a message is given, the `reject` promise will throw and therefore never return.
+  return result as M extends string ? T : undefined | T
 }
 
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,14 @@ export interface Migration {
   uninstall?: string[]
 }
 
+export type JobsConfig = Record<string, {
+}>
+export type DefaultJobsConfig = Record<string, {
+}>
+
+// Helper types which should be used in the library.
+export type JobNames<C extends JobsConfig> = keyof C & string
+
 export interface ConstructorOptions extends DatabaseOptions, SchedulingOptions, MaintenanceOptions {
   /** @internal */
   __test__warn_slow_query?: boolean;
@@ -150,15 +158,15 @@ export type SendOptions = JobOptions & QueueOptions & ConnectionOptions
 
 export type QueuePolicy = 'standard' | 'short' | 'singleton' | 'stately' | 'exclusive' | (string & {})
 
-export interface Queue extends QueueOptions {
-  name: string;
+export interface Queue<N extends string> extends QueueOptions {
+  name: N;
   policy?: QueuePolicy;
   partition?: boolean;
   deadLetter?: string;
   warningQueueSize?: number;
 }
 
-export interface QueueResult extends Queue {
+export interface QueueResult<N extends string> extends Queue<N> {
   deferredCount: number;
   queuedCount: number;
   activeCount: number;
@@ -221,8 +229,8 @@ export interface WorkWithMetadataHandler<ReqData, ResData = any> {
   (job: JobWithMetadata<ReqData>[]): Promise<ResData>;
 }
 
-export interface Request {
-  name: string;
+export interface Request<N extends string> {
+  name: N;
   data?: object;
   options?: SendOptions;
 }
@@ -322,7 +330,7 @@ export interface FunctionsMixin {
   functions: Function[];
 }
 
-export type UpdateQueueOptions = Omit<Queue, 'name' | 'partition' | 'policy'>
+export type UpdateQueueOptions = Omit<Queue<string>, 'name' | 'partition' | 'policy'>
 
 export interface Warning { message: string, data: object }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,13 +254,12 @@ export interface ResolvedWorkOptions extends WorkOptions {
 }
 
 export interface WorkHandler<C extends JobsConfig, N extends JobNames<C>> {
-  (job: Job<JobInput<C, N>>[]): JobOutput<C, N, 'completed'> | Promise<JobOutput<C, N, 'completed'>>;
+  (job: Job<JobInput<C, N>>[]): Promise<JobOutput<C, N, 'completed'>>;
 }
 
 export interface WorkWithMetadataHandler<C extends JobsConfig, N extends JobNames<C>> {
-  (job: JobWithMetadata<C, N>[]): JobOutput<C, N, 'completed'> | Promise<JobOutput<C, N, 'completed'>>;
+  (job: JobWithMetadata<C, N>[]): Promise<JobOutput<C, N, 'completed'>>;
 }
-
 export interface Request<C extends JobsConfig, N extends JobNames<C>> {
   name: N;
   data?: JobInput<C, N>;
@@ -312,7 +311,7 @@ export interface JobWithMetadataAndState<C extends JobsConfig, N extends JobName
   output: JobOutput<C, N, S>;
 }
 
-export interface JobInsert<T = object> {
+export interface JobInsert<T> {
   id?: string;
   data?: T;
   priority?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -379,11 +379,13 @@ export interface CommandResponse {
   affected: number;
 }
 
+type BamStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
+
 export interface BamEntry {
   id: string
   name: string
   version: number
-  status: 'pending' | 'in_progress' | 'completed' | 'failed'
+  status: BamStatus
   queue?: string
   table: string
   command: string
@@ -394,7 +396,7 @@ export interface BamEntry {
 }
 
 export interface BamStatusSummary {
-  status: 'pending' | 'in_progress' | 'completed' | 'failed'
+  status: BamStatus
   count: number
   lastCreatedOn: Date
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,10 +177,10 @@ export interface CompleteOptions extends ConnectionOptions {
   includeQueued?: boolean;
 }
 
-export interface FindJobsOptions<T extends object> extends ConnectionOptions {
+export interface FindJobsOptions<C extends JobsConfig, N extends JobNames<C>> extends ConnectionOptions {
   id?: string;
   key?: string;
-  data?: Partial<T>;
+  data?: Partial<NonNullable<JobInput<C, N>>>;
   queued?: boolean;
 }
 
@@ -311,9 +311,9 @@ export interface JobWithMetadataAndState<C extends JobsConfig, N extends JobName
   output: JobOutput<C, N, S>;
 }
 
-export interface JobInsert<T> {
+export interface JobInsert<C extends JobsConfig, N extends JobNames<C>> {
   id?: string;
-  data?: T;
+  data?: JobInput<C, N>;
   priority?: number;
   retryLimit?: number;
   retryDelay?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,12 +66,15 @@ export interface Migration {
 }
 
 export type JobsConfig = Record<string, {
+  input: object | null;
 }>
 export type DefaultJobsConfig = Record<string, {
+  input: object | null,
 }>
 
 // Helper types which should be used in the library.
 export type JobNames<C extends JobsConfig> = keyof C & string
+export type JobInput<C extends JobsConfig, N extends JobNames<C>> = C[N]['input']
 export type EventConfig<C extends JobsConfig> = Record<string, JobNames<C>>
 export type EventNames<C extends JobsConfig, EC extends EventConfig<C>> = keyof EC & string
 
@@ -147,10 +150,10 @@ export interface CompleteOptions extends ConnectionOptions {
   includeQueued?: boolean;
 }
 
-export interface FindJobsOptions extends ConnectionOptions {
+export interface FindJobsOptions<T extends object> extends ConnectionOptions {
   id?: string;
   key?: string;
-  data?: object;
+  data?: Partial<T>;
   queued?: boolean;
 }
 
@@ -223,26 +226,26 @@ export interface ResolvedWorkOptions extends WorkOptions {
   pollingInterval: number;
 }
 
-export interface WorkHandler<ReqData, ResData = any> {
-  (job: Job<ReqData>[]): Promise<ResData>;
+export interface WorkHandler<C extends JobsConfig, N extends JobNames<C>, ResData = any> {
+  (job: Job<JobInput<C, N>>[]): Promise<ResData>;
 }
 
-export interface WorkWithMetadataHandler<ReqData, ResData = any> {
-  (job: JobWithMetadata<ReqData>[]): Promise<ResData>;
+export interface WorkWithMetadataHandler<C extends JobsConfig, N extends JobNames<C>, ResData = any> {
+  (job: JobWithMetadata<JobInput<C, N>>[]): Promise<ResData>;
 }
 
-export interface Request<N extends string> {
+export interface Request<C extends JobsConfig, N extends JobNames<C>> {
   name: N;
-  data?: object;
+  data?: JobInput<C, N>;
   options?: SendOptions;
 }
 
-export interface Schedule<N extends string> {
+export interface Schedule<C extends JobsConfig, N extends string> {
   name: N;
   key: string;
   cron: string;
   timezone: string;
-  data?: object;
+  data?: JobInput<C, N>;
   options?: SendOptions;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ type InternalJobOutput = {
 }
 export type JobsConfig = Record<string, {
   input: object | null | undefined;
-  output: {
+  output?: {
     [S in JobStates[keyof JobStates]]?: unknown;
   }
 }>
@@ -101,7 +101,7 @@ export type DefaultJobsConfig = Record<string, {
 // Helper types which should be used in the library.
 export type JobNames<C extends JobsConfig> = keyof C & string
 export type JobInput<C extends JobsConfig, N extends JobNames<C>> = C[N]['input']
-export type JobOutput<C extends JobsConfig, N extends JobNames<C>, S extends keyof JobStates> = InternalJobOutput[S] | (C[N]['output'][S] extends undefined ? void | undefined : C[N]['output'][S])
+export type JobOutput<C extends JobsConfig, N extends JobNames<C>, S extends keyof JobStates> = InternalJobOutput[S] | (C[N]['output'] extends undefined ? void | undefined : (NonNullable<C[N]['output']>[S] extends undefined ? void | undefined : NonNullable<C[N]['output']>[S]))
 export type EventConfig<C extends JobsConfig> = Record<string, JobNames<C>>
 export type EventNames<C extends JobsConfig, EC extends EventConfig<C>> = keyof EC & string
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,7 +254,7 @@ export interface ResolvedWorkOptions extends WorkOptions {
 }
 
 export interface WorkHandler<C extends JobsConfig, N extends JobNames<C>> {
-  (job: Job<JobInput<C, N>>[]): Promise<JobOutput<C, N, 'completed'>>;
+  (job: Job<C, N>[]): Promise<JobOutput<C, N, 'completed'>>;
 }
 
 export interface WorkWithMetadataHandler<C extends JobsConfig, N extends JobNames<C>> {
@@ -275,10 +275,10 @@ export interface Schedule<C extends JobsConfig, N extends string> {
   options?: SendOptions;
 }
 
-export interface Job<T = object> {
+export interface Job<C extends JobsConfig, N extends string> {
   id: string;
-  name: string;
-  data: T;
+  name: N;
+  data: JobInput<C, N>;
   expireInSeconds: number;
   signal: AbortSignal;
   groupId?: string | null;
@@ -289,7 +289,7 @@ export type JobWithMetadata<C extends JobsConfig, N extends JobNames<C>> = {
   [S in JobStates[keyof JobStates]]: JobWithMetadataAndState<C, N, S>;
 }[JobStates[keyof JobStates]]
 
-export interface JobWithMetadataAndState<C extends JobsConfig, N extends JobNames<C>, S extends JobStates[keyof JobStates]> extends Job<JobInput<C, N>> {
+export interface JobWithMetadataAndState<C extends JobsConfig, N extends JobNames<C>, S extends JobStates[keyof JobStates]> extends Job<C, N> {
   priority: number;
   state: S;
   retryLimit: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,8 @@ export type DefaultJobsConfig = Record<string, {
 
 // Helper types which should be used in the library.
 export type JobNames<C extends JobsConfig> = keyof C & string
+export type EventConfig<C extends JobsConfig> = Record<string, JobNames<C>>
+export type EventNames<C extends JobsConfig, EC extends EventConfig<C>> = keyof EC & string
 
 export interface ConstructorOptions extends DatabaseOptions, SchedulingOptions, MaintenanceOptions {
   /** @internal */

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,8 +235,8 @@ export interface Request<N extends string> {
   options?: SendOptions;
 }
 
-export interface Schedule {
-  name: string;
+export interface Schedule<N extends string> {
+  name: N;
   key: string;
   cron: string;
   timezone: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,13 +86,13 @@ type InternalJobOutput = {
   failed: ErrorObject | string;
 }
 export type JobsConfig = Record<string, {
-  input: object | null;
+  input: object | null | undefined;
   output: {
     [S in JobStates[keyof JobStates]]?: unknown;
   }
 }>
 export type DefaultJobsConfig = Record<string, {
-  input: object | null,
+  input: object | null | undefined,
   output: {
     [S in JobStates[keyof JobStates]]: Json | undefined | void;
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,26 +8,26 @@ const WORKER_STATES = {
   stopped: 'stopped'
 } as const
 
-interface WorkerOptions<T> {
+interface WorkerOptions<C extends types.JobsConfig, N extends types.JobNames<C>> {
   id: string
   name: string
   options: types.WorkOptions
   interval: number
-  fetch: () => Promise<types.Job<T>[]>
-  onFetch: (jobs: types.Job<T>[]) => Promise<void>
+  fetch: () => Promise<types.Job<C, N>[]>
+  onFetch: (jobs: types.Job<C, N>[]) => Promise<void>
   onError: (err: any) => void
 }
 
-class Worker<T = unknown> {
+class Worker<C extends types.JobsConfig, N extends types.JobNames<C>> {
   readonly id: string
   readonly name: string
   readonly options: types.WorkOptions
-  readonly fetch: () => Promise<types.Job<T>[]>
-  readonly onFetch: (jobs: types.Job<T>[]) => Promise<void>
+  readonly fetch: () => Promise<types.Job<C, N>[]>
+  readonly onFetch: (jobs: types.Job<C, N>[]) => Promise<void>
   readonly onError: (err: any) => void
   readonly interval: number
 
-  jobs: types.Job<T>[] = []
+  jobs: types.Job<C, N>[] = []
   createdOn = Date.now()
   state: types.WorkerState = WORKER_STATES.created
   lastFetchedOn: number | null = null
@@ -43,7 +43,7 @@ class Worker<T = unknown> {
   private beenNotified = false
   private runPromise: Promise<void> | null = null
 
-  constructor ({ id, name, options, interval, fetch, onFetch, onError }: WorkerOptions<T>) {
+  constructor ({ id, name, options, interval, fetch, onFetch, onError }: WorkerOptions<C, N>) {
     this.id = id
     this.name = name
     this.options = options

--- a/test/bamTest.ts
+++ b/test/bamTest.ts
@@ -96,8 +96,8 @@ describe('bam', function () {
       const failedEntry = bamStatus.find((e: any) => e.name === 'test_error_1')
 
       expect(failedEntry).toBeDefined()
-      expect(failedEntry.status).toBe('failed')
-      expect(failedEntry.error).toContain(errorMessage)
+      expect(failedEntry!.status).toBe('failed')
+      expect(failedEntry!.error).toContain(errorMessage)
     }, 10000)
 
     it('should emit error event when command fails', async function () {
@@ -178,10 +178,10 @@ describe('bam', function () {
       const successEntry = bamStatus.find((e: any) => e.name === 'test_success')
 
       expect(failedEntry).toBeDefined()
-      expect(failedEntry.status).toBe('failed')
+      expect(failedEntry!.status).toBe('failed')
 
       expect(successEntry).toBeDefined()
-      expect(successEntry.status).toBe('completed')
+      expect(successEntry!.status).toBe('completed')
     }, 15000)
 
     it('should capture error message for type cast errors', async function () {
@@ -198,9 +198,9 @@ describe('bam', function () {
       const entry = bamStatus.find((e: any) => e.name === 'test_cast_error')
 
       expect(entry).toBeDefined()
-      expect(entry.status).toBe('failed')
-      expect(entry.error).toBeDefined()
-      expect(entry.error.length).toBeGreaterThan(0)
+      expect(entry!.status).toBe('failed')
+      expect(entry!.error).toBeDefined()
+      expect(entry!.error!.length).toBeGreaterThan(0)
     }, 10000)
   })
 
@@ -219,8 +219,8 @@ describe('bam', function () {
       const entry = bamStatus.find((e: any) => e.name === 'test_success_1')
 
       expect(entry).toBeDefined()
-      expect(entry.status).toBe('completed')
-      expect(entry.completedOn).toBeDefined()
+      expect(entry!.status).toBe('completed')
+      expect(entry!.completedOn).toBeDefined()
     }, 10000)
 
     it('should emit bam events for in_progress and completed', async function () {

--- a/test/concurrencyGroupTest.ts
+++ b/test/concurrencyGroupTest.ts
@@ -258,7 +258,7 @@ describe('groupConcurrency', function () {
 
     // Invalid groupConcurrency object (missing default)
     await expect(async () => {
-      // @ts-ignore
+      // @ts-expect-error
       await ctx.boss!.work(ctx.schema, { groupConcurrency: { tiers: {} } }, async () => {})
     }).rejects.toThrow('groupConcurrency.default must be an integer >= 1')
 

--- a/test/failureTest.ts
+++ b/test/failureTest.ts
@@ -210,7 +210,7 @@ describe('failure', function () {
     assertTruthy(jobId)
     await ctx.boss.fail(ctx.schema, jobId)
 
-    const [job] = await ctx.boss.fetch<{ key: string }>(deadLetter)
+    const [job] = await ctx.boss.fetch<typeof ctx.schema, { key: string }>(deadLetter)
 
     expect(job.data.key).toBe(ctx.schema)
   })

--- a/test/failureTest.ts
+++ b/test/failureTest.ts
@@ -3,6 +3,8 @@ import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { assertTruthy } from './testHelper.ts'
 import { ctx } from './hooks.ts'
+import type { JobsConfig } from '../src/types.ts'
+import { PgBoss } from '../src/index.ts'
 
 describe('failure', function () {
   it('should reject missing id argument', async function () {
@@ -199,7 +201,7 @@ describe('failure', function () {
       name: { input: { key: string }, output: {} },
       name_dlq: { input: { key: string }, output: {} }
     }>({ ...ctx.bossConfig, noDefault: true })
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     const deadLetter = `${schema}_dlq` as const

--- a/test/failureTest.ts
+++ b/test/failureTest.ts
@@ -195,24 +195,29 @@ describe('failure', function () {
   })
 
   it('dead letter queues are working', async function () {
-    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+    const boss = await helper.start<{
+      name: { input: { key: string }, output: {} },
+      name_dlq: { input: { key: string }, output: {} }
+    }>({ ...ctx.bossConfig, noDefault: true })
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
-    const deadLetter = `${ctx.schema}_dlq`
+    const deadLetter = `${schema}_dlq` as const
 
-    await ctx.boss.createQueue(deadLetter)
-    await ctx.boss.createQueue(ctx.schema, { deadLetter })
+    await boss.createQueue(deadLetter)
+    await boss.createQueue(schema, { deadLetter })
 
-    const jobId = await ctx.boss.send(ctx.schema, { key: ctx.schema }, { retryLimit: 0 })
+    const jobId = await boss.send(schema, { key: schema }, { retryLimit: 0 })
 
     expect(jobId).toBeTruthy()
 
-    await ctx.boss.fetch(ctx.schema)
+    await boss.fetch(schema)
     assertTruthy(jobId)
-    await ctx.boss.fail(ctx.schema, jobId)
+    await boss.fail(schema, jobId)
 
-    const [job] = await ctx.boss.fetch<typeof ctx.schema, { key: string }>(deadLetter)
+    const [job] = await boss.fetch(deadLetter)
 
-    expect(job.data.key).toBe(ctx.schema)
+    expect(job.data.key).toBe(schema)
   })
 
   it('should fail active jobs in a worker during shutdown', async function () {

--- a/test/findJobsTest.ts
+++ b/test/findJobsTest.ts
@@ -41,13 +41,17 @@ describe('findJobs', function () {
   })
 
   it('should find jobs by data', async function () {
-    ctx.boss = await helper.start(ctx.bossConfig)
+    const boss = await helper.start<{
+      name: { input: { type: string, to: string }, output: {} },
+    }>(ctx.bossConfig)
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
-    await ctx.boss.send(ctx.schema, { type: 'email', to: 'user1@test.com' })
-    await ctx.boss.send(ctx.schema, { type: 'email', to: 'user2@test.com' })
-    await ctx.boss.send(ctx.schema, { type: 'sms', to: '555-1234' })
+    await boss.send(schema, { type: 'email', to: 'user1@test.com' })
+    await boss.send(schema, { type: 'email', to: 'user2@test.com' })
+    await boss.send(schema, { type: 'sms', to: '555-1234' })
 
-    const emailJobs = await ctx.boss.findJobs(ctx.schema, { data: { type: 'email' } })
+    const emailJobs = await boss.findJobs(schema, { data: { type: 'email' } })
 
     expect(emailJobs.length).toBe(2)
     expect(emailJobs.every(j => j.data?.type === 'email')).toBe(true)
@@ -122,13 +126,17 @@ describe('findJobs', function () {
   })
 
   it('should combine key and data filters', async function () {
-    ctx.boss = await helper.start(ctx.bossConfig)
+    const boss = await helper.start<{
+      name: { input: { category: string, value: number }, output: {} },
+    }>(ctx.bossConfig)
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
-    await ctx.boss.send(ctx.schema, { category: 'A', value: 1 }, { singletonKey: 'key-1' })
-    await ctx.boss.send(ctx.schema, { category: 'B', value: 2 }, { singletonKey: 'key-1' })
-    await ctx.boss.send(ctx.schema, { category: 'A', value: 3 }, { singletonKey: 'key-2' })
+    await boss.send(schema, { category: 'A', value: 1 }, { singletonKey: 'key-1' })
+    await boss.send(schema, { category: 'B', value: 2 }, { singletonKey: 'key-1' })
+    await boss.send(schema, { category: 'A', value: 3 }, { singletonKey: 'key-2' })
 
-    const jobs = await ctx.boss.findJobs(ctx.schema, {
+    const jobs = await boss.findJobs(schema, {
       key: 'key-1',
       data: { category: 'A' }
     })

--- a/test/findJobsTest.ts
+++ b/test/findJobsTest.ts
@@ -1,6 +1,8 @@
 import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { ctx } from './hooks.ts'
+import type { JobsConfig } from '../src/types.ts'
+import { PgBoss } from '../src/index.ts'
 
 describe('findJobs', function () {
   it('should reject missing queue argument', async function () {
@@ -44,7 +46,7 @@ describe('findJobs', function () {
     const boss = await helper.start<{
       name: { input: { type: string, to: string }, output: {} },
     }>(ctx.bossConfig)
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     await boss.send(schema, { type: 'email', to: 'user1@test.com' })
@@ -129,7 +131,7 @@ describe('findJobs', function () {
     const boss = await helper.start<{
       name: { input: { category: string, value: number }, output: {} },
     }>(ctx.bossConfig)
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     await boss.send(schema, { category: 'A', value: 1 }, { singletonKey: 'key-1' })

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -1,12 +1,12 @@
 import { beforeAll, beforeEach, afterEach, expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { assertTruthy } from './testHelper.ts'
-import type { ConstructorOptions } from '../src/types.ts'
+import type { ConstructorOptions, JobsConfig } from '../src/types.ts'
 import type { PgBoss } from '../src/index.ts'
 import crypto from 'node:crypto'
 
 export interface TestContext {
-  boss?: PgBoss
+  boss?: PgBoss<JobsConfig>
   bossConfig: ConstructorOptions & { schema: string }
   schema: string
 }

--- a/test/publishTest.ts
+++ b/test/publishTest.ts
@@ -37,7 +37,7 @@ describe('pubsub', function () {
     await ctx.boss.subscribe(event, ctx.schema)
     await ctx.boss.publish(event, { message })
 
-    const [job] = await ctx.boss.fetch<{ message: string }>(ctx.schema)
+    const [job] = await ctx.boss.fetch<typeof ctx.schema, { message: string }>(ctx.schema)
 
     expect(job.data.message).toBe(message)
   })
@@ -49,8 +49,8 @@ describe('pubsub', function () {
       message: string
     }
 
-    const queue1 = 'subqueue1'
-    const queue2 = 'subqueue2'
+    const queue1 = 'subqueue1' as const
+    const queue2 = 'subqueue2' as const
 
     await ctx.boss.createQueue(queue1)
     await ctx.boss.createQueue(queue2)
@@ -62,8 +62,8 @@ describe('pubsub', function () {
     await ctx.boss.subscribe(event, queue2)
     await ctx.boss.publish(event, { message })
 
-    const [job1] = await ctx.boss.fetch<Message>(queue1)
-    const [job2] = await ctx.boss.fetch<Message>(queue2)
+    const [job1] = await ctx.boss.fetch<typeof queue1, Message>(queue1)
+    const [job2] = await ctx.boss.fetch<typeof queue2, Message>(queue2)
 
     expect(job1.data.message).toBe(message)
     expect(job2.data.message).toBe(message)

--- a/test/publishTest.ts
+++ b/test/publishTest.ts
@@ -1,6 +1,8 @@
 import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { ctx } from './hooks.ts'
+import type { JobsConfig } from '../src/types.ts'
+import { PgBoss } from '../src/index.ts'
 
 describe('pubsub', function () {
   it('should fail with no arguments', async function () {
@@ -32,7 +34,7 @@ describe('pubsub', function () {
     const boss = await helper.start<{
       name: { input: { message: string }, output: {} },
     }>(ctx.bossConfig)
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     const event = 'event'
@@ -55,7 +57,7 @@ describe('pubsub', function () {
       subqueue1: { input: Message, output: {} },
       subqueue2: { input: Message, output: {} },
     }>({ ...ctx.bossConfig, noDefault: true })
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
 
     const queue1 = 'subqueue1' as const
     const queue2 = 'subqueue2' as const

--- a/test/queueStatsTest.ts
+++ b/test/queueStatsTest.ts
@@ -1,8 +1,9 @@
 import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { randomUUID } from 'node:crypto'
-import type { ConstructorOptions } from '../src/types.ts'
+import type { ConstructorOptions, JobsConfig } from '../src/types.ts'
 import { ctx } from './hooks.ts'
+import { PgBoss } from '../src/index.ts'
 
 describe('queueStats', function () {
   const queue1 = `q${randomUUID().replaceAll('-', '')}`
@@ -23,7 +24,7 @@ describe('queueStats', function () {
   }
 
   it('should get accurate stats', async function () {
-    ctx.boss = await init(ctx.bossConfig)
+    ctx.boss = await init(ctx.bossConfig) as unknown as PgBoss<JobsConfig>
     const queueData = await ctx.boss.getQueueStats(queue1)
     expect(queueData).not.toBe(undefined)
 
@@ -43,7 +44,7 @@ describe('queueStats', function () {
   })
 
   it('should get accurate stats on an empty queue', async function () {
-    ctx.boss = await init(ctx.bossConfig)
+    ctx.boss = await init(ctx.bossConfig) as unknown as PgBoss<JobsConfig>
     const queue3 = randomUUID()
     await ctx.boss.createQueue(queue3)
 

--- a/test/sendTest.ts
+++ b/test/sendTest.ts
@@ -2,6 +2,8 @@ import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { assertTruthy } from './testHelper.ts'
 import { ctx } from './hooks.ts'
+import type { JobsConfig } from '../src/types.ts'
+import { PgBoss } from '../src/index.ts'
 
 describe('send', function () {
   it('should fail with no arguments', async function () {
@@ -47,7 +49,7 @@ describe('send', function () {
     const boss = await helper.start<{
       name: { input: { message: string }, output: {} },
     }>(ctx.bossConfig)
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     const message = 'hi'

--- a/test/sendTest.ts
+++ b/test/sendTest.ts
@@ -44,13 +44,17 @@ describe('send', function () {
   })
 
   it('should accept job object with name and data only', async function () {
-    ctx.boss = await helper.start(ctx.bossConfig)
+    const boss = await helper.start<{
+      name: { input: { message: string }, output: {} },
+    }>(ctx.bossConfig)
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
     const message = 'hi'
 
-    await ctx.boss.send({ name: ctx.schema, data: { message } })
+    await boss.send({ name: schema, data: { message } })
 
-    const [job] = await ctx.boss.fetch<typeof ctx.schema, { message: string }>(ctx.schema)
+    const [job] = await boss.fetch(schema)
 
     expect(job.data.message).toBe(message)
   })

--- a/test/sendTest.ts
+++ b/test/sendTest.ts
@@ -50,7 +50,7 @@ describe('send', function () {
 
     await ctx.boss.send({ name: ctx.schema, data: { message } })
 
-    const [job] = await ctx.boss.fetch<{ message: string }>(ctx.schema)
+    const [job] = await ctx.boss.fetch<typeof ctx.schema, { message: string }>(ctx.schema)
 
     expect(job.data.message).toBe(message)
   })

--- a/test/spyTest.ts
+++ b/test/spyTest.ts
@@ -104,7 +104,7 @@ describe('spy', function () {
   it('should support waitForJob with data selector', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 
-    const spy = ctx.boss.getSpy<{ value: string }>(ctx.schema)
+    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
 
     await ctx.boss.send(ctx.schema, { value: 'first' })
     await ctx.boss.send(ctx.schema, { value: 'second' })
@@ -123,7 +123,7 @@ describe('spy', function () {
   it('should await job that completes after calling waitForJob', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 
-    const spy = ctx.boss.getSpy<{ value: string }>(ctx.schema)
+    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
 
     // Start waiting before job exists
     const waitPromise = spy.waitForJob(
@@ -190,7 +190,7 @@ describe('spy', function () {
   it('should work with insert (bulk send)', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 
-    const spy = ctx.boss.getSpy<{ value: string }>(ctx.schema)
+    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
 
     // Use explicit IDs for bulk insert
     const { randomUUID } = await import('node:crypto')
@@ -219,7 +219,7 @@ describe('spy', function () {
   it('should protect against data mutation', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 
-    const spy = ctx.boss.getSpy<{ value: string }>(ctx.schema)
+    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
 
     const jobId = await ctx.boss.send(ctx.schema, { value: 'original' })
 
@@ -284,7 +284,7 @@ describe('spy', function () {
   it('should handle race condition - await before job creation', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 
-    const spy = ctx.boss.getSpy<{ value: string }>(ctx.schema)
+    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
 
     // Start awaiting before job is even created
     const waitPromise = spy.waitForJob(

--- a/test/spyTest.ts
+++ b/test/spyTest.ts
@@ -196,9 +196,13 @@ describe('spy', function () {
   })
 
   it('should work with insert (bulk send)', async function () {
-    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const boss = await helper.start<{
+      name: { input: { value: string }, output: {} },
+    }>({ ...ctx.bossConfig, __test__enableSpies: true })
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
-    const spy = ctx.boss.getSpy(ctx.schema)
+    const spy = boss.getSpy(schema)
 
     // Use explicit IDs for bulk insert
     const { randomUUID } = await import('node:crypto')
@@ -206,7 +210,7 @@ describe('spy', function () {
     const id2 = randomUUID()
     const id3 = randomUUID()
 
-    await ctx.boss.insert(ctx.schema, [
+    await boss.insert(schema, [
       { id: id1, data: { value: 'bulk1' } },
       { id: id2, data: { value: 'bulk2' } },
       { id: id3, data: { value: 'bulk3' } }

--- a/test/spyTest.ts
+++ b/test/spyTest.ts
@@ -3,6 +3,8 @@ import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { assertTruthy } from './testHelper.ts'
 import { ctx } from './hooks.ts'
+import type { JobsConfig } from '../src/types.ts'
+import { PgBoss } from '../src/index.ts'
 
 describe('spy', function () {
   it('should track job creation', async function () {
@@ -105,7 +107,7 @@ describe('spy', function () {
     const boss = await helper.start<{
       name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     const spy = boss.getSpy(schema)
@@ -128,7 +130,7 @@ describe('spy', function () {
     const boss = await helper.start<{
       name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     const spy = boss.getSpy(schema)
@@ -199,7 +201,7 @@ describe('spy', function () {
     const boss = await helper.start<{
       name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     const spy = boss.getSpy(schema)
@@ -232,7 +234,7 @@ describe('spy', function () {
     const boss = await helper.start<{
       name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     const spy = boss.getSpy(schema)
@@ -301,7 +303,7 @@ describe('spy', function () {
     const boss = await helper.start<{
       name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
-    ctx.boss = boss
+    ctx.boss = boss as unknown as PgBoss<JobsConfig>
     const schema = ctx.schema as 'name'
 
     const spy = boss.getSpy(schema)

--- a/test/spyTest.ts
+++ b/test/spyTest.ts
@@ -103,7 +103,7 @@ describe('spy', function () {
 
   it('should support waitForJob with data selector', async function () {
     const boss = await helper.start<{
-      name: { input: { value: string } },
+      name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
     ctx.boss = boss
     const schema = ctx.schema as 'name'
@@ -126,7 +126,7 @@ describe('spy', function () {
 
   it('should await job that completes after calling waitForJob', async function () {
     const boss = await helper.start<{
-      name: { input: { value: string } },
+      name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
     ctx.boss = boss
     const schema = ctx.schema as 'name'
@@ -226,7 +226,7 @@ describe('spy', function () {
 
   it('should protect against data mutation', async function () {
     const boss = await helper.start<{
-      name: { input: { value: string } },
+      name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
     ctx.boss = boss
     const schema = ctx.schema as 'name'
@@ -295,7 +295,7 @@ describe('spy', function () {
 
   it('should handle race condition - await before job creation', async function () {
     const boss = await helper.start<{
-      name: { input: { value: string } },
+      name: { input: { value: string }, output: {} },
     }>({ ...ctx.bossConfig, __test__enableSpies: true })
     ctx.boss = boss
     const schema = ctx.schema as 'name'

--- a/test/spyTest.ts
+++ b/test/spyTest.ts
@@ -102,14 +102,18 @@ describe('spy', function () {
   })
 
   it('should support waitForJob with data selector', async function () {
-    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const boss = await helper.start<{
+      name: { input: { value: string } },
+    }>({ ...ctx.bossConfig, __test__enableSpies: true })
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
-    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
+    const spy = boss.getSpy(schema)
 
-    await ctx.boss.send(ctx.schema, { value: 'first' })
-    await ctx.boss.send(ctx.schema, { value: 'second' })
+    await boss.send(schema, { value: 'first' })
+    await boss.send(schema, { value: 'second' })
 
-    await ctx.boss.work(ctx.schema, async () => {})
+    await boss.work(schema, async () => {})
 
     const job = await spy.waitForJob(
       (data) => data.value === 'second',
@@ -121,9 +125,13 @@ describe('spy', function () {
   })
 
   it('should await job that completes after calling waitForJob', async function () {
-    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const boss = await helper.start<{
+      name: { input: { value: string } },
+    }>({ ...ctx.bossConfig, __test__enableSpies: true })
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
-    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
+    const spy = boss.getSpy(schema)
 
     // Start waiting before job exists
     const waitPromise = spy.waitForJob(
@@ -132,8 +140,8 @@ describe('spy', function () {
     )
 
     // Send and process job after
-    await ctx.boss.send(ctx.schema, { value: 'awaited' })
-    await ctx.boss.work(ctx.schema, async () => {})
+    await boss.send(schema, { value: 'awaited' })
+    await boss.work(schema, async () => {})
 
     const job = await waitPromise
 
@@ -190,7 +198,7 @@ describe('spy', function () {
   it('should work with insert (bulk send)', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 
-    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
+    const spy = ctx.boss.getSpy(ctx.schema)
 
     // Use explicit IDs for bulk insert
     const { randomUUID } = await import('node:crypto')
@@ -217,11 +225,15 @@ describe('spy', function () {
   })
 
   it('should protect against data mutation', async function () {
-    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const boss = await helper.start<{
+      name: { input: { value: string } },
+    }>({ ...ctx.bossConfig, __test__enableSpies: true })
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
-    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
+    const spy = boss.getSpy(schema)
 
-    const jobId = await ctx.boss.send(ctx.schema, { value: 'original' })
+    const jobId = await boss.send(schema, { value: 'original' })
 
     assertTruthy(jobId)
     const job1 = await spy.waitForJobWithId(jobId, 'created')
@@ -282,9 +294,13 @@ describe('spy', function () {
   })
 
   it('should handle race condition - await before job creation', async function () {
-    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const boss = await helper.start<{
+      name: { input: { value: string } },
+    }>({ ...ctx.bossConfig, __test__enableSpies: true })
+    ctx.boss = boss
+    const schema = ctx.schema as 'name'
 
-    const spy = ctx.boss.getSpy<typeof ctx.schema, { value: string }>(ctx.schema)
+    const spy = boss.getSpy(schema)
 
     // Start awaiting before job is even created
     const waitPromise = spy.waitForJob(
@@ -292,7 +308,7 @@ describe('spy', function () {
       'created'
     )
 
-    await ctx.boss.send(ctx.schema, { value: 'race-test' })
+    await boss.send(schema, { value: 'race-test' })
 
     const job = await waitPromise
 

--- a/test/testHelper.ts
+++ b/test/testHelper.ts
@@ -2,7 +2,7 @@ import Db from '../src/db.ts'
 import { PgBoss } from '../src/index.ts'
 import crypto from 'node:crypto'
 import configJson from './config.json' with { type: 'json' }
-import type { ConstructorOptions } from '../src/types.ts'
+import type { ConstructorOptions, JobsConfig, DefaultJobsConfig } from '../src/types.ts'
 
 const sha1 = (value: string): string => crypto.createHash('sha1').update(value).digest('hex')
 
@@ -87,11 +87,13 @@ async function tryCreateDb (database: string): Promise<void> {
   }
 }
 
-async function start (options?: Partial<ConstructorOptions> & { testKey?: string; noDefault?: boolean }): Promise<PgBoss> {
+async function start<
+  C extends JobsConfig = DefaultJobsConfig
+> (options?: Partial<ConstructorOptions> & { testKey?: string; noDefault?: boolean }): Promise<PgBoss<C>> {
   try {
     const config = getConfig(options)
 
-    const boss = new PgBoss(config)
+    const boss = new PgBoss<C>(config)
     // boss.on('error', err => console.log({ schema: config.schema, message: err.message }))
 
     await boss.start()

--- a/test/workTest.ts
+++ b/test/workTest.ts
@@ -435,7 +435,7 @@ describe('work', function () {
     await ctx.boss.start()
 
     assertTruthy(jobId)
-    const job = await ctx.boss.getJobById<{}>(ctx.schema, jobId)
+    const job = await ctx.boss.getJobById<typeof ctx.schema, {}>(ctx.schema, jobId)
 
     assertTruthy(job)
     expect(job.state).toBe('failed')

--- a/test/workTest.ts
+++ b/test/workTest.ts
@@ -435,7 +435,7 @@ describe('work', function () {
     await ctx.boss.start()
 
     assertTruthy(jobId)
-    const job = await ctx.boss.getJobById<typeof ctx.schema, {}>(ctx.schema, jobId)
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
 
     assertTruthy(job)
     expect(job.state).toBe('failed')


### PR DESCRIPTION
Fixes #692.

I've set quite some types and think this is as complete as I can get it. I also tried to split up the work into meaningful commits, so going through them one-by-one should give the reviewer a good understanding of the individual type-refactorings I did.

I haven't yet put down the work for showing how the types work, other than the example. I can create some documentation around this but first want to know whether this goes into the right direction.

I found the function `getQueues()` not to pass on the `name` property. Maybe this is something that should be fixed.