### PR TITLE
Match `pg.PoolConfig` typing on `DatabaseOptions`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type pg from 'pg'
+
 export type JobStates = {
   created: 'created',
   retry: 'retry',
@@ -19,19 +21,9 @@ export interface IDatabase {
   executeSql(text: string, values?: unknown[]): Promise<{ rows: any[] }>;
 }
 
-export interface DatabaseOptions {
-  application_name?: string;
-  database?: string;
-  user?: string;
-  password?: string | (() => string | Promise<string>);
-  host?: string;
-  port?: number;
+export interface DatabaseOptions extends pg.PoolConfig {
   schema?: string;
-  ssl?: any;
-  connectionString?: string;
-  max?: number;
   db?: IDatabase;
-  connectionTimeoutMillis?: number;
   /** @internal */
   debug?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface DatabaseOptions {
   application_name?: string;
   database?: string;
   user?: string;
-  password?: string | (() => string) | (() => Promise<string>);
+  password?: string | (() => string | Promise<string>);
   host?: string;
   port?: number;
   schema?: string;


### PR DESCRIPTION
The typing of `DatabaseOptions` doesn't exactly match the `pg.PoolConfig` type used by `pg.Pool()`. This can lead to type mismatches when passing a shared pg config object directly to `pg-boss`.

I chose to extend `pg.PoolConfig`, rather than adjust the existing typing.