### PR TITLE
Add JSDoc comments for queue-related types, `JobPollingOptions` and `JobFetchOptions`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -263,14 +263,40 @@ export interface QueueResult extends Queue {
 export type ScheduleOptions = SendOptions & { tz?: string, key?: string }
 
 export interface JobPollingOptions {
+  /**
+   * Interval to check for new jobs, in seconds. Must be >= `0.5` (500 ms).
+   * @default 2
+   */
   pollingIntervalSeconds?: number;
 }
 
 export interface JobFetchOptions {
+  /**
+   * If `true`, all job metadata will be included in the returned job object.
+   * @default false
+   */
   includeMetadata?: boolean;
+  /**
+   * Allow jobs with a higher priority to be fetched before jobs with lower or
+   * no priority.
+   * @default true
+   */
   priority?: boolean;
+  /**
+   * Fetch jobs in the order they were created. Set to `false` to disable this
+   * sorting and improve performance when the order of jobs does not matter.
+   * @default true
+   */
   orderByCreatedOn?: boolean;
+  /**
+   * The number of jobs to fetch.
+   * @default 1
+   */
   batchSize?: number;
+  /**
+   * Fetch jobs even if they have a `startAfter` timestamp in the future.
+   * @default false
+   */
   ignoreStartAfter?: boolean;
 }
 


### PR DESCRIPTION
Provided one uses an editor which supports displaying these comments (e.g. VS Code), this makes it much easier to understand what the options mean without having to consult the documentation.

As an example, if you pass `{ retryBackoff: true }` to `createQueue()` and hover over the the `retryBackoff` key, this PR makes VS Code show this:

<img width="810" height="239" alt="image" src="https://github.com/user-attachments/assets/e8c7aad0-8c1b-4a30-8a44-fa898c001a00" />

All the comments have been lifted from the relevant files in `docs/`, with some light rewording and reformatting where necessary. (For instance, the queue policy table doesn't work well as JSDoc, so I turned it into a list instead.)

Would be happy to do this for more types if you agree that this is valuable. (The recently added `WorkConcurrencyOptions` has these type of comments already, FWIW.) One problem is that there is now two sources of truth: the comments and the docs. It would perhaps be good if the docs were generated from the comments instead, but I haven't looked into what tooling is out there for that kind of stuff.