### PR TITLE
Expose wip

### DIFF
--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -4,7 +4,7 @@
 
 Adds a new polling worker for a queue and executes the provided callback function when jobs are found. Each call to work() will add a new worker and resolve a unqiue worker id.
 
-Workers can be stopped via `offWork()` all at once by queue name or individually by using the worker id. Worker activity may be monitored by listening to the `wip` event.
+Workers can be stopped via `offWork()` all at once by queue name or individually by using the worker id. Worker activity may be monitored by listening to the `wip` event or by polling [`getWipData()`](#getwipdata).
 
 The default options for `work()` is 1 job every 2 seconds.
 
@@ -215,6 +215,33 @@ work() with abort signal
 await boss.work('process-video', async ([ job ]) => {
   const result = await fetch('https://api.example.com/process', { signal: job.signal })
 })
+```
+
+### `getWipData(options)`
+
+Returns a snapshot of all active workers in this instance of pg-boss. This is the same data payload emitted by the `wip` event, but available on-demand without waiting for a job transition.
+
+Use this for continuous monitoring of worker utilization — for example, driving metrics or autoscaling signals when jobs are long-running and the `wip` event may not fire frequently enough.
+
+**Arguments**
+- `options`: object *(optional)*
+
+**Options**
+
+* **includeInternal**, bool, *(default=false)*
+
+  If true, includes workers for pg-boss internal queues (e.g., scheduling).
+
+**Returns**: `WipData[]`
+
+```js
+// Poll worker utilization every 2 seconds for metrics
+setInterval(() => {
+  const workers = boss.getWipData()
+  const working = workers.filter(w => w.state === 'active' && w.count > 0).length
+  const idle = workers.filter(w => w.state === 'active' && w.count === 0).length
+  console.log(`working: ${working}, idle: ${idle}`)
+}, 2000)
 ```
 
 ### `notifyWorker(id)`

--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -4,7 +4,7 @@
 
 Adds a new polling worker for a queue and executes the provided callback function when jobs are found. Each call to work() will add a new worker and resolve a unqiue worker id.
 
-Workers can be stopped via `offWork()` all at once by queue name or individually by using the worker id. Worker activity may be monitored by listening to the `wip` event or by polling [`getWipData()`](#getwipdata).
+Workers can be stopped via `offWork()` all at once by queue name or individually by using the worker id. Worker activity may be monitored by listening to the `wip` event or by polling [`getWipData()`](#getwipdataoptions).
 
 The default options for `work()` is 1 job every 2 seconds.
 
@@ -219,7 +219,7 @@ await boss.work('process-video', async ([ job ]) => {
 
 ### `getWipData(options)`
 
-Returns a snapshot of all active workers in this instance of pg-boss. This is the same data payload emitted by the `wip` event, but available on-demand without waiting for a job transition.
+Returns a snapshot of all workers in this instance of pg-boss with state `created`, `active`, or `stopping`. This is the same data payload emitted by the `wip` event, but available on-demand without waiting for a job transition.
 
 Use this for continuous monitoring of worker utilization — for example, driving metrics or autoscaling signals when jobs are long-running and the `wip` event may not fire frequently enough.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,10 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this.#boss.supervise(name)
   }
 
+  getWipData (options?: { includeInternal?: boolean }): types.WipData[] {
+    return this.#manager.getWipData(options)
+  }
+
   getSpy<T = object> (name: string): JobSpyInterface<T> {
     return this.#manager.getSpy<T>(name)
   }

--- a/test/workTest.ts
+++ b/test/workTest.ts
@@ -328,6 +328,24 @@ describe('work', function () {
     expect(wip2.length).toBe(1)
   })
 
+  it('getWipData() should return current worker state', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await ctx.boss.send(ctx.schema)
+
+    await ctx.boss.work(ctx.schema, { pollingIntervalSeconds: 1 }, () => delay(2000))
+
+    // Wait for the job to be picked up
+    const firstWipEvent = new Promise<void>(resolve => ctx.boss!.once('wip', () => resolve()))
+    await firstWipEvent
+
+    const wip = ctx.boss.getWipData()
+
+    expect(wip.length).toBe(1)
+    expect(wip[0].name).toBe(ctx.schema)
+    expect(wip[0].state).toBe('active')
+  })
+
   it('should reject work() after stopping', async function () {
     ctx.boss = await helper.start(ctx.bossConfig)
 


### PR DESCRIPTION
Sorry to spam so many PRs! 

I ran into a bit of a footgun with the WIP event. I understood it to emit every 2 seconds when there was work de-queued into a worker, but apparently its only every 2 seconds max, between job transitions (which is normally way more often than 2s in a healthy queue!).

But if you have a large queue of work that takes 20 minutes each job, and you de-queue 15 jobs, and they all start to run for 20 minutes at the same time, you only really get WIP ~20 minutes. 

Since I want to use WIP as an observability hook, only getting metrics every 20 minutes won't work for that use case. 

This PR exposes the WIP method so that I can call it from the outside at whatever frequency makes sense for the metrics collector (in my case).