### PR TITLE
localGroupConcurrency with tiers silently ignores tier capacity

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -33,6 +33,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
   #spies: Map<string, JobSpy>
   #localGroupActive: Map<string, Map<string, number>>
   #localGroupConfig: Map<string, types.GroupConcurrencyConfig>
+  #localGroupMaxLimit: Map<string, number>
 
   constructor (db: types.IDatabase, config: types.ResolvedConstructorOptions) {
     super()
@@ -46,6 +47,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     this.#spies = new Map()
     this.#localGroupActive = new Map()
     this.#localGroupConfig = new Map()
+    this.#localGroupMaxLimit = new Map()
   }
 
   getSpy<T = object> (name: string): JobSpyInterface<T> {
@@ -83,12 +85,17 @@ class Manager extends EventEmitter implements types.EventsMixin {
     const queueGroups = this.#localGroupActive.get(queueName)
     if (!queueGroups) return []
 
+    // Only exclude a group from fetching when it has no remaining capacity for
+    // any tier. Using config.default alone would exclude groups that still have
+    // room for higher tier jobs. Those jobs never reach the per tier check in
+    // #trackLocalGroupStart because ignoreGroups filters them out of the fetch
+    // query before that point. maxLimit is precomputed once at setup time so
+    // Object.values is not called on every fetch cycle.
+    const maxLimit = this.#localGroupMaxLimit.get(queueName) ?? config.default
+
     const atCapacity: string[] = []
     for (const [groupId, activeCount] of queueGroups.entries()) {
-      // We don't have tier info here, so use default limit
-      // Jobs with tiers will be checked individually after fetch
-      const limit = config.default
-      if (activeCount >= limit) {
+      if (activeCount >= maxLimit) {
         atCapacity.push(groupId)
       }
     }
@@ -149,6 +156,9 @@ class Manager extends EventEmitter implements types.EventsMixin {
       ? { default: localGroupConcurrency }
       : localGroupConcurrency
     this.#localGroupConfig.set(name, config)
+    this.#localGroupMaxLimit.set(name, config.tiers
+      ? Math.max(config.default, ...Object.values(config.tiers))
+      : config.default)
   }
 
   #cleanupLocalGroupTracking (name: string): void {
@@ -157,6 +167,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     if (!hasWorkersForQueue) {
       this.#localGroupConfig.delete(name)
       this.#localGroupActive.delete(name)
+      this.#localGroupMaxLimit.delete(name)
     }
   }
 
@@ -296,6 +307,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     // Clean up all local group tracking on full stop
     this.#localGroupConfig.clear()
     this.#localGroupActive.clear()
+    this.#localGroupMaxLimit.clear()
   }
 
   async failWip () {

--- a/test/concurrencyLocalGroupTest.ts
+++ b/test/concurrencyLocalGroupTest.ts
@@ -472,4 +472,47 @@ describe('localGroupConcurrency', function () {
     // All jobs should be processed
     expect(totalProcessed).toBe(8)
   })
+
+  it('should fetch enterprise-tier jobs for a group that is at its default limit', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const groupId = 'test-group'
+    const localGroupConcurrency = { default: 1, tiers: { enterprise: 3 } }
+
+    let enterpriseJobsProcessed = 0
+
+    // Start the worker before sending jobs so we can control ordering precisely.
+    await ctx.boss.work(ctx.schema, {
+      localConcurrency: 3,
+      localGroupConcurrency,
+      pollingIntervalSeconds: 0.5
+    }, async ([job]) => {
+      if ((job.data as { tier: string }).tier === 'default') {
+        await delay(5000) // hold active for the full test window
+      } else {
+        enterpriseJobsProcessed++
+      }
+    })
+
+    // Send the default-tier job and wait long enough for the worker to pick it
+    // up and increment the in-memory count to 1.
+    await ctx.boss.send(ctx.schema, { tier: 'default' }, { group: { id: groupId } })
+    await delay(1000)
+
+    // Now queue enterprise-tier jobs. The group is at its default limit (count=1),
+    // but the enterprise limit is 3, so these should still be fetchable.
+    // #getGroupsAtLocalCapacity uses config.default for all groups regardless of
+    // tier, so it adds the group to ignoreGroups and these jobs are never reached.
+    await ctx.boss.send(ctx.schema, { tier: 'enterprise' }, { group: { id: groupId, tier: 'enterprise' } })
+    await ctx.boss.send(ctx.schema, { tier: 'enterprise' }, { group: { id: groupId, tier: 'enterprise' } })
+
+    // Several polling cycles for the second worker to pick up enterprise jobs.
+    await delay(3000)
+
+    // BUG: enterpriseJobsProcessed is 0. #getGroupsAtLocalCapacity checks
+    // activeCount >= config.default (1 >= 1) and adds the group to ignoreGroups,
+    // excluding all its jobs from the fetch query regardless of their tier.
+    // The enterprise limit of 3 is never consulted.
+    expect(enterpriseJobsProcessed).toBeGreaterThan(0)
+  })
 })

