### PR TITLE
Change WIP to reliably emit even during slow jobs

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -57,7 +57,7 @@ const boss = new PgBoss({
 
 ## `wip`
 
-Emitted at most once every 2 seconds when workers are receiving jobs. The payload is an array that represents each worker in this instance of pg-boss.
+Emitted at most once every 2 seconds whenever at least one worker has an active job. The payload is an array that represents each worker in this instance of pg-boss.
 
 ```js
 [

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -27,6 +27,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
   workers: Map<string, Worker>
   stopped: boolean | undefined
   queueCacheInterval: NodeJS.Timeout | undefined
+  wipInterval: NodeJS.Timeout | undefined
   timekeeper: Timekeeper | undefined
   queues: Record<string, types.QueueResult> | null
   pendingOffWorkCleanups: Set<Promise<any>>
@@ -260,6 +261,18 @@ class Manager extends EventEmitter implements types.EventsMixin {
   async start () {
     this.stopped = false
     this.queueCacheInterval = setInterval(() => this.onCacheQueues({ emit: true }), this.config.queueCacheIntervalSeconds! * 1000)
+    this.wipInterval = setInterval(() => {
+      const now = Date.now()
+      if ((now - this.wipTs) < 2000) {
+        return
+      }
+
+      const wip = this.getWipData()
+      if (wip.some(w => w.count > 0)) {
+        this.emit(events.wip, wip)
+        this.wipTs = now
+      }
+    }, 2000)
     await this.onCacheQueues()
   }
 
@@ -297,6 +310,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     this.stopped = true
 
     clearInterval(this.queueCacheInterval)
+    clearInterval(this.wipInterval)
 
     await Promise.allSettled(
       [...this.workers.values()]

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -27,6 +27,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
   workers: Map<string, Worker>
   stopped: boolean | undefined
   queueCacheInterval: NodeJS.Timeout | undefined
+  wipInterval: NodeJS.Timeout | undefined
   timekeeper: Timekeeper | undefined
   queues: Record<string, types.QueueResult> | null
   pendingOffWorkCleanups: Set<Promise<any>>
@@ -249,6 +250,18 @@ class Manager extends EventEmitter implements types.EventsMixin {
   async start () {
     this.stopped = false
     this.queueCacheInterval = setInterval(() => this.onCacheQueues({ emit: true }), this.config.queueCacheIntervalSeconds! * 1000)
+    this.wipInterval = setInterval(() => {
+      const now = Date.now()
+      if ((now - this.wipTs) < 2000) {
+        return
+      }
+
+      const wip = this.getWipData()
+      if (wip.some(w => w.count > 0)) {
+        this.emit(events.wip, wip)
+        this.wipTs = now
+      }
+    }, 2000)
     await this.onCacheQueues()
   }
 
@@ -286,6 +299,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     this.stopped = true
 
     clearInterval(this.queueCacheInterval)
+    clearInterval(this.wipInterval)
 
     await Promise.allSettled(
       [...this.workers.values()]

--- a/test/workTest.ts
+++ b/test/workTest.ts
@@ -369,6 +369,36 @@ describe('work', function () {
     expect(wip[0].state).toBe('active')
   })
 
+  it('should emit wip heartbeat while workers are busy with long-running jobs', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await ctx.boss.send(ctx.schema)
+
+    let jobStartedResolve!: () => void
+    const jobStarted = new Promise<void>(resolve => { jobStartedResolve = resolve })
+
+    await ctx.boss.work(ctx.schema, { pollingIntervalSeconds: 1 }, async ([job]) => {
+      jobStartedResolve()
+      const ac = new AbortController()
+      job.signal.addEventListener('abort', () => ac.abort(), { once: true })
+      try {
+        await delay(10000, undefined, ac)
+      } catch {
+        // aborted during boss.stop() teardown — expected
+      }
+    })
+
+    await jobStarted
+
+    let wipCount = 0
+    const listener = () => { wipCount++ }
+    ctx.boss.on('wip', listener)
+    await delay(6000)
+    ctx.boss.off('wip', listener)
+
+    expect(wipCount).toBeGreaterThanOrEqual(2)
+  }, 20000)
+
   it('should reject work() after stopping', async function () {
     ctx.boss = await helper.start(ctx.bossConfig)
 

--- a/test/workTest.ts
+++ b/test/workTest.ts
@@ -328,6 +328,36 @@ describe('work', function () {
     expect(wip2.length).toBe(1)
   })
 
+  it('should emit wip heartbeat while workers are busy with long-running jobs', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await ctx.boss.send(ctx.schema)
+
+    let jobStartedResolve!: () => void
+    const jobStarted = new Promise<void>(resolve => { jobStartedResolve = resolve })
+
+    await ctx.boss.work(ctx.schema, { pollingIntervalSeconds: 1 }, async ([job]) => {
+      jobStartedResolve()
+      const ac = new AbortController()
+      job.signal.addEventListener('abort', () => ac.abort(), { once: true })
+      try {
+        await delay(10000, undefined, ac)
+      } catch {
+        // aborted during boss.stop() teardown — expected
+      }
+    })
+
+    await jobStarted
+
+    let wipCount = 0
+    const listener = () => { wipCount++ }
+    ctx.boss.on('wip', listener)
+    await delay(6000)
+    ctx.boss.off('wip', listener)
+
+    expect(wipCount).toBeGreaterThanOrEqual(2)
+  }, 20000)
+
   it('should reject work() after stopping', async function () {
     ctx.boss = await helper.start(ctx.bossConfig)
 


### PR DESCRIPTION
I ran into a footgun with WIP. When every job takes a long time, it only emits between job transitions. I understood WIP to emit every 2 seconds while jobs were active in a worker, and tried to use it as a metrics hook. Needless to say that didn't go well with long running jobs. 

Not sure if this was the original intention here or not, but in case it was, here is what it would look like for WIP to emit reliably every 2 seconds while jobs are in workers, rather than only during job transitions. If emitting only during transitions only was the intention/design, feel feel free to close.