### PR TITLE
Ahead of line blocking Fix

### DIFF
--- a/src/plans.ts
+++ b/src/plans.ts
@@ -902,7 +902,7 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
   ].filter(Boolean).join(', ')
 
   const activeGroupCountsCte = hasGroupConcurrency
-    ? `active_group_counts AS (
+    ? `active_group_counts AS MATERIALIZED (
         SELECT group_id, COUNT(*)::int as active_cnt
         FROM ${schema}.${table}
         WHERE name = '${name}' AND state = '${JOB_STATES.active}' AND group_id IS NOT NULL
@@ -910,7 +910,37 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
       ), `
     : ''
 
-  const nextCte = `
+  // When groupConcurrency is active, active_group_counts is joined directly into
+  // the next CTE so that fully-saturated groups are excluded BEFORE LIMIT is
+  // applied. Without this, LIMIT 1 (the default batchSize) would always pick the
+  // oldest queued job — which may belong to a saturated group — leaving every
+  // other group permanently unreachable (head-of-line blocking).
+  // Column references are qualified with j. to avoid ambiguity with the join.
+  const nextCte = hasGroupConcurrency
+    ? `
+      next AS (
+        SELECT j.id${singletonFetch ? ', j.singleton_key' : ''}, j.group_id, j.group_tier
+        FROM ${schema}.${table} j
+        LEFT JOIN active_group_counts agc ON j.group_id = agc.group_id
+        WHERE j.name = '${name}'
+          AND j.state < '${JOB_STATES.active}'
+          ${!ignoreStartAfter ? 'AND j.start_after < now()' : ''}
+          ${hasIgnoreSingletons ? `AND j.singleton_key <> ALL(${params.ignoreSingletonsParam})` : ''}
+          ${hasIgnoreGroups ? `AND (j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : ''}
+          ${hasMinPriority ? `AND j.priority >= ${params.minPriorityParam}` : ''}
+          ${hasMaxPriority ? `AND j.priority <= ${params.maxPriorityParam}` : ''}
+          AND (
+            j.group_id IS NULL
+            OR agc.active_cnt IS NULL
+            OR agc.active_cnt < ${hasTiers
+              ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
+              : params.defaultGroupLimitParam}
+          )
+        ORDER BY ${priority ? 'j.priority desc, ' : ''}${orderByCreatedOn ? 'j.created_on, ' : ''}j.id
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
+      )`
+    : `
       next AS (
         SELECT ${selectCols}
         FROM ${schema}.${table}

--- a/test/concurrencyGroupTest.ts
+++ b/test/concurrencyGroupTest.ts
@@ -248,6 +248,64 @@ describe('groupConcurrency', function () {
     }).rejects.toThrow('group.tier must be a non-empty string if provided')
   })
 
+  it('should process available group jobs when saturated group dominates the front of the queue', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const groupA = 'group-saturated'
+    const groupB = 'group-available'
+    const groupConcurrency = 1
+
+    // Step 1: Send one group A job and fetch it directly to make it "active",
+    // holding group A at its concurrency limit for the entire duration of the test.
+    // This simulates a long-running job consuming the one allowed slot.
+    await ctx.boss.send(ctx.schema, {}, { group: { id: groupA } })
+    const [activeJob] = await ctx.boss.fetch(ctx.schema)
+    assertTruthy(activeJob)
+    // activeJob is now in "active" state and will never be completed during this
+    // test, keeping group A permanently saturated (active_cnt = 1 = groupConcurrency).
+
+    // Step 2: Flood the front of the queue with group A jobs.
+    // Sent AFTER the active job, so they occupy positions 1–5 in
+    // ORDER BY created_on, id — ahead of group B in queue order.
+    for (let i = 0; i < 5; i++) {
+      await ctx.boss.send(ctx.schema, { index: i }, { group: { id: groupA } })
+    }
+
+    // Step 3: Enqueue one group B job. It is fully eligible (0 active, under its
+    // concurrency limit), but created last so it sits at position 6 in queue order,
+    // behind all of the group A queued jobs.
+    await ctx.boss.send(ctx.schema, {}, { group: { id: groupB } })
+
+    // Step 4: Start a single worker with groupConcurrency: 1.
+    // With the bug, every poll executes:
+    //   next CTE  →  LIMIT 1  →  picks the oldest queued job (a group A job)
+    //   group_filtered  →  active_cnt(1) + group_rn(1) = 2 > 1  →  discarded
+    //   UPDATE affects 0 rows  →  worker sleeps 500 ms  →  repeat forever.
+    // The group B job is never reached because it sits behind the group A pile.
+    let groupBProcessed = false
+
+    await ctx.boss.work(ctx.schema, {
+      groupConcurrency,
+      localConcurrency: 1,
+      pollingIntervalSeconds: 0.5
+    }, async ([job]) => {
+      if (job.groupId === groupB) {
+        groupBProcessed = true
+      }
+    })
+
+    // 10 polling cycles at 500 ms — more than enough for a correct implementation
+    // to find the group B job on its very first fetch (group A is pre-filtered out).
+    // With the bug, the worker starves indefinitely on group A jobs.
+    await delay(5000)
+
+    // BUG: this assertion fails. groupBProcessed is false because the group B job
+    // is starved behind the group A queued jobs. The `next` CTE applies LIMIT 1
+    // before the group concurrency check in `group_filtered`, so a saturated group
+    // dominating the front of the queue blocks every other group from being reached.
+    expect(groupBProcessed).toBe(true)
+  })
+
   it('should validate groupConcurrency option in work', async function () {
     ctx.boss = await helper.start(ctx.bossConfig)
 


### PR DESCRIPTION
Follow up fix to: https://github.com/timgit/pg-boss/pull/756


I wanted to have the failing test run separate from the fix, but the fix is to filter out saturated concurrency group jobs before looking for the next job. 