--- a/test/concurrencyLocalGroupTest.ts
+++ b/test/concurrencyLocalGroupTest.ts
@@ -481,6 +481,11 @@ describe('localGroupConcurrency', function () {
 
     let enterpriseJobsProcessed = 0
 
+    // Resolved from inside the handler the moment the default-tier job starts,
+    // giving a hard synchronisation point before enterprise jobs are enqueued.
+    let signalDefaultJobActive: () => void
+    const defaultJobActive = new Promise<void>(resolve => { signalDefaultJobActive = resolve })
+
     // Start the worker before sending jobs so we can control ordering precisely.
     await ctx.boss.work(ctx.schema, {
       localConcurrency: 3,
@@ -488,31 +493,30 @@ describe('localGroupConcurrency', function () {
       pollingIntervalSeconds: 0.5
     }, async ([job]) => {
       if ((job.data as { tier: string }).tier === 'default') {
+        signalDefaultJobActive() // in-memory count is now 1
         await delay(5000) // hold active for the full test window
       } else {
         enterpriseJobsProcessed++
       }
     })
 
-    // Send the default-tier job and wait long enough for the worker to pick it
-    // up and increment the in-memory count to 1.
+    // Send the default-tier job and wait for a hard signal that it is active and
+    // the in-memory count has been incremented before enqueueing enterprise jobs.
     await ctx.boss.send(ctx.schema, { tier: 'default' }, { group: { id: groupId } })
-    await delay(1000)
+    await defaultJobActive
 
-    // Now queue enterprise-tier jobs. The group is at its default limit (count=1),
-    // but the enterprise limit is 3, so these should still be fetchable.
-    // #getGroupsAtLocalCapacity uses config.default for all groups regardless of
-    // tier, so it adds the group to ignoreGroups and these jobs are never reached.
+    // Regression coverage: previously #getGroupsAtLocalCapacity compared against
+    // config.default only, so once the group had one active job it was added to
+    // ignoreGroups and all its enterprise-tier jobs were excluded from fetching
+    // entirely, even though the enterprise limit of 3 had capacity remaining.
     await ctx.boss.send(ctx.schema, { tier: 'enterprise' }, { group: { id: groupId, tier: 'enterprise' } })
     await ctx.boss.send(ctx.schema, { tier: 'enterprise' }, { group: { id: groupId, tier: 'enterprise' } })
 
-    // Several polling cycles for the second worker to pick up enterprise jobs.
+    // Several polling cycles for the available workers to pick up enterprise jobs.
     await delay(3000)
 
-    // BUG: enterpriseJobsProcessed is 0. #getGroupsAtLocalCapacity checks
-    // activeCount >= config.default (1 >= 1) and adds the group to ignoreGroups,
-    // excluding all its jobs from the fetch query regardless of their tier.
-    // The enterprise limit of 3 is never consulted.
-    expect(enterpriseJobsProcessed).toBeGreaterThan(0)
+    // Both enterprise jobs should be processed — the group is at its default limit
+    // but the enterprise tier still has capacity.
+    expect(enterpriseJobsProcessed).toBe(2)
   })
 })


### PR DESCRIPTION
When `localGroupConcurrency` is configured with tier-specific limits, a group that reaches its default limit is excluded from fetching entirely, even when it still has capacity available under a higher tier limit.

`#getGroupsAtLocalCapacity` is responsible for building the list of groups that get passed as `ignoreGroups` to the fetch query. A group in `ignoreGroups` is filtered out of the `next` CTE's WHERE clause, meaning none of its jobs are fetched regardless of their tier. The problem is that `#getGroupsAtLocalCapacity` always compares the group's active count against `config.default`, ignoring any tier-specific limits that may be higher:

```js
const limit = config.default
if (activeCount >= limit) {
  atCapacity.push(groupId)
}
```

The original code has a comment that says "jobs with tiers will be checked individually after fetch", but this is incorrect. If the group is added to `ignoreGroups`, its jobs are excluded from the fetch query before any per-tier check can run. They never reach `#trackLocalGroupStart` where the tier-specific limit would apply.

### How it manifests

Consider a queue configured with `localGroupConcurrency: { default: 1, tiers: { enterprise: 3 } }`. A group that has one active default-tier job has filled its default slot and gets added to `ignoreGroups`. From that point on, all of that group's queued jobs are excluded from fetching, including enterprise-tier jobs that have three slots available. The enterprise capacity sits completely idle regardless of how many workers are polling or how many enterprise jobs are waiting.

This is silent. There is no error and no log output. Enterprise jobs simply accumulate in the queue without being processed. The only observable symptom is throughput for higher-tier jobs in a busy group being unexpectedly low or zero.

### The failing test

The test starts the worker first, then sends one default-tier job and waits long enough for a worker to pick it up and increment the in-memory count to 1. At that point the group is at its default limit. Two enterprise-tier jobs are then queued and the test waits for several polling cycles. With the bug present, `enterpriseJobsProcessed` is 0 because the group is in `ignoreGroups` and none of its jobs are fetched.

### The fix

`#getGroupsAtLocalCapacity` should only exclude a group when it has no remaining capacity for any configured tier. A group should stay fetchable as long as at least one tier still has room. The fix precomputes the highest limit across all tiers at setup time in `#storeLocalGroupConfig` and stores it in a dedicated `#localGroupMaxLimit` map. `#getGroupsAtLocalCapacity` then compares against that value instead of `config.default`.

```js
this.#localGroupMaxLimit.set(name, config.tiers
  ? Math.max(config.default, ...Object.values(config.tiers))
  : config.default)
```

A group is now only added to `ignoreGroups` when its total active count has reached the highest possible limit, meaning no tier has any remaining capacity. The existing per-tier enforcement in `#trackLocalGroupStart` is unchanged and continues to apply the correct tier-specific limit to each individual job after it is fetched. The two mechanisms work together: the pre-filter uses the maximum limit to avoid over-excluding groups, and the post-fetch check uses the per-tier limit to enforce precise concurrency.

The maximum limit is precomputed once when `work()` is called rather than recomputed on every fetch cycle, so `Object.values(config.tiers)` is not called in the hot path.