### PR TITLE
fix: address head-of-line blocking bug in groupConcurrency

### DIFF
--- a/src/plans.ts
+++ b/src/plans.ts
@@ -902,7 +902,7 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
   ].filter(Boolean).join(', ')
 
   const activeGroupCountsCte = hasGroupConcurrency
-    ? `active_group_counts AS (
+    ? `active_group_counts AS MATERIALIZED (
         SELECT group_id, COUNT(*)::int as active_cnt
         FROM ${schema}.${table}
         WHERE name = '${name}' AND state = '${JOB_STATES.active}' AND group_id IS NOT NULL
@@ -910,7 +910,37 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
       ), `
     : ''
 
-  const nextCte = `
+  // When groupConcurrency is active, active_group_counts is joined directly into
+  // the next CTE so that fully-saturated groups are excluded BEFORE LIMIT is
+  // applied. Without this, LIMIT 1 (the default batchSize) would always pick the
+  // oldest queued job — which may belong to a saturated group — leaving every
+  // other group permanently unreachable (head-of-line blocking).
+  // Column references are qualified with j. to avoid ambiguity with the join.
+  const nextCte = hasGroupConcurrency
+    ? `
+      next AS (
+        SELECT j.id${singletonFetch ? ', j.singleton_key' : ''}, j.group_id, j.group_tier
+        FROM ${schema}.${table} j
+        LEFT JOIN active_group_counts agc ON j.group_id = agc.group_id
+        WHERE j.name = '${name}'
+          AND j.state < '${JOB_STATES.active}'
+          ${!ignoreStartAfter ? 'AND j.start_after < now()' : ''}
+          ${hasIgnoreSingletons ? `AND j.singleton_key <> ALL(${params.ignoreSingletonsParam})` : ''}
+          ${hasIgnoreGroups ? `AND (j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : ''}
+          ${hasMinPriority ? `AND j.priority >= ${params.minPriorityParam}` : ''}
+          ${hasMaxPriority ? `AND j.priority <= ${params.maxPriorityParam}` : ''}
+          AND (
+            j.group_id IS NULL
+            OR agc.active_cnt IS NULL
+            OR agc.active_cnt < ${hasTiers
+              ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
+              : params.defaultGroupLimitParam}
+          )
+        ORDER BY ${priority ? 'j.priority desc, ' : ''}${orderByCreatedOn ? 'j.created_on, ' : ''}j.id
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
+      )`
+    : `
       next AS (
         SELECT ${selectCols}
         FROM ${schema}.${table}

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -643,7 +643,7 @@ function deleteJobsById (schema: string, table: string) {
     WITH results as (
       DELETE FROM ${schema}.${table}
       WHERE name = $1
-        AND id IN (SELECT UNNEST($2::uuid[]))        
+        AND id IN (SELECT UNNEST($2::uuid[]))
       RETURNING 1
     )
     SELECT COUNT(*) from results
@@ -885,21 +885,6 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
 
   const params = buildFetchParams(options)
 
-  // Build the base WHERE conditions shared by both nextCte branches. The alias
-  // parameter (e.g. 'j.') qualifies column references for the groupConcurrency
-  // branch which introduces a LEFT JOIN that would otherwise make group_id ambiguous.
-  const buildBaseConditions = (alias = '') => [
-    `${alias}name = '${name}'`,
-    `${alias}state < '${JOB_STATES.active}'`,
-    !ignoreStartAfter ? `${alias}start_after < now()` : '',
-    hasIgnoreSingletons ? `${alias}singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
-    hasIgnoreGroups ? `(${alias}group_id IS NULL OR ${alias}group_id <> ALL(${params.ignoreGroupsParam}))` : '',
-    hasMinPriority ? `${alias}priority >= ${params.minPriorityParam}` : '',
-    hasMaxPriority ? `${alias}priority <= ${params.maxPriorityParam}` : ''
-  ].filter(Boolean)
-
-  const whereConditions = buildBaseConditions().join(' AND ')
-
   const selectCols = [
     'id',
     singletonFetch ? 'singleton_key' : '',
@@ -921,20 +906,38 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
   // oldest queued job — which may belong to a saturated group — leaving every
   // other group permanently unreachable (head-of-line blocking).
   // Column references are qualified with j. to avoid ambiguity with the join.
+  const whereConditions = hasGroupConcurrency
+    ? [
+        `j.name = '${name}'`,
+        `j.state < '${JOB_STATES.active}'`,
+        !ignoreStartAfter ? 'j.start_after < now()' : '',
+        hasIgnoreSingletons ? `j.singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
+        hasIgnoreGroups ? `(j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : '',
+        hasMinPriority ? `j.priority >= ${params.minPriorityParam}` : '',
+        hasMaxPriority ? `j.priority <= ${params.maxPriorityParam}` : '',
+        `(j.group_id IS NULL
+            OR agc.active_cnt IS NULL
+            OR agc.active_cnt < ${hasTiers
+              ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
+              : params.defaultGroupLimitParam})`
+      ].filter(Boolean).join('\n          AND ')
+    : [
+        `name = '${name}'`,
+        `state < '${JOB_STATES.active}'`,
+        !ignoreStartAfter ? 'start_after < now()' : '',
+        hasIgnoreSingletons ? `singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
+        hasIgnoreGroups ? `(group_id IS NULL OR group_id <> ALL(${params.ignoreGroupsParam}))` : '',
+        hasMinPriority ? `priority >= ${params.minPriorityParam}` : '',
+        hasMaxPriority ? `priority <= ${params.maxPriorityParam}` : ''
+      ].filter(Boolean).join(' AND ')
+
   const nextCte = hasGroupConcurrency
     ? `
       next AS (
         SELECT j.id${singletonFetch ? ', j.singleton_key' : ''}, j.group_id, j.group_tier
         FROM ${schema}.${table} j
         LEFT JOIN active_group_counts agc ON j.group_id = agc.group_id
-        WHERE ${[
-          ...buildBaseConditions('j.'),
-          `(j.group_id IS NULL
-            OR agc.active_cnt IS NULL
-            OR agc.active_cnt < ${hasTiers
-              ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
-              : params.defaultGroupLimitParam})`
-        ].join('\n          AND ')}
+        WHERE ${whereConditions}
         ORDER BY ${priority ? 'j.priority desc, ' : ''}${orderByCreatedOn ? 'j.created_on, ' : ''}j.id
         LIMIT ${limit}
         FOR UPDATE OF j SKIP LOCKED

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -891,6 +891,11 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
     hasGroupConcurrency ? 'j.group_id, j.group_tier' : ''
   ].filter(Boolean).join(', ')
 
+  // MATERIALIZED forces Postgres to compute this aggregation once and cache the
+  // result. Without it, Postgres 12+ may inline the CTE and re-evaluate the
+  // COUNT query at each reference site. active_group_counts is referenced twice:
+  // once in the next CTE join (to pre-filter saturated groups before LIMIT) and
+  // once in group_ranking (to enforce the per-batch concurrency limit).
   const activeGroupCountsCte = hasGroupConcurrency
     ? `active_group_counts AS MATERIALIZED (
         SELECT group_id, COUNT(*)::int as active_cnt

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -886,9 +886,9 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
   const params = buildFetchParams(options)
 
   const selectCols = [
-    'id',
-    singletonFetch ? 'singleton_key' : '',
-    hasGroupConcurrency ? 'group_id, group_tier' : ''
+    'j.id',
+    singletonFetch ? 'j.singleton_key' : '',
+    hasGroupConcurrency ? 'j.group_id, j.group_tier' : ''
   ].filter(Boolean).join(', ')
 
   const activeGroupCountsCte = hasGroupConcurrency
@@ -900,56 +900,35 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
       ), `
     : ''
 
-  // When groupConcurrency is active, active_group_counts is joined directly into
-  // the next CTE so that fully-saturated groups are excluded BEFORE LIMIT is
-  // applied. Without this, LIMIT 1 (the default batchSize) would always pick the
-  // oldest queued job — which may belong to a saturated group — leaving every
-  // other group permanently unreachable (head-of-line blocking).
-  // Column references are qualified with j. to avoid ambiguity with the join.
-  const whereConditions = hasGroupConcurrency
-    ? [
-        `j.name = '${name}'`,
-        `j.state < '${JOB_STATES.active}'`,
-        !ignoreStartAfter ? 'j.start_after < now()' : '',
-        hasIgnoreSingletons ? `j.singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
-        hasIgnoreGroups ? `(j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : '',
-        hasMinPriority ? `j.priority >= ${params.minPriorityParam}` : '',
-        hasMaxPriority ? `j.priority <= ${params.maxPriorityParam}` : '',
-        `(j.group_id IS NULL
+  // Column references are qualified with j. throughout so both the base case and
+  // the groupConcurrency branch (which joins active_group_counts) share one set of
+  // expressions. The join introduces agc.group_id which would otherwise be ambiguous.
+  const whereConditions = [
+    `j.name = '${name}'`,
+    `j.state < '${JOB_STATES.active}'`,
+    !ignoreStartAfter ? 'j.start_after < now()' : '',
+    hasIgnoreSingletons ? `j.singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
+    hasIgnoreGroups ? `(j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : '',
+    hasMinPriority ? `j.priority >= ${params.minPriorityParam}` : '',
+    hasMaxPriority ? `j.priority <= ${params.maxPriorityParam}` : '',
+    hasGroupConcurrency
+      ? `(j.group_id IS NULL
             OR agc.active_cnt IS NULL
             OR agc.active_cnt < ${hasTiers
               ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
               : params.defaultGroupLimitParam})`
-      ].filter(Boolean).join('\n          AND ')
-    : [
-        `name = '${name}'`,
-        `state < '${JOB_STATES.active}'`,
-        !ignoreStartAfter ? 'start_after < now()' : '',
-        hasIgnoreSingletons ? `singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
-        hasIgnoreGroups ? `(group_id IS NULL OR group_id <> ALL(${params.ignoreGroupsParam}))` : '',
-        hasMinPriority ? `priority >= ${params.minPriorityParam}` : '',
-        hasMaxPriority ? `priority <= ${params.maxPriorityParam}` : ''
-      ].filter(Boolean).join(' AND ')
+      : ''
+  ].filter(Boolean).join('\n          AND ')
 
-  const nextCte = hasGroupConcurrency
-    ? `
+  const nextCte = `
       next AS (
-        SELECT j.id${singletonFetch ? ', j.singleton_key' : ''}, j.group_id, j.group_tier
+        SELECT ${selectCols}
         FROM ${schema}.${table} j
-        LEFT JOIN active_group_counts agc ON j.group_id = agc.group_id
+        ${hasGroupConcurrency ? 'LEFT JOIN active_group_counts agc ON j.group_id = agc.group_id' : ''}
         WHERE ${whereConditions}
         ORDER BY ${priority ? 'j.priority desc, ' : ''}${orderByCreatedOn ? 'j.created_on, ' : ''}j.id
         LIMIT ${limit}
         FOR UPDATE OF j SKIP LOCKED
-      )`
-    : `
-      next AS (
-        SELECT ${selectCols}
-        FROM ${schema}.${table}
-        WHERE ${whereConditions}
-        ORDER BY ${priority ? 'priority desc, ' : ''}${orderByCreatedOn ? 'created_on, ' : ''}id
-        LIMIT ${limit}
-        FOR UPDATE SKIP LOCKED
       )`
 
   const singletonCte = singletonFetch

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -938,7 +938,7 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
           )
         ORDER BY ${priority ? 'j.priority desc, ' : ''}${orderByCreatedOn ? 'j.created_on, ' : ''}j.id
         LIMIT ${limit}
-        FOR UPDATE SKIP LOCKED
+        FOR UPDATE OF j SKIP LOCKED
       )`
     : `
       next AS (

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -885,15 +885,20 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
 
   const params = buildFetchParams(options)
 
-  const whereConditions = [
-    `name = '${name}'`,
-    `state < '${JOB_STATES.active}'`,
-    !ignoreStartAfter ? 'start_after < now()' : '',
-    hasIgnoreSingletons ? `singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
-    hasIgnoreGroups ? `(group_id IS NULL OR group_id <> ALL(${params.ignoreGroupsParam}))` : '',
-    hasMinPriority ? `priority >= ${params.minPriorityParam}` : '',
-    hasMaxPriority ? `priority <= ${params.maxPriorityParam}` : ''
-  ].filter(Boolean).join(' AND ')
+  // Build the base WHERE conditions shared by both nextCte branches. The alias
+  // parameter (e.g. 'j.') qualifies column references for the groupConcurrency
+  // branch which introduces a LEFT JOIN that would otherwise make group_id ambiguous.
+  const buildBaseConditions = (alias = '') => [
+    `${alias}name = '${name}'`,
+    `${alias}state < '${JOB_STATES.active}'`,
+    !ignoreStartAfter ? `${alias}start_after < now()` : '',
+    hasIgnoreSingletons ? `${alias}singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
+    hasIgnoreGroups ? `(${alias}group_id IS NULL OR ${alias}group_id <> ALL(${params.ignoreGroupsParam}))` : '',
+    hasMinPriority ? `${alias}priority >= ${params.minPriorityParam}` : '',
+    hasMaxPriority ? `${alias}priority <= ${params.maxPriorityParam}` : ''
+  ].filter(Boolean)
+
+  const whereConditions = buildBaseConditions().join(' AND ')
 
   const selectCols = [
     'id',
@@ -922,20 +927,14 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
         SELECT j.id${singletonFetch ? ', j.singleton_key' : ''}, j.group_id, j.group_tier
         FROM ${schema}.${table} j
         LEFT JOIN active_group_counts agc ON j.group_id = agc.group_id
-        WHERE j.name = '${name}'
-          AND j.state < '${JOB_STATES.active}'
-          ${!ignoreStartAfter ? 'AND j.start_after < now()' : ''}
-          ${hasIgnoreSingletons ? `AND j.singleton_key <> ALL(${params.ignoreSingletonsParam})` : ''}
-          ${hasIgnoreGroups ? `AND (j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : ''}
-          ${hasMinPriority ? `AND j.priority >= ${params.minPriorityParam}` : ''}
-          ${hasMaxPriority ? `AND j.priority <= ${params.maxPriorityParam}` : ''}
-          AND (
-            j.group_id IS NULL
+        WHERE ${[
+          ...buildBaseConditions('j.'),
+          `(j.group_id IS NULL
             OR agc.active_cnt IS NULL
             OR agc.active_cnt < ${hasTiers
               ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
-              : params.defaultGroupLimitParam}
-          )
+              : params.defaultGroupLimitParam})`
+        ].join('\n          AND ')}
         ORDER BY ${priority ? 'j.priority desc, ' : ''}${orderByCreatedOn ? 'j.created_on, ' : ''}j.id
         LIMIT ${limit}
         FOR UPDATE OF j SKIP LOCKED

--- a/test/concurrencyGroupTest.ts
+++ b/test/concurrencyGroupTest.ts
@@ -266,15 +266,17 @@ describe('groupConcurrency', function () {
     // test, keeping group A permanently saturated (active_cnt = 1 = groupConcurrency).
 
     // Step 2: Flood the front of the queue with group A jobs.
-    // Sent AFTER the active job, so they occupy positions 1–5 in
-    // ORDER BY created_on, id — ahead of group B in queue order.
+    // All jobs in this test use the same default priority, so after the
+    // priority desc sort key, created_on and id determine queue position.
+    // Sent after the active job, these group A jobs occupy positions 1-5
+    // ahead of group B.
     for (let i = 0; i < 5; i++) {
       await ctx.boss.send(ctx.schema, { index: i }, { group: { id: groupA } })
     }
 
     // Step 3: Enqueue one group B job. It is fully eligible (0 active, under its
-    // concurrency limit), but created last so it sits at position 6 in queue order,
-    // behind all of the group A queued jobs.
+    // concurrency limit), but with the same default priority and a later
+    // created_on/id it sits at position 6 behind all of the group A queued jobs.
     const groupBJobId = await ctx.boss.send(ctx.schema, {}, { group: { id: groupB } })
     assertTruthy(groupBJobId)
 

--- a/test/concurrencyGroupTest.ts
+++ b/test/concurrencyGroupTest.ts
@@ -248,6 +248,64 @@ describe('groupConcurrency', function () {
     }).rejects.toThrow('group.tier must be a non-empty string if provided')
   })
 
+  it('should process available group jobs when saturated group dominates the front of the queue', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const groupA = 'group-saturated'
+    const groupB = 'group-available'
+    const groupConcurrency = 1
+
+    // Step 1: Send one group A job and fetch it directly to make it "active",
+    // holding group A at its concurrency limit for the entire duration of the test.
+    // This simulates a long-running job consuming the one allowed slot.
+    await ctx.boss.send(ctx.schema, {}, { group: { id: groupA } })
+    const [activeJob] = await ctx.boss.fetch(ctx.schema)
+    assertTruthy(activeJob)
+    // activeJob is now in "active" state and will never be completed during this
+    // test, keeping group A permanently saturated (active_cnt = 1 = groupConcurrency).
+
+    // Step 2: Flood the front of the queue with group A jobs.
+    // Sent AFTER the active job, so they occupy positions 1–5 in
+    // ORDER BY created_on, id — ahead of group B in queue order.
+    for (let i = 0; i < 5; i++) {
+      await ctx.boss.send(ctx.schema, { index: i }, { group: { id: groupA } })
+    }
+
+    // Step 3: Enqueue one group B job. It is fully eligible (0 active, under its
+    // concurrency limit), but created last so it sits at position 6 in queue order,
+    // behind all of the group A queued jobs.
+    await ctx.boss.send(ctx.schema, {}, { group: { id: groupB } })
+
+    // Step 4: Start a single worker with groupConcurrency: 1.
+    // With the bug, every poll executes:
+    //   next CTE  →  LIMIT 1  →  picks the oldest queued job (a group A job)
+    //   group_filtered  →  active_cnt(1) + group_rn(1) = 2 > 1  →  discarded
+    //   UPDATE affects 0 rows  →  worker sleeps 500 ms  →  repeat forever.
+    // The group B job is never reached because it sits behind the group A pile.
+    let groupBProcessed = false
+
+    await ctx.boss.work(ctx.schema, {
+      groupConcurrency,
+      localConcurrency: 1,
+      pollingIntervalSeconds: 0.5
+    }, async ([job]) => {
+      if (job.groupId === groupB) {
+        groupBProcessed = true
+      }
+    })
+
+    // 10 polling cycles at 500 ms — more than enough for a correct implementation
+    // to find the group B job on its very first fetch (group A is pre-filtered out).
+    // With the bug, the worker starves indefinitely on group A jobs.
+    await delay(5000)
+
+    // BUG: this assertion fails. groupBProcessed is false because the group B job
+    // is starved behind the group A queued jobs. The `next` CTE applies LIMIT 1
+    // before the group concurrency check in `group_filtered`, so a saturated group
+    // dominating the front of the queue blocks every other group from being reached.
+    expect(groupBProcessed).toBe(true)
+  })
+
   it('should validate groupConcurrency option in work', async function () {
     ctx.boss = await helper.start(ctx.bossConfig)
 

--- a/test/concurrencyGroupTest.ts
+++ b/test/concurrencyGroupTest.ts
@@ -249,7 +249,8 @@ describe('groupConcurrency', function () {
   })
 
   it('should process available group jobs when saturated group dominates the front of the queue', async function () {
-    ctx.boss = await helper.start(ctx.bossConfig)
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
 
     const groupA = 'group-saturated'
     const groupB = 'group-available'
@@ -274,36 +275,22 @@ describe('groupConcurrency', function () {
     // Step 3: Enqueue one group B job. It is fully eligible (0 active, under its
     // concurrency limit), but created last so it sits at position 6 in queue order,
     // behind all of the group A queued jobs.
-    await ctx.boss.send(ctx.schema, {}, { group: { id: groupB } })
+    const groupBJobId = await ctx.boss.send(ctx.schema, {}, { group: { id: groupB } })
+    assertTruthy(groupBJobId)
 
     // Step 4: Start a single worker with groupConcurrency: 1.
-    // With the bug, every poll executes:
-    //   next CTE  →  LIMIT 1  →  picks the oldest queued job (a group A job)
-    //   group_filtered  →  active_cnt(1) + group_rn(1) = 2 > 1  →  discarded
-    //   UPDATE affects 0 rows  →  worker sleeps 500 ms  →  repeat forever.
-    // The group B job is never reached because it sits behind the group A pile.
-    let groupBProcessed = false
-
+    // Regression: previously the next CTE applied LIMIT 1 before the group
+    // concurrency check, so a saturated group at the front of the queue would
+    // starve all other groups. The group B job should be reached on the first
+    // poll now that saturated groups are pre-filtered in the WHERE clause.
     await ctx.boss.work(ctx.schema, {
       groupConcurrency,
       localConcurrency: 1,
       pollingIntervalSeconds: 0.5
-    }, async ([job]) => {
-      if (job.groupId === groupB) {
-        groupBProcessed = true
-      }
-    })
+    }, async () => {})
 
-    // 10 polling cycles at 500 ms — more than enough for a correct implementation
-    // to find the group B job on its very first fetch (group A is pre-filtered out).
-    // With the bug, the worker starves indefinitely on group A jobs.
-    await delay(5000)
-
-    // BUG: this assertion fails. groupBProcessed is false because the group B job
-    // is starved behind the group A queued jobs. The `next` CTE applies LIMIT 1
-    // before the group concurrency check in `group_filtered`, so a saturated group
-    // dominating the front of the queue blocks every other group from being reached.
-    expect(groupBProcessed).toBe(true)
+    const completedJob = await spy.waitForJobWithId(groupBJobId, 'completed')
+    expect(completedJob.state).toBe('completed')
   })
 
   it('should validate groupConcurrency option in work', async function () {


### PR DESCRIPTION
When `groupConcurrency` is configured and a saturated group's queued jobs occupy the front of the queue, workers stall indefinitely and never reach jobs from other groups, even groups with zero active jobs and full capacity available, defeating half the purpose of the feature.

The test sets up the scenario directly: one group A job is fetched and held active (putting group A at its concurrency limit), several more group A jobs are queued behind it, then a single group B job is queued last. A worker with `groupConcurrency: 1` and `localConcurrency: 1` is started and given 10 polling cycles to process the group B job, which is fully eligible. It never does.

Scaling up workers provides accidental relief since `FOR UPDATE SKIP LOCKED` lets enough concurrent workers collectively skip past the saturated group's jobs to reach available ones, but this is not reliable and depends on worker count exceeding the number of saturated-group jobs at the front of the queue.



## Before and After: groupConcurrency head-of-line blocking fix

Queue: `process-webhook`, groupConcurrency: 2, batchSize: 1 (default)

### Scenario

The queue contains these jobs in order:

| position | group_id   | state   |
|----------|------------|---------|
| 1        | yellowcard | created |
| 2        | yellowcard | created |
| 3        | yellowcard | created |
| 4        | acme       | created |

`yellowcard` already has 2 active jobs. It is at its concurrency limit.
`acme` has 0 active jobs and is fully eligible.

---

### Before (buggy)

```sql
WITH
active_group_counts AS MATERIALIZED (
  SELECT group_id, COUNT(*)::int as active_cnt
  FROM pgboss.job
  WHERE name = 'process-webhook'
    AND state = 'active'
    AND group_id IS NOT NULL
  GROUP BY group_id
  -- result: { yellowcard: 2 }
),
next AS (
  SELECT id, group_id, group_tier
  FROM pgboss.job
  WHERE name = 'process-webhook'
    AND state < 'active'
    AND start_after < now()
  ORDER BY priority desc, created_on, id
  LIMIT 1                         -- picks position 1: a yellowcard job
  FOR UPDATE SKIP LOCKED
  -- result: one yellowcard row
),
group_ranking AS (
  SELECT t.id, t.group_id, t.group_tier,
    ROW_NUMBER() OVER (PARTITION BY t.group_id ORDER BY t.id) as group_rn,
    COALESCE(agc.active_cnt, 0) as active_cnt
  FROM next t
  LEFT JOIN active_group_counts agc ON t.group_id = agc.group_id
  -- result: { group_id: yellowcard, group_rn: 1, active_cnt: 2 }
),
group_filtered AS (
  SELECT id FROM group_ranking
  WHERE group_id IS NULL
    OR (active_cnt + group_rn) <= $1  -- 2 + 1 = 3, exceeds limit of 2, filtered out
  -- result: empty
)
UPDATE pgboss.job j SET
  state = 'active', started_on = now(), heartbeat_on = now(),
  retry_count = CASE WHEN started_on IS NOT NULL THEN retry_count + 1 ELSE retry_count END
FROM group_filtered
WHERE name = 'process-webhook' AND j.id = group_filtered.id
RETURNING j.id, j.name, j.data, j.expire_seconds as "expireInSeconds",
          j.group_id as "groupId", j.group_tier as "groupTier"
-- result: 0 rows. Worker sleeps 2s and tries again.
-- The acme job at position 4 is never reached.
```

---

### After (fixed)

```sql
WITH
active_group_counts AS MATERIALIZED (
  SELECT group_id, COUNT(*)::int as active_cnt
  FROM pgboss.job
  WHERE name = 'process-webhook'
    AND state = 'active'
    AND group_id IS NOT NULL
  GROUP BY group_id
  -- result: { yellowcard: 2 }
),
next AS (
  SELECT j.id, j.group_id, j.group_tier
  FROM pgboss.job j
  LEFT JOIN active_group_counts agc ON j.group_id = agc.group_id
  WHERE j.name = 'process-webhook'
    AND j.state < 'active'
    AND j.start_after < now()
    AND (
      j.group_id IS NULL        -- ungrouped jobs are always eligible
      OR agc.active_cnt IS NULL -- group has no active jobs yet
      OR agc.active_cnt < $1   -- yellowcard: 2 < 2 is false, all yellowcard rows excluded
                                -- acme: active_cnt is NULL, passes through
    )
  ORDER BY j.priority desc, j.created_on, j.id
  LIMIT 1                       -- yellowcard rows are gone before LIMIT runs, picks acme
  FOR UPDATE OF j SKIP LOCKED
  -- result: one acme row
),
group_ranking AS (
  SELECT t.id, t.group_id, t.group_tier,
    ROW_NUMBER() OVER (PARTITION BY t.group_id ORDER BY t.id) as group_rn,
    COALESCE(agc.active_cnt, 0) as active_cnt
  FROM next t
  LEFT JOIN active_group_counts agc ON t.group_id = agc.group_id
  -- result: { group_id: acme, group_rn: 1, active_cnt: 0 }
),
group_filtered AS (
  SELECT id FROM group_ranking
  WHERE group_id IS NULL
    OR (active_cnt + group_rn) <= $1  -- 0 + 1 = 1, within limit of 2, passes
  -- result: the acme row
)
UPDATE pgboss.job j SET
  state = 'active', started_on = now(), heartbeat_on = now(),
  retry_count = CASE WHEN started_on IS NOT NULL THEN retry_count + 1 ELSE retry_count END
FROM group_filtered
WHERE name = 'process-webhook' AND j.id = group_filtered.id
RETURNING j.id, j.name, j.data, j.expire_seconds as "expireInSeconds",
          j.group_id as "groupId", j.group_tier as "groupTier"
-- result: 1 row. The acme job is now active.
```

---

### Summary

The only structural difference is in the `next` CTE. Before the fix, `next` was a plain scan that applied `LIMIT 1` against the full queue and handed whatever job came first to the downstream concurrency check. After the fix, `next` joins `active_group_counts` and excludes saturated groups in the `WHERE` clause so that `LIMIT 1` only sees eligible candidates. The `group_ranking` and `group_filtered` CTEs are unchanged and continue to enforce precise per-batch concurrency for the case where `batchSize > 1` and a partially-saturated group has multiple jobs in a single fetch.