### PR TITLE
Add missing docs to main dashboard documentation

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -46,6 +46,21 @@ The dashboard is configured via environment variables:
 | `DATABASE_URL` | PostgreSQL connection string(s) | `postgres://localhost/pgboss` |
 | `PGBOSS_SCHEMA` | pg-boss schema name(s) | `pgboss` |
 | `PORT` | Server port | `3000` |
+| `PGBOSS_DASHBOARD_AUTH_USERNAME` | Basic auth username (optional) | - |
+| `PGBOSS_DASHBOARD_AUTH_PASSWORD` | Basic auth password (optional) | - |
+
+### Basic Authentication
+
+To protect the dashboard with basic authentication, set `PGBOSS_DASHBOARD_AUTH_USERNAME` and `PGBOSS_DASHBOARD_AUTH_PASSWORD`:
+
+```bash
+PGBOSS_DASHBOARD_AUTH_USERNAME=admin \
+PGBOSS_DASHBOARD_AUTH_PASSWORD=secret \
+DATABASE_URL="postgres://localhost/mydb" \
+npx pg-boss-dashboard
+```
+
+Both variables must be provided together. If only one is set, the dashboard will throw an error on startup.
 
 ### Multi-Database Configuration
 


### PR DESCRIPTION
Sorry, missed this one - detailed dashboard documentation does not have the new env variables