### PR TITLE
Add support for job dependencies in pg boss

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -201,6 +201,52 @@ interface JobInsert<T = object> {
 }
 ```
 
+```js
+const [idA, idB] = await boss.insert('etl', [
+  { data: { step: 'extract' } },
+  { data: { step: 'transform' } }
+], { returnId: true })
+```
+
+### `createFlow(jobs, options)`
+
+Create a set of jobs and their dependencies atomically in one transaction.
+
+Use `createFlow()` when jobs depend on other jobs. Dependencies are not configured on `send()` or `insert()` because creating jobs and dependencies in separate calls can race with job completion.
+
+The method accepts a flat array of jobs in any order. Each job has a local `ref`, and dependent jobs reference parent refs with `dependsOn`.
+
+```ts
+interface FlowJob {
+  ref: string;
+  name: string;
+  data?: object;
+  options?: Omit<JobInsert, 'data'>;
+  dependsOn?: string[];
+}
+```
+
+Returns a map of `ref` to created job id.
+
+```js
+const flow = await boss.createFlow([
+  { ref: 'extract-a', name: 'extract', data: { file: '1.csv' } },
+  { ref: 'extract-b', name: 'extract', data: { file: '2.csv' } },
+  {
+    ref: 'load',
+    name: 'load',
+    data: { output: 'report.csv' },
+    dependsOn: ['extract-a', 'extract-b']
+  }
+])
+
+const loadJobId = flow.load
+```
+
+Dependent jobs are created in a `blocked` state and won't be eligible for fetching until all parent jobs have completed. If a parent job fails or is cancelled, the child remains blocked. You can explicitly `cancel` or `fail` the blocked child if needed.
+
+When a dependent job uses `startAfter`, both conditions must be met: all dependencies completed and `startAfter` has passed.
+
 ### `fetch(name, options)`
 
 Returns an array of jobs from a queue
@@ -261,6 +307,8 @@ Returns an array of jobs from a queue
       createdOn: Date;
       completedOn: Date | null;
       keepUntil: Date;
+      blocked: boolean,
+      blocking: boolean,
       deadLetter: string,
       policy: string,
       output: object
@@ -472,4 +520,22 @@ const jobs = await boss.findJobs('my-queue', {
   data: { type: 'email' },
   queued: true
 })
+```
+
+### `getDependencies(name, id, options)`
+
+Returns an array of parent job references that the specified job depends on.
+
+```js
+const parents = await boss.getDependencies('aggregate-results', jobId)
+// [{ name: 'process-data', id: '...' }, { name: 'process-data', id: '...' }]
+```
+
+### `getDependents(name, id, options)`
+
+Returns an array of child job references that depend on the specified job.
+
+```js
+const children = await boss.getDependents('process-data', parentJobId)
+// [{ name: 'aggregate-results', id: '...' }]
 ```

--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -214,6 +214,8 @@ Create a set of jobs and their dependencies atomically in one transaction.
 
 Use `createFlow()` when jobs depend on other jobs. Dependencies are not configured on `send()` or `insert()` because creating jobs and dependencies in separate calls can race with job completion.
 
+Atomicity is handled by pg-boss when it owns the database connection. If you pass a custom `db` in `options`, wrap the call in your own transaction if you need the job and dependency inserts to commit or roll back together.
+
 The method accepts a flat array of jobs in any order. Each job has a local `ref`, and dependent jobs reference parent refs with `dependsOn`.
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "db:construct": "node --import=tsx -e 'console.log(require(\"./src\").getConstructionPlans())'"
   },
   "pgboss": {
-    "schema": 30
+    "schema": 31
   },
   "repository": {
     "type": "git",

--- a/packages/proxy/src/contracts.ts
+++ b/packages/proxy/src/contracts.ts
@@ -148,6 +148,8 @@ export const jobWithMetadataSchema = jobSchemaBase.extend({
   createdOn: z.iso.datetime().transform((val) => new Date(val)),
   completedOn: z.iso.datetime().nullable().transform((val) => val ? new Date(val) : null),
   keepUntil: z.iso.datetime().transform((val) => new Date(val)),
+  blocked: z.boolean(),
+  blocking: z.boolean(),
   policy: z.string(),
   deadLetter: z.string(),
   output: jsonRecordSchema,

--- a/packages/proxy/src/contracts.ts
+++ b/packages/proxy/src/contracts.ts
@@ -150,6 +150,7 @@ export const jobWithMetadataSchema = jobSchemaBase.extend({
   keepUntil: z.iso.datetime().transform((val) => new Date(val)),
   blocked: z.boolean(),
   blocking: z.boolean(),
+  pendingDependencies: z.number(),
   policy: z.string(),
   deadLetter: z.string(),
   output: jsonRecordSchema,

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -85,6 +85,104 @@ function validateGroupConfig (config: any) {
   assert(!('tier' in config.group) || (typeof config.group.tier === 'string' && config.group.tier.length > 0), 'group.tier must be a non-empty string if provided')
 }
 
+function validateFlowJobs (jobs: types.FlowJob[]) {
+  assert(Array.isArray(jobs), 'createFlow requires an array of jobs')
+  assert(jobs.length >= 2, 'createFlow requires at least 2 jobs')
+
+  const refs = new Set<string>()
+  for (const job of jobs) {
+    assert(typeof job.ref === 'string' && job.ref.length > 0, 'each flow job must have a non-empty ref')
+    assert(!refs.has(job.ref), `duplicate ref: "${job.ref}"`)
+    refs.add(job.ref)
+
+    assert(typeof job.name === 'string' && job.name.length > 0, 'each flow job must have a non-empty name')
+    assertObjectName(job.name)
+  }
+
+  const hasDeps = jobs.some(j => j.dependsOn && j.dependsOn.length > 0)
+  assert(hasDeps, 'createFlow requires at least one job with dependsOn')
+
+  for (const job of jobs) {
+    if (!job.dependsOn) continue
+    assert(Array.isArray(job.dependsOn), `dependsOn for ref "${job.ref}" must be an array`)
+    for (const dep of job.dependsOn) {
+      assert(typeof dep === 'string' && dep.length > 0, `dependsOn entries must be non-empty strings`)
+      assert(dep !== job.ref, `job "${job.ref}" cannot depend on itself`)
+      assert(refs.has(dep), `dependsOn ref "${dep}" not found in flow`)
+    }
+  }
+
+  // Cycle detection via topological sort
+  const inDegree = new Map<string, number>()
+  const edges = new Map<string, string[]>()
+  for (const job of jobs) {
+    inDegree.set(job.ref, 0)
+    edges.set(job.ref, [])
+  }
+  for (const job of jobs) {
+    if (!job.dependsOn) continue
+    for (const dep of job.dependsOn) {
+      edges.get(dep)!.push(job.ref)
+      inDegree.set(job.ref, inDegree.get(job.ref)! + 1)
+    }
+  }
+  const queue: string[] = []
+  for (const [ref, deg] of inDegree) {
+    if (deg === 0) queue.push(ref)
+  }
+  let visited = 0
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    visited++
+    for (const child of edges.get(current)!) {
+      const newDeg = inDegree.get(child)! - 1
+      inDegree.set(child, newDeg)
+      if (newDeg === 0) queue.push(child)
+    }
+  }
+  if (visited !== jobs.length) {
+    const cycle = findDependencyCycle(edges)
+    assert(false, `createFlow contains a dependency cycle: ${cycle.join(' -> ')}`)
+  }
+}
+
+function findDependencyCycle (edges: Map<string, string[]>): string[] {
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const path: string[] = []
+
+  function visit (ref: string): string[] | null {
+    if (visiting.has(ref)) {
+      const start = path.indexOf(ref)
+      return [...path.slice(start), ref]
+    }
+
+    if (visited.has(ref)) return null
+
+    visiting.add(ref)
+    path.push(ref)
+
+    for (const child of edges.get(ref) || []) {
+      const cycle = visit(child)
+      if (cycle) return cycle
+    }
+
+    path.pop()
+    visiting.delete(ref)
+    visited.add(ref)
+
+    return null
+  }
+
+  let cycle: string[] | null = null
+  for (const ref of edges.keys()) {
+    cycle = visit(ref)
+    if (cycle) break
+  }
+
+  return cycle!
+}
+
 function validateGroupConcurrencyValue (value: any, optionName: string) {
   if (typeof value === 'number') {
     assert(Number.isInteger(value) && value >= 1, `${optionName} must be an integer >= 1`)
@@ -374,5 +472,6 @@ export {
   checkWorkArgs,
   getConfig,
   POLICY,
+  validateFlowJobs,
   validateQueueArgs
 }

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -106,7 +106,7 @@ function validateFlowJobs (jobs: types.FlowJob[]) {
     if (!job.dependsOn) continue
     assert(Array.isArray(job.dependsOn), `dependsOn for ref "${job.ref}" must be an array`)
     for (const dep of job.dependsOn) {
-      assert(typeof dep === 'string' && dep.length > 0, `dependsOn entries must be non-empty strings`)
+      assert(typeof dep === 'string' && dep.length > 0, 'dependsOn entries must be non-empty strings')
       assert(dep !== job.ref, `job "${job.ref}" cannot depend on itself`)
       assert(refs.has(dep), `dependsOn ref "${dep}" not found in flow`)
     }

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -246,6 +246,9 @@ class Boss extends EventEmitter implements types.EventsMixin {
       const queues = rows.map((q) => q.name)
       const sql = plans.deletion(this.#config.schema, table, queues)
       await this.#executeQuery(sql)
+
+      const depSql = plans.cleanupDependencies(this.#config.schema, table, queues)
+      await this.#executeQuery(depSql)
     }
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -54,6 +54,26 @@ class Db extends EventEmitter implements types.IDatabase, types.EventsMixin {
 
     return await this.pool.query(text, values)
   }
+
+  async withTransaction<T> (fn: (db: types.IDatabase) => Promise<T>): Promise<T> {
+    assert(this.opened, 'Database not opened. Call open() before executing SQL.')
+
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      const txDb: types.IDatabase = {
+        executeSql: (text: string, values?: unknown[]) => client.query(text, values)
+      }
+      const result = await fn(txDb)
+      await client.query('COMMIT')
+      return result
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    } finally {
+      client.release()
+    }
+  }
 }
 
 export default Db

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,15 +21,15 @@ export const events: types.Events = Object.freeze({
   bam: 'bam'
 })
 
-export function getConstructionPlans (schema?: string) {
+export function getConstructionPlans(schema?: string) {
   return Contractor.constructionPlans(schema)
 }
 
-export function getMigrationPlans (schema?: string, version?: number) {
+export function getMigrationPlans(schema?: string, version?: number) {
   return Contractor.migrationPlans(schema, version)
 }
 
-export function getRollbackPlans (schema?: string, version?: number) {
+export function getRollbackPlans(schema?: string, version?: number) {
   return Contractor.rollbackPlans(schema, version)
 }
 
@@ -46,9 +46,9 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
   #timekeeper: Timekeeper
   #bam: Bam
 
-  constructor (connectionString: string)
-  constructor (options: types.ConstructorOptions)
-  constructor (value: string | types.ConstructorOptions) {
+  constructor(connectionString: string)
+  constructor(options: types.ConstructorOptions)
+  constructor(value: string | types.ConstructorOptions) {
     super()
     this.#stoppingOn = null
     this.#stopped = true
@@ -86,13 +86,13 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     this.#bam = bam
   }
 
-  #promoteEvents (emitter: types.EventsMixin) {
+  #promoteEvents(emitter: types.EventsMixin) {
     for (const event of Object.values(emitter?.events) as (keyof types.PgBossEventMap)[]) {
       emitter.on(event, arg => this.emit(event, arg))
     }
   }
 
-  async start (): Promise<this> {
+  async start(): Promise<this> {
     if (this.#starting || this.#started) {
       return this
     }
@@ -130,7 +130,7 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this
   }
 
-  async stop (options: types.StopOptions = {}): Promise<void> {
+  async stop(options: types.StopOptions = {}): Promise<void> {
     if (this.#stoppingOn || this.#stopped) {
       return
     }
@@ -174,29 +174,33 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     await shutdown()
   }
 
-  send (request: types.Request): Promise<string | null>
-  send (name: string, data?: object | null, options?: types.SendOptions): Promise<string | null>
-  async send (...args: any[]): Promise<string | null> {
+  send(request: types.Request): Promise<string | null>
+  send(name: string, data?: object | null, options?: types.SendOptions): Promise<string | null>
+  async send(...args: any[]): Promise<string | null> {
     return await this.#manager.send(...args as Parameters<Manager['send']>)
   }
 
-  sendAfter (name: string, data: object | null, options: types.SendOptions | null, date: Date): Promise<string | null>
-  sendAfter (name: string, data: object | null, options: types.SendOptions | null, dateString: string): Promise<string | null>
-  sendAfter (name: string, data: object | null, options: types.SendOptions | null, seconds: number): Promise<string | null>
-  async sendAfter (name: string, data: object | null, options: types.SendOptions | null, after: Date | string | number): Promise<string | null> {
+  sendAfter(name: string, data: object | null, options: types.SendOptions | null, date: Date): Promise<string | null>
+  sendAfter(name: string, data: object | null, options: types.SendOptions | null, dateString: string): Promise<string | null>
+  sendAfter(name: string, data: object | null, options: types.SendOptions | null, seconds: number): Promise<string | null>
+  async sendAfter(name: string, data: object | null, options: types.SendOptions | null, after: Date | string | number): Promise<string | null> {
     return this.#manager.sendAfter(name, data, options, after)
   }
 
-  sendThrottled (name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
+  sendThrottled(name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
     return this.#manager.sendThrottled(name, data, options, seconds, key)
   }
 
-  sendDebounced (name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
+  sendDebounced(name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
     return this.#manager.sendDebounced(name, data, options, seconds, key)
   }
 
-  insert (name: string, jobs: types.JobInsert[], options?: types.InsertOptions): Promise<string[] | null> {
+  insert(name: string, jobs: types.JobInsert[], options?: types.InsertOptions): Promise<string[] | null> {
     return this.#manager.insert(name, jobs, options)
+  }
+
+  createFlow(jobs: types.FlowJob[], options?: types.ConnectionOptions): Promise<Record<string, string>> {
+    return this.#manager.createFlow(jobs, options)
   }
 
   fetch<T>(name: string, options: types.FetchOptions & { includeMetadata: true }): Promise<types.JobWithMetadata<T>[]>
@@ -208,67 +212,67 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
   work<ReqData, ResData = any>(name: string, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
   work<ReqData, ResData = any>(name: string, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData, ResData>): Promise<string>
   work<ReqData, ResData = any>(name: string, options: types.WorkOptions, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
-  work (...args: any[]): Promise<string> {
+  work(...args: any[]): Promise<string> {
     return this.#manager.work(...args as Parameters<Manager['work']>)
   }
 
-  offWork (name: string, options?: types.OffWorkOptions): Promise<void> {
+  offWork(name: string, options?: types.OffWorkOptions): Promise<void> {
     return this.#manager.offWork(name, options)
   }
 
-  notifyWorker (workerId: string): void {
+  notifyWorker(workerId: string): void {
     return this.#manager.notifyWorker(workerId)
   }
 
-  subscribe (event: string, name: string): Promise<void> {
+  subscribe(event: string, name: string): Promise<void> {
     return this.#manager.subscribe(event, name)
   }
 
-  unsubscribe (event: string, name: string): Promise<void> {
+  unsubscribe(event: string, name: string): Promise<void> {
     return this.#manager.unsubscribe(event, name)
   }
 
-  publish (event: string, data?: object, options?: types.SendOptions): Promise<void> {
+  publish(event: string, data?: object, options?: types.SendOptions): Promise<void> {
     return this.#manager.publish(event, data, options)
   }
 
-  cancel (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  cancel(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.cancel(name, id, options)
   }
 
-  resume (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  resume(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.resume(name, id, options)
   }
 
-  retry (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  retry(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.retry(name, id, options)
   }
 
-  deleteJob (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  deleteJob(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.deleteJob(name, id, options)
   }
 
-  deleteQueuedJobs (name: string): Promise<void> {
+  deleteQueuedJobs(name: string): Promise<void> {
     return this.#manager.deleteQueuedJobs(name)
   }
 
-  deleteStoredJobs (name: string): Promise<void> {
+  deleteStoredJobs(name: string): Promise<void> {
     return this.#manager.deleteStoredJobs(name)
   }
 
-  deleteAllJobs (name?: string): Promise<void> {
+  deleteAllJobs(name?: string): Promise<void> {
     return this.#manager.deleteAllJobs(name)
   }
 
-  complete (name: string, id: string | string[], data?: object | null, options?: types.CompleteOptions): Promise<types.CommandResponse> {
+  complete(name: string, id: string | string[], data?: object | null, options?: types.CompleteOptions): Promise<types.CommandResponse> {
     return this.#manager.complete(name, id, data, options)
   }
 
-  fail (name: string, id: string | string[], data?: object | null, options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  fail(name: string, id: string | string[], data?: object | null, options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.fail(name, id, data, options)
   }
 
-  touch (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  touch(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.touch(name, id, options)
   }
 
@@ -283,95 +287,103 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this.#manager.findJobs<T>(name, options)
   }
 
-  createQueue (name: string, options?: Omit<types.Queue, 'name'>): Promise<void> {
+  createQueue(name: string, options?: Omit<types.Queue, 'name'>): Promise<void> {
     return this.#manager.createQueue(name, options)
   }
 
-  getBlockedKeys (name: string): Promise<string[]> {
+  getBlockedKeys(name: string): Promise<string[]> {
     return this.#manager.getBlockedKeys(name)
   }
 
-  updateQueue (name: string, options?: types.UpdateQueueOptions): Promise<void> {
+  getDependencies(name: string, id: string, options?: types.ConnectionOptions): Promise<types.DependencyRef[]> {
+    return this.#manager.getDependencies(name, id, options)
+  }
+
+  getDependents(name: string, id: string, options?: types.ConnectionOptions): Promise<types.DependencyRef[]> {
+    return this.#manager.getDependents(name, id, options)
+  }
+
+  updateQueue(name: string, options?: types.UpdateQueueOptions): Promise<void> {
     return this.#manager.updateQueue(name, options)
   }
 
-  deleteQueue (name: string): Promise<void> {
+  deleteQueue(name: string): Promise<void> {
     return this.#manager.deleteQueue(name)
   }
 
-  getQueues (names?: string[]): Promise<types.QueueResult[]> {
+  getQueues(names?: string[]): Promise<types.QueueResult[]> {
     return this.#manager.getQueues()
   }
 
-  getQueue (name: string): Promise<types.QueueResult | null> {
+  getQueue(name: string): Promise<types.QueueResult | null> {
     return this.#manager.getQueue(name)
   }
 
-  getQueueStats (name: string): Promise<types.QueueResult> {
+  getQueueStats(name: string): Promise<types.QueueResult> {
     return this.#manager.getQueueStats(name)
   }
 
-  isMaintaining (): boolean {
+  isMaintaining(): boolean {
     return this.#boss.maintaining
   }
 
-  isBamWorking (): boolean {
+  isBamWorking(): boolean {
     return this.#bam.working
   }
 
-  isCheckingSkew (): boolean {
+  isCheckingSkew(): boolean {
     return this.#timekeeper.checkingSkew
   }
 
-  supervise (name?: string): Promise<void> {
+  supervise(name?: string): Promise<void> {
     return this.#boss.supervise(name)
   }
 
-  getWipData (options?: { includeInternal?: boolean }): types.WipData[] {
+  getWipData(options?: { includeInternal?: boolean }): types.WipData[] {
     return this.#manager.getWipData(options)
   }
 
-  getSpy<T = object> (name: string): JobSpyInterface<T> {
+  getSpy<T = object>(name: string): JobSpyInterface<T> {
     return this.#manager.getSpy<T>(name)
   }
 
-  clearSpies (): void {
+  clearSpies(): void {
     this.#manager.clearSpies()
   }
 
-  isInstalled (): Promise<boolean> {
+  isInstalled(): Promise<boolean> {
     return this.#contractor.isInstalled()
   }
 
-  schemaVersion (): Promise<number | null> {
+  schemaVersion(): Promise<number | null> {
     return this.#contractor.schemaVersion()
   }
 
-  schedule (name: string, cron: string, data?: object | null, options?: types.ScheduleOptions): Promise<void> {
+  schedule(name: string, cron: string, data?: object | null, options?: types.ScheduleOptions): Promise<void> {
     return this.#timekeeper.schedule(name, cron, data, options)
   }
 
-  unschedule (name: string, key?: string): Promise<void> {
+  unschedule(name: string, key?: string): Promise<void> {
     return this.#timekeeper.unschedule(name, key)
   }
 
-  getSchedules (name?: string, key?: string): Promise<types.Schedule[]> {
+  getSchedules(name?: string, key?: string): Promise<types.Schedule[]> {
     return this.#timekeeper.getSchedules(name, key)
   }
 
-  async getBamStatus (): Promise<types.BamStatusSummary[]> {
+  async getBamStatus(): Promise<types.BamStatusSummary[]> {
     const sql = plans.getBamStatus(this.#config.schema)
     const { rows } = await this.#db.executeSql(sql)
     return rows
   }
 
-  async getBamEntries (): Promise<types.BamEntry[]> {
+  async getBamEntries(): Promise<types.BamEntry[]> {
     const sql = plans.getBamEntries(this.#config.schema)
     const { rows } = await this.#db.executeSql(sql)
     return rows
   }
 
-  getDb (): types.IDatabase {
+  getDb(): types.IDatabase {
     if (this.#db) {
       return this.#db
     }
@@ -394,8 +406,10 @@ export type {
   ConstructorOptions,
   DatabaseOptions,
   FetchGroupConcurrencyOptions,
+  DependencyRef,
   FetchOptions,
   FindJobsOptions,
+  FlowJob,
   GroupConcurrencyConfig,
   GroupOptions,
   IDatabase as Db,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,15 +21,15 @@ export const events: types.Events = Object.freeze({
   bam: 'bam'
 })
 
-export function getConstructionPlans(schema?: string) {
+export function getConstructionPlans (schema?: string) {
   return Contractor.constructionPlans(schema)
 }
 
-export function getMigrationPlans(schema?: string, version?: number) {
+export function getMigrationPlans (schema?: string, version?: number) {
   return Contractor.migrationPlans(schema, version)
 }
 
-export function getRollbackPlans(schema?: string, version?: number) {
+export function getRollbackPlans (schema?: string, version?: number) {
   return Contractor.rollbackPlans(schema, version)
 }
 
@@ -46,9 +46,9 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
   #timekeeper: Timekeeper
   #bam: Bam
 
-  constructor(connectionString: string)
-  constructor(options: types.ConstructorOptions)
-  constructor(value: string | types.ConstructorOptions) {
+  constructor (connectionString: string)
+  constructor (options: types.ConstructorOptions)
+  constructor (value: string | types.ConstructorOptions) {
     super()
     this.#stoppingOn = null
     this.#stopped = true
@@ -86,13 +86,13 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     this.#bam = bam
   }
 
-  #promoteEvents(emitter: types.EventsMixin) {
+  #promoteEvents (emitter: types.EventsMixin) {
     for (const event of Object.values(emitter?.events) as (keyof types.PgBossEventMap)[]) {
       emitter.on(event, arg => this.emit(event, arg))
     }
   }
 
-  async start(): Promise<this> {
+  async start (): Promise<this> {
     if (this.#starting || this.#started) {
       return this
     }
@@ -130,7 +130,7 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this
   }
 
-  async stop(options: types.StopOptions = {}): Promise<void> {
+  async stop (options: types.StopOptions = {}): Promise<void> {
     if (this.#stoppingOn || this.#stopped) {
       return
     }
@@ -174,32 +174,32 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     await shutdown()
   }
 
-  send(request: types.Request): Promise<string | null>
-  send(name: string, data?: object | null, options?: types.SendOptions): Promise<string | null>
-  async send(...args: any[]): Promise<string | null> {
+  send (request: types.Request): Promise<string | null>
+  send (name: string, data?: object | null, options?: types.SendOptions): Promise<string | null>
+  async send (...args: any[]): Promise<string | null> {
     return await this.#manager.send(...args as Parameters<Manager['send']>)
   }
 
-  sendAfter(name: string, data: object | null, options: types.SendOptions | null, date: Date): Promise<string | null>
-  sendAfter(name: string, data: object | null, options: types.SendOptions | null, dateString: string): Promise<string | null>
-  sendAfter(name: string, data: object | null, options: types.SendOptions | null, seconds: number): Promise<string | null>
-  async sendAfter(name: string, data: object | null, options: types.SendOptions | null, after: Date | string | number): Promise<string | null> {
+  sendAfter (name: string, data: object | null, options: types.SendOptions | null, date: Date): Promise<string | null>
+  sendAfter (name: string, data: object | null, options: types.SendOptions | null, dateString: string): Promise<string | null>
+  sendAfter (name: string, data: object | null, options: types.SendOptions | null, seconds: number): Promise<string | null>
+  async sendAfter (name: string, data: object | null, options: types.SendOptions | null, after: Date | string | number): Promise<string | null> {
     return this.#manager.sendAfter(name, data, options, after)
   }
 
-  sendThrottled(name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
+  sendThrottled (name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
     return this.#manager.sendThrottled(name, data, options, seconds, key)
   }
 
-  sendDebounced(name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
+  sendDebounced (name: string, data: object | null, options: types.SendOptions | null, seconds: number, key?: string): Promise<string | null> {
     return this.#manager.sendDebounced(name, data, options, seconds, key)
   }
 
-  insert(name: string, jobs: types.JobInsert[], options?: types.InsertOptions): Promise<string[] | null> {
+  insert (name: string, jobs: types.JobInsert[], options?: types.InsertOptions): Promise<string[] | null> {
     return this.#manager.insert(name, jobs, options)
   }
 
-  createFlow(jobs: types.FlowJob[], options?: types.ConnectionOptions): Promise<Record<string, string>> {
+  createFlow (jobs: types.FlowJob[], options?: types.ConnectionOptions): Promise<Record<string, string>> {
     return this.#manager.createFlow(jobs, options)
   }
 
@@ -212,67 +212,67 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
   work<ReqData, ResData = any>(name: string, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
   work<ReqData, ResData = any>(name: string, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData, ResData>): Promise<string>
   work<ReqData, ResData = any>(name: string, options: types.WorkOptions, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
-  work(...args: any[]): Promise<string> {
+  work (...args: any[]): Promise<string> {
     return this.#manager.work(...args as Parameters<Manager['work']>)
   }
 
-  offWork(name: string, options?: types.OffWorkOptions): Promise<void> {
+  offWork (name: string, options?: types.OffWorkOptions): Promise<void> {
     return this.#manager.offWork(name, options)
   }
 
-  notifyWorker(workerId: string): void {
+  notifyWorker (workerId: string): void {
     return this.#manager.notifyWorker(workerId)
   }
 
-  subscribe(event: string, name: string): Promise<void> {
+  subscribe (event: string, name: string): Promise<void> {
     return this.#manager.subscribe(event, name)
   }
 
-  unsubscribe(event: string, name: string): Promise<void> {
+  unsubscribe (event: string, name: string): Promise<void> {
     return this.#manager.unsubscribe(event, name)
   }
 
-  publish(event: string, data?: object, options?: types.SendOptions): Promise<void> {
+  publish (event: string, data?: object, options?: types.SendOptions): Promise<void> {
     return this.#manager.publish(event, data, options)
   }
 
-  cancel(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  cancel (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.cancel(name, id, options)
   }
 
-  resume(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  resume (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.resume(name, id, options)
   }
 
-  retry(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  retry (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.retry(name, id, options)
   }
 
-  deleteJob(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  deleteJob (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.deleteJob(name, id, options)
   }
 
-  deleteQueuedJobs(name: string): Promise<void> {
+  deleteQueuedJobs (name: string): Promise<void> {
     return this.#manager.deleteQueuedJobs(name)
   }
 
-  deleteStoredJobs(name: string): Promise<void> {
+  deleteStoredJobs (name: string): Promise<void> {
     return this.#manager.deleteStoredJobs(name)
   }
 
-  deleteAllJobs(name?: string): Promise<void> {
+  deleteAllJobs (name?: string): Promise<void> {
     return this.#manager.deleteAllJobs(name)
   }
 
-  complete(name: string, id: string | string[], data?: object | null, options?: types.CompleteOptions): Promise<types.CommandResponse> {
+  complete (name: string, id: string | string[], data?: object | null, options?: types.CompleteOptions): Promise<types.CommandResponse> {
     return this.#manager.complete(name, id, data, options)
   }
 
-  fail(name: string, id: string | string[], data?: object | null, options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  fail (name: string, id: string | string[], data?: object | null, options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.fail(name, id, data, options)
   }
 
-  touch(name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
+  touch (name: string, id: string | string[], options?: types.ConnectionOptions): Promise<types.CommandResponse> {
     return this.#manager.touch(name, id, options)
   }
 
@@ -287,103 +287,103 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this.#manager.findJobs<T>(name, options)
   }
 
-  createQueue(name: string, options?: Omit<types.Queue, 'name'>): Promise<void> {
+  createQueue (name: string, options?: Omit<types.Queue, 'name'>): Promise<void> {
     return this.#manager.createQueue(name, options)
   }
 
-  getBlockedKeys(name: string): Promise<string[]> {
+  getBlockedKeys (name: string): Promise<string[]> {
     return this.#manager.getBlockedKeys(name)
   }
 
-  getDependencies(name: string, id: string, options?: types.ConnectionOptions): Promise<types.DependencyRef[]> {
+  getDependencies (name: string, id: string, options?: types.ConnectionOptions): Promise<types.DependencyRef[]> {
     return this.#manager.getDependencies(name, id, options)
   }
 
-  getDependents(name: string, id: string, options?: types.ConnectionOptions): Promise<types.DependencyRef[]> {
+  getDependents (name: string, id: string, options?: types.ConnectionOptions): Promise<types.DependencyRef[]> {
     return this.#manager.getDependents(name, id, options)
   }
 
-  updateQueue(name: string, options?: types.UpdateQueueOptions): Promise<void> {
+  updateQueue (name: string, options?: types.UpdateQueueOptions): Promise<void> {
     return this.#manager.updateQueue(name, options)
   }
 
-  deleteQueue(name: string): Promise<void> {
+  deleteQueue (name: string): Promise<void> {
     return this.#manager.deleteQueue(name)
   }
 
-  getQueues(names?: string[]): Promise<types.QueueResult[]> {
+  getQueues (names?: string[]): Promise<types.QueueResult[]> {
     return this.#manager.getQueues()
   }
 
-  getQueue(name: string): Promise<types.QueueResult | null> {
+  getQueue (name: string): Promise<types.QueueResult | null> {
     return this.#manager.getQueue(name)
   }
 
-  getQueueStats(name: string): Promise<types.QueueResult> {
+  getQueueStats (name: string): Promise<types.QueueResult> {
     return this.#manager.getQueueStats(name)
   }
 
-  isMaintaining(): boolean {
+  isMaintaining (): boolean {
     return this.#boss.maintaining
   }
 
-  isBamWorking(): boolean {
+  isBamWorking (): boolean {
     return this.#bam.working
   }
 
-  isCheckingSkew(): boolean {
+  isCheckingSkew (): boolean {
     return this.#timekeeper.checkingSkew
   }
 
-  supervise(name?: string): Promise<void> {
+  supervise (name?: string): Promise<void> {
     return this.#boss.supervise(name)
   }
 
-  getWipData(options?: { includeInternal?: boolean }): types.WipData[] {
+  getWipData (options?: { includeInternal?: boolean }): types.WipData[] {
     return this.#manager.getWipData(options)
   }
 
-  getSpy<T = object>(name: string): JobSpyInterface<T> {
+  getSpy<T = object> (name: string): JobSpyInterface<T> {
     return this.#manager.getSpy<T>(name)
   }
 
-  clearSpies(): void {
+  clearSpies (): void {
     this.#manager.clearSpies()
   }
 
-  isInstalled(): Promise<boolean> {
+  isInstalled (): Promise<boolean> {
     return this.#contractor.isInstalled()
   }
 
-  schemaVersion(): Promise<number | null> {
+  schemaVersion (): Promise<number | null> {
     return this.#contractor.schemaVersion()
   }
 
-  schedule(name: string, cron: string, data?: object | null, options?: types.ScheduleOptions): Promise<void> {
+  schedule (name: string, cron: string, data?: object | null, options?: types.ScheduleOptions): Promise<void> {
     return this.#timekeeper.schedule(name, cron, data, options)
   }
 
-  unschedule(name: string, key?: string): Promise<void> {
+  unschedule (name: string, key?: string): Promise<void> {
     return this.#timekeeper.unschedule(name, key)
   }
 
-  getSchedules(name?: string, key?: string): Promise<types.Schedule[]> {
+  getSchedules (name?: string, key?: string): Promise<types.Schedule[]> {
     return this.#timekeeper.getSchedules(name, key)
   }
 
-  async getBamStatus(): Promise<types.BamStatusSummary[]> {
+  async getBamStatus (): Promise<types.BamStatusSummary[]> {
     const sql = plans.getBamStatus(this.#config.schema)
     const { rows } = await this.#db.executeSql(sql)
     return rows
   }
 
-  async getBamEntries(): Promise<types.BamEntry[]> {
+  async getBamEntries (): Promise<types.BamEntry[]> {
     const sql = plans.getBamEntries(this.#config.schema)
     const { rows } = await this.#db.executeSql(sql)
     return rows
   }
 
-  getDb(): types.IDatabase {
+  getDb (): types.IDatabase {
     if (this.#db) {
       return this.#db
     }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -509,7 +509,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     await this.db.executeSql(sql, [event, name])
   }
 
-  publish(event: string, data?: object, options?: types.SendOptions): Promise<void>
+  publish (event: string, data?: object, options?: types.SendOptions): Promise<void>
   async publish (event: string, data?: object, options?: types.SendOptions): Promise<void> {
     assert(event, 'Missing required argument')
     const sql = plans.getQueuesForEvent(this.config.schema)
@@ -518,8 +518,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
     await Promise.allSettled(rows.map(({ name }) => this.send(name, data, options)))
   }
 
-  send(request: types.Request): Promise<string | null>
-  send(name: string, data?: object | null, options?: types.SendOptions | null): Promise<string | null>
+  send (request: types.Request): Promise<string | null>
+  send (name: string, data?: object | null, options?: types.SendOptions | null): Promise<string | null>
   async send (...args: any[]): Promise<string | null> {
     const result = Attorney.checkSendArgs(args)
 
@@ -627,6 +627,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
 
     if (singletonNextSlot) {
+      // delay starting by the offset to honor throttling config
       job.startAfter = this.getDebounceStartAfter(singletonSeconds!, this.timekeeper!.clockSkew)
       job.singletonOffset = singletonSeconds
 
@@ -647,13 +648,6 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return null
   }
 
-  async #markParentsBlocking (db: types.IDatabase, deps: types.DependencyRef[]) {
-    const uniqueParents = [...new Map(deps.map(d => [`${d.name}:${d.id}`, d])).values()]
-    const query = plans.markJobsBlocking(this.config.schema)
-    const parentRefs = uniqueParents.map(d => ({ parent_name: d.name, parent_id: d.id }))
-    await db.executeSql(query.text, [JSON.stringify(parentRefs)])
-  }
-
   async insert (
     name: string,
     jobs: types.JobInsert[],
@@ -672,18 +666,21 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
 
     const insertPayload = jobs.map(j => {
-      const { group, ...rest } = j
-      return {
-        ...rest,
-        groupId: group?.id ?? undefined,
-        groupTier: group?.tier ?? undefined
-      }
+      const {
+        blocked,
+        blocking,
+        pendingDependencies,
+        ...rest
+      } = j as types.JobInsert & { blocked?: unknown, blocking?: unknown, pendingDependencies?: unknown }
+
+      return rest
     })
 
     const db = this.assertDb(options)
 
     const spy = this.config.__test__enableSpies ? this.#spies.get(name) : undefined
 
+    // Return IDs if spy is active for this queue (needed for job tracking)
     const returnId = !!spy || !!options.returnId
 
     const sql = plans.insertJobs(this.config.schema, { table, name, returnId })
@@ -711,6 +708,27 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
 
     const execute = async (db: types.IDatabase): Promise<Record<string, string>> => {
+      const refToJob = new Map(jobs.map(job => [job.ref, job]))
+      const dependencyCountByRef = new Map<string, number>()
+      const parentRefs = new Set<string>()
+      const depRows: { child_name: string, child_id: string, parent_name: string, parent_id: string }[] = []
+
+      for (const job of jobs) {
+        const dependsOn = [...new Set(job.dependsOn ?? [])]
+        dependencyCountByRef.set(job.ref, dependsOn.length)
+
+        for (const depRef of dependsOn) {
+          const parentJob = refToJob.get(depRef)!
+          parentRefs.add(depRef)
+          depRows.push({
+            child_name: job.name,
+            child_id: refToId[job.ref],
+            parent_name: parentJob.name,
+            parent_id: refToId[depRef]
+          })
+        }
+      }
+
       const byQueue = new Map<string, types.FlowJob[]>()
       for (const job of jobs) {
         const group = byQueue.get(job.name) || []
@@ -722,7 +740,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
         const { table } = await this.getQueueCache(queueName)
 
         const insertPayload = queueJobs.map(j => {
-          const hasDeps = j.dependsOn && j.dependsOn.length > 0
+          const dependencyCount = dependencyCountByRef.get(j.ref) ?? 0
           return {
             id: refToId[j.ref],
             name: queueName,
@@ -742,35 +760,25 @@ class Manager extends EventEmitter implements types.EventsMixin {
             retryDelayMax: j.options?.retryDelayMax,
             heartbeatSeconds: j.options?.heartbeatSeconds,
             deadLetter: j.options?.deadLetter ?? undefined,
-            blocked: hasDeps || undefined
+            blocked: dependencyCount > 0 || undefined,
+            blocking: parentRefs.has(j.ref) || undefined,
+            pendingDependencies: dependencyCount || undefined
           }
         })
 
-        const sql = plans.insertJobs(this.config.schema, { table, name: queueName, returnId: false })
-        await db.executeSql(sql, [JSON.stringify(insertPayload)])
-      }
+        const sql = plans.insertJobs(this.config.schema, { table, name: queueName, returnId: true })
+        const { rows } = await db.executeSql(sql, [JSON.stringify(insertPayload)])
+        const insertedIds = new Set(rows.map(row => row.id))
+        const expectedIds = queueJobs.map(job => refToId[job.ref])
 
-      const depRows: { child_name: string, child_id: string, parent_name: string, parent_id: string }[] = []
-      const parentRefs: types.DependencyRef[] = []
-
-      for (const job of jobs) {
-        if (!job.dependsOn || job.dependsOn.length === 0) continue
-        for (const depRef of job.dependsOn) {
-          const parentJob = jobs.find(j => j.ref === depRef)!
-          depRows.push({
-            child_name: job.name,
-            child_id: refToId[job.ref],
-            parent_name: parentJob.name,
-            parent_id: refToId[depRef]
-          })
-          parentRefs.push({ name: parentJob.name, id: refToId[depRef] })
+        if (rows.length !== insertPayload.length || expectedIds.some(id => !insertedIds.has(id))) {
+          throw new Error(`createFlow failed to insert all jobs for queue ${queueName}`)
         }
       }
 
       if (depRows.length > 0) {
         const depSql = plans.insertDependencies(this.config.schema)
         await db.executeSql(depSql, [JSON.stringify(depRows)])
-        await this.#markParentsBlocking(db, parentRefs)
       }
 
       return refToId
@@ -1083,16 +1091,16 @@ class Manager extends EventEmitter implements types.EventsMixin {
     const { rows } = await this.db.executeSql(query.text, query.values)
 
     return Object.assign(queue, rows.at(0) ||
-      {
-        deferredCount: 0,
-        queuedCount: 0,
-        activeCount: 0,
-        totalCount: 0
-      }
+            {
+              deferredCount: 0,
+              queuedCount: 0,
+              activeCount: 0,
+              totalCount: 0
+            }
     )
   }
 
-  async getJobById<T> (name: string, id: string, options: types.ConnectionOptions = {}): Promise<types.JobWithMetadata<T> | null> {
+  async getJobById<T>(name: string, id: string, options: types.ConnectionOptions = {}): Promise<types.JobWithMetadata<T> | null> {
     Attorney.assertQueueName(name)
 
     const db = this.assertDb(options)
@@ -1110,7 +1118,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  async findJobs<T> (name: string, options: types.FindJobsOptions = {}): Promise<types.JobWithMetadata<T>[]> {
+  async findJobs<T>(name: string, options: types.FindJobsOptions = {}): Promise<types.JobWithMetadata<T>[]> {
     Attorney.assertQueueName(name)
 
     const db = this.assertDb(options)

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -509,7 +509,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     await this.db.executeSql(sql, [event, name])
   }
 
-  publish (event: string, data?: object, options?: types.SendOptions): Promise<void>
+  publish(event: string, data?: object, options?: types.SendOptions): Promise<void>
   async publish (event: string, data?: object, options?: types.SendOptions): Promise<void> {
     assert(event, 'Missing required argument')
     const sql = plans.getQueuesForEvent(this.config.schema)
@@ -518,8 +518,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
     await Promise.allSettled(rows.map(({ name }) => this.send(name, data, options)))
   }
 
-  send (request: types.Request): Promise<string | null>
-  send (name: string, data?: object | null, options?: types.SendOptions | null): Promise<string | null>
+  send(request: types.Request): Promise<string | null>
+  send(name: string, data?: object | null, options?: types.SendOptions | null): Promise<string | null>
   async send (...args: any[]): Promise<string | null> {
     const result = Attorney.checkSendArgs(args)
 
@@ -627,7 +627,6 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
 
     if (singletonNextSlot) {
-      // delay starting by the offset to honor throttling config
       job.startAfter = this.getDebounceStartAfter(singletonSeconds!, this.timekeeper!.clockSkew)
       job.singletonOffset = singletonSeconds
 
@@ -648,6 +647,13 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return null
   }
 
+  async #markParentsBlocking (db: types.IDatabase, deps: types.DependencyRef[]) {
+    const uniqueParents = [...new Map(deps.map(d => [`${d.name}:${d.id}`, d])).values()]
+    const query = plans.markJobsBlocking(this.config.schema)
+    const parentRefs = uniqueParents.map(d => ({ parent_name: d.name, parent_id: d.id }))
+    await db.executeSql(query.text, [JSON.stringify(parentRefs)])
+  }
+
   async insert (
     name: string,
     jobs: types.JobInsert[],
@@ -665,16 +671,24 @@ class Manager extends EventEmitter implements types.EventsMixin {
       }
     }
 
+    const insertPayload = jobs.map(j => {
+      const { group, ...rest } = j
+      return {
+        ...rest,
+        groupId: group?.id ?? undefined,
+        groupTier: group?.tier ?? undefined
+      }
+    })
+
     const db = this.assertDb(options)
 
     const spy = this.config.__test__enableSpies ? this.#spies.get(name) : undefined
 
-    // Return IDs if spy is active for this queue (needed for job tracking)
     const returnId = !!spy || !!options.returnId
 
     const sql = plans.insertJobs(this.config.schema, { table, name, returnId })
 
-    const { rows } = await db.executeSql(sql, [JSON.stringify(jobs)])
+    const { rows } = await db.executeSql(sql, [JSON.stringify(insertPayload)])
 
     if (rows.length) {
       if (spy) {
@@ -686,6 +700,91 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
 
     return null
+  }
+
+  async createFlow (jobs: types.FlowJob[], options: types.ConnectionOptions = {}): Promise<Record<string, string>> {
+    Attorney.validateFlowJobs(jobs)
+
+    const refToId: Record<string, string> = {}
+    for (const job of jobs) {
+      refToId[job.ref] = job.options?.id ?? randomUUID()
+    }
+
+    const execute = async (db: types.IDatabase): Promise<Record<string, string>> => {
+      const byQueue = new Map<string, types.FlowJob[]>()
+      for (const job of jobs) {
+        const group = byQueue.get(job.name) || []
+        group.push(job)
+        byQueue.set(job.name, group)
+      }
+
+      for (const [queueName, queueJobs] of byQueue) {
+        const { table } = await this.getQueueCache(queueName)
+
+        const insertPayload = queueJobs.map(j => {
+          const hasDeps = j.dependsOn && j.dependsOn.length > 0
+          return {
+            id: refToId[j.ref],
+            name: queueName,
+            data: j.data ?? null,
+            priority: j.options?.priority,
+            startAfter: j.options?.startAfter,
+            singletonKey: j.options?.singletonKey ?? undefined,
+            singletonSeconds: j.options?.singletonSeconds,
+            groupId: j.options?.group?.id ?? undefined,
+            groupTier: j.options?.group?.tier ?? undefined,
+            expireInSeconds: j.options?.expireInSeconds,
+            deleteAfterSeconds: j.options?.deleteAfterSeconds,
+            retentionSeconds: j.options?.retentionSeconds,
+            retryLimit: j.options?.retryLimit,
+            retryDelay: j.options?.retryDelay,
+            retryBackoff: j.options?.retryBackoff,
+            retryDelayMax: j.options?.retryDelayMax,
+            heartbeatSeconds: j.options?.heartbeatSeconds,
+            deadLetter: j.options?.deadLetter ?? undefined,
+            blocked: hasDeps || undefined
+          }
+        })
+
+        const sql = plans.insertJobs(this.config.schema, { table, name: queueName, returnId: false })
+        await db.executeSql(sql, [JSON.stringify(insertPayload)])
+      }
+
+      const depRows: { child_name: string, child_id: string, parent_name: string, parent_id: string }[] = []
+      const parentRefs: types.DependencyRef[] = []
+
+      for (const job of jobs) {
+        if (!job.dependsOn || job.dependsOn.length === 0) continue
+        for (const depRef of job.dependsOn) {
+          const parentJob = jobs.find(j => j.ref === depRef)!
+          depRows.push({
+            child_name: job.name,
+            child_id: refToId[job.ref],
+            parent_name: parentJob.name,
+            parent_id: refToId[depRef]
+          })
+          parentRefs.push({ name: parentJob.name, id: refToId[depRef] })
+        }
+      }
+
+      if (depRows.length > 0) {
+        const depSql = plans.insertDependencies(this.config.schema)
+        await db.executeSql(depSql, [JSON.stringify(depRows)])
+        await this.#markParentsBlocking(db, parentRefs)
+      }
+
+      return refToId
+    }
+
+    if (options.db) {
+      return execute(options.db)
+    }
+
+    if (this.db._pgbdb) {
+      return (this.db as any).withTransaction(execute)
+    }
+
+    return execute(this.db)
   }
 
   getDebounceStartAfter (singletonSeconds: number, clockOffset: number) {
@@ -984,16 +1083,16 @@ class Manager extends EventEmitter implements types.EventsMixin {
     const { rows } = await this.db.executeSql(query.text, query.values)
 
     return Object.assign(queue, rows.at(0) ||
-            {
-              deferredCount: 0,
-              queuedCount: 0,
-              activeCount: 0,
-              totalCount: 0
-            }
+      {
+        deferredCount: 0,
+        queuedCount: 0,
+        activeCount: 0,
+        totalCount: 0
+      }
     )
   }
 
-  async getJobById<T>(name: string, id: string, options: types.ConnectionOptions = {}): Promise<types.JobWithMetadata<T> | null> {
+  async getJobById<T> (name: string, id: string, options: types.ConnectionOptions = {}): Promise<types.JobWithMetadata<T> | null> {
     Attorney.assertQueueName(name)
 
     const db = this.assertDb(options)
@@ -1011,7 +1110,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  async findJobs<T>(name: string, options: types.FindJobsOptions = {}): Promise<types.JobWithMetadata<T>[]> {
+  async findJobs<T> (name: string, options: types.FindJobsOptions = {}): Promise<types.JobWithMetadata<T>[]> {
     Attorney.assertQueueName(name)
 
     const db = this.assertDb(options)
@@ -1035,6 +1134,22 @@ class Manager extends EventEmitter implements types.EventsMixin {
     const result = await db.executeSql(sql, values)
 
     return result?.rows || []
+  }
+
+  async getDependencies (name: string, id: string, options: types.ConnectionOptions = {}): Promise<types.DependencyRef[]> {
+    Attorney.assertQueueName(name)
+    const db = this.assertDb(options)
+    const sql = plans.getDependencies(this.config.schema)
+    const { rows } = await db.executeSql(sql, [name, id])
+    return rows.map((r: any) => ({ name: r.parentName, id: r.parentId }))
+  }
+
+  async getDependents (name: string, id: string, options: types.ConnectionOptions = {}): Promise<types.DependencyRef[]> {
+    Attorney.assertQueueName(name)
+    const db = this.assertDb(options)
+    const sql = plans.getDependents(this.config.schema)
+    const { rows } = await db.executeSql(sql, [name, id])
+    return rows.map((r: any) => ({ name: r.childName, id: r.childId }))
   }
 
   private assertDb (options: types.ConnectionOptions) {

--- a/src/migrationStore.ts
+++ b/src/migrationStore.ts
@@ -820,6 +820,277 @@ function getAll (schema: string): types.Migration[] {
         `ALTER TABLE ${schema}.job DROP COLUMN heartbeat_seconds`,
         `ALTER TABLE ${schema}.job DROP COLUMN heartbeat_on`
       ]
+    },
+    {
+      release: '12.15.0',
+      version: 31,
+      previous: 30,
+      install: [
+        `ALTER TABLE ${schema}.job ADD COLUMN blocked boolean NOT NULL DEFAULT false`,
+        `ALTER TABLE ${schema}.job ADD COLUMN blocking boolean NOT NULL DEFAULT false`,
+        `
+        CREATE TABLE IF NOT EXISTS ${schema}.job_dependency (
+          child_name text NOT NULL,
+          child_id uuid NOT NULL,
+          parent_name text NOT NULL,
+          parent_id uuid NOT NULL,
+          PRIMARY KEY (child_name, child_id, parent_name, parent_id)
+        )
+        `,
+        `CREATE INDEX job_dep_parent_idx ON ${schema}.job_dependency (parent_name, parent_id)`,
+        `SELECT ${schema}.job_table_run($cmd$DROP INDEX IF EXISTS ${schema}.job_i5$cmd$)`,
+        `SELECT ${schema}.job_table_run($cmd$CREATE INDEX job_i5 ON ${schema}.job (name, start_after) INCLUDE (priority, created_on, id) WHERE state < 'active' AND NOT blocked$cmd$)`,
+        `
+        CREATE OR REPLACE FUNCTION ${schema}.create_queue(queue_name text, options jsonb)
+        RETURNS VOID AS
+        $$
+        DECLARE
+          tablename varchar := CASE WHEN options->>'partition' = 'true'
+                                THEN 'j' || encode(sha224(queue_name::bytea), 'hex')
+                                ELSE 'job_common'
+                                END;
+          queue_created_on timestamptz;
+        BEGIN
+
+          WITH q as (
+            INSERT INTO ${schema}.queue (
+              name,
+              policy,
+              retry_limit,
+              retry_delay,
+              retry_backoff,
+              retry_delay_max,
+              expire_seconds,
+              retention_seconds,
+              deletion_seconds,
+              warning_queued,
+              dead_letter,
+              partition,
+              table_name,
+              heartbeat_seconds
+            )
+            VALUES (
+              queue_name,
+              options->>'policy',
+              COALESCE((options->>'retryLimit')::int, 2),
+              COALESCE((options->>'retryDelay')::int, 0),
+              COALESCE((options->>'retryBackoff')::bool, false),
+              (options->>'retryDelayMax')::int,
+              COALESCE((options->>'expireInSeconds')::int, 900),
+              COALESCE((options->>'retentionSeconds')::int, 1209600),
+              COALESCE((options->>'deleteAfterSeconds')::int, 604800),
+              COALESCE((options->>'warningQueueSize')::int, 0),
+              options->>'deadLetter',
+              COALESCE((options->>'partition')::bool, false),
+              tablename,
+              (options->>'heartbeatSeconds')::int
+            )
+            ON CONFLICT DO NOTHING
+            RETURNING created_on
+          )
+          SELECT created_on into queue_created_on from q;
+
+          IF queue_created_on IS NULL OR options->>'partition' IS DISTINCT FROM 'true' THEN
+            RETURN;
+          END IF;
+
+          EXECUTE format('CREATE TABLE ${schema}.%I (LIKE ${schema}.job INCLUDING DEFAULTS)', tablename);
+
+          EXECUTE ${schema}.job_table_format($cmd$ALTER TABLE ${schema}.job ADD PRIMARY KEY (name, id)$cmd$, tablename);
+          EXECUTE ${schema}.job_table_format($cmd$ALTER TABLE ${schema}.job ADD CONSTRAINT q_fkey FOREIGN KEY (name) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED$cmd$, tablename);
+          EXECUTE ${schema}.job_table_format($cmd$ALTER TABLE ${schema}.job ADD CONSTRAINT dlq_fkey FOREIGN KEY (dead_letter) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED$cmd$, tablename);
+
+          EXECUTE ${schema}.job_table_format($cmd$CREATE INDEX job_i5 ON ${schema}.job (name, start_after) INCLUDE (priority, created_on, id) WHERE state < 'active' AND NOT blocked$cmd$, tablename);
+          EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i4 ON ${schema}.job (name, singleton_on, COALESCE(singleton_key, '')) WHERE state <> 'cancelled' AND singleton_on IS NOT NULL$cmd$, tablename);
+          EXECUTE ${schema}.job_table_format($cmd$CREATE INDEX job_i7 ON ${schema}.job (name, group_id) WHERE state = 'active' AND group_id IS NOT NULL$cmd$, tablename);
+
+          IF options->>'policy' = 'short' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i1 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state = 'created' AND policy = 'short'$cmd$, tablename);
+          ELSIF options->>'policy' = 'singleton' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i2 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state = 'active' AND policy = 'singleton'$cmd$, tablename);
+          ELSIF options->>'policy' = 'stately' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i3 ON ${schema}.job (name, state, COALESCE(singleton_key, '')) WHERE state <= 'active' AND policy = 'stately'$cmd$, tablename);
+          ELSIF options->>'policy' = 'exclusive' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i6 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state <= 'active' AND policy = 'exclusive'$cmd$, tablename);
+          ELSIF options->>'policy' = 'key_strict_fifo' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i8 ON ${schema}.job (name, singleton_key) WHERE state IN ('active', 'retry', 'failed') AND policy = 'key_strict_fifo'$cmd$, tablename);
+            EXECUTE ${schema}.job_table_format($cmd$ALTER TABLE ${schema}.job ADD CONSTRAINT job_key_strict_fifo_singleton_key_check CHECK (NOT (policy = 'key_strict_fifo' AND singleton_key IS NULL))$cmd$, tablename);
+          END IF;
+
+          EXECUTE format('ALTER TABLE ${schema}.%I ADD CONSTRAINT cjc CHECK (name=%L)', tablename, queue_name);
+          EXECUTE format('ALTER TABLE ${schema}.job ATTACH PARTITION ${schema}.%I FOR VALUES IN (%L)', tablename, queue_name);
+        END;
+        $$
+        LANGUAGE plpgsql;
+        `,
+        `
+        CREATE OR REPLACE FUNCTION ${schema}.complete_jobs(
+          queue_name text,
+          job_table text,
+          job_ids uuid[],
+          job_output jsonb,
+          include_queued boolean DEFAULT false
+        )
+        RETURNS bigint AS
+        $$
+        DECLARE
+          completed_count bigint;
+          has_blocking boolean;
+        BEGIN
+          EXECUTE format(
+            'CREATE TEMP TABLE _completed ON COMMIT DROP AS
+             WITH results AS (
+               UPDATE %I.%I
+               SET completed_on = now(),
+                   state = ''completed'',
+                   output = $1
+               WHERE name = $2
+                 AND id IN (SELECT UNNEST($3))
+                 AND %s
+               RETURNING *
+             )
+             SELECT * FROM results',
+            '${schema}', job_table,
+            CASE WHEN include_queued
+              THEN 'state < ''completed'''
+              ELSE 'state = ''active'''
+            END
+          ) USING job_output, queue_name, job_ids;
+
+          SELECT COUNT(*) INTO completed_count FROM _completed;
+
+          IF completed_count = 0 THEN
+            RETURN 0;
+          END IF;
+
+          SELECT EXISTS(SELECT 1 FROM _completed WHERE blocking = true)
+            INTO has_blocking;
+
+          IF has_blocking THEN
+            EXECUTE format(
+              'UPDATE %I.job j
+               SET blocked = false
+               FROM (
+                 SELECT DISTINCT d.child_name, d.child_id
+                 FROM %I.job_dependency d
+                 JOIN _completed c ON c.name = d.parent_name AND c.id = d.parent_id
+                 WHERE c.blocking = true
+               ) ct
+               WHERE j.name = ct.child_name
+                 AND j.id = ct.child_id
+                 AND j.blocked = true
+                 AND NOT EXISTS (
+                   SELECT 1
+                   FROM %I.job_dependency d2
+                   JOIN %I.job p ON p.name = d2.parent_name AND p.id = d2.parent_id
+                   LEFT JOIN _completed r ON r.name = p.name AND r.id = p.id
+                   WHERE d2.child_name = ct.child_name
+                     AND d2.child_id = ct.child_id
+                     AND p.state <> ''completed''
+                     AND r.id IS NULL
+                 )',
+              '${schema}', '${schema}', '${schema}', '${schema}'
+            );
+          END IF;
+
+          RETURN completed_count;
+        END;
+        $$
+        LANGUAGE plpgsql;
+        `
+      ],
+      uninstall: [
+        `DROP FUNCTION IF EXISTS ${schema}.complete_jobs`,
+        `DROP INDEX IF EXISTS ${schema}.job_dep_parent_idx`,
+        `DROP TABLE IF EXISTS ${schema}.job_dependency`,
+        `
+        CREATE OR REPLACE FUNCTION ${schema}.create_queue(queue_name text, options jsonb)
+        RETURNS VOID AS
+        $$
+        DECLARE
+          tablename varchar := CASE WHEN options->>'partition' = 'true'
+                                THEN 'j' || encode(sha224(queue_name::bytea), 'hex')
+                                ELSE 'job_common'
+                                END;
+          queue_created_on timestamptz;
+        BEGIN
+
+          WITH q as (
+            INSERT INTO ${schema}.queue (
+              name,
+              policy,
+              retry_limit,
+              retry_delay,
+              retry_backoff,
+              retry_delay_max,
+              expire_seconds,
+              retention_seconds,
+              deletion_seconds,
+              warning_queued,
+              dead_letter,
+              partition,
+              table_name,
+              heartbeat_seconds
+            )
+            VALUES (
+              queue_name,
+              options->>'policy',
+              COALESCE((options->>'retryLimit')::int, 2),
+              COALESCE((options->>'retryDelay')::int, 0),
+              COALESCE((options->>'retryBackoff')::bool, false),
+              (options->>'retryDelayMax')::int,
+              COALESCE((options->>'expireInSeconds')::int, 900),
+              COALESCE((options->>'retentionSeconds')::int, 1209600),
+              COALESCE((options->>'deleteAfterSeconds')::int, 604800),
+              COALESCE((options->>'warningQueueSize')::int, 0),
+              options->>'deadLetter',
+              COALESCE((options->>'partition')::bool, false),
+              tablename,
+              (options->>'heartbeatSeconds')::int
+            )
+            ON CONFLICT DO NOTHING
+            RETURNING created_on
+          )
+          SELECT created_on into queue_created_on from q;
+
+          IF queue_created_on IS NULL OR options->>'partition' IS DISTINCT FROM 'true' THEN
+            RETURN;
+          END IF;
+
+          EXECUTE format('CREATE TABLE ${schema}.%I (LIKE ${schema}.job INCLUDING DEFAULTS)', tablename);
+
+          EXECUTE ${schema}.job_table_format($cmd$ALTER TABLE ${schema}.job ADD PRIMARY KEY (name, id)$cmd$, tablename);
+          EXECUTE ${schema}.job_table_format($cmd$ALTER TABLE ${schema}.job ADD CONSTRAINT q_fkey FOREIGN KEY (name) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED$cmd$, tablename);
+          EXECUTE ${schema}.job_table_format($cmd$ALTER TABLE ${schema}.job ADD CONSTRAINT dlq_fkey FOREIGN KEY (dead_letter) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED$cmd$, tablename);
+
+          EXECUTE ${schema}.job_table_format($cmd$CREATE INDEX job_i5 ON ${schema}.job (name, start_after) INCLUDE (priority, created_on, id) WHERE state < 'active'$cmd$, tablename);
+          EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i4 ON ${schema}.job (name, singleton_on, COALESCE(singleton_key, '')) WHERE state <> 'cancelled' AND singleton_on IS NOT NULL$cmd$, tablename);
+          EXECUTE ${schema}.job_table_format($cmd$CREATE INDEX job_i7 ON ${schema}.job (name, group_id) WHERE state = 'active' AND group_id IS NOT NULL$cmd$, tablename);
+
+          IF options->>'policy' = 'short' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i1 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state = 'created' AND policy = 'short'$cmd$, tablename);
+          ELSIF options->>'policy' = 'singleton' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i2 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state = 'active' AND policy = 'singleton'$cmd$, tablename);
+          ELSIF options->>'policy' = 'stately' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i3 ON ${schema}.job (name, state, COALESCE(singleton_key, '')) WHERE state <= 'active' AND policy = 'stately'$cmd$, tablename);
+          ELSIF options->>'policy' = 'exclusive' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i6 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state <= 'active' AND policy = 'exclusive'$cmd$, tablename);
+          ELSIF options->>'policy' = 'key_strict_fifo' THEN
+            EXECUTE ${schema}.job_table_format($cmd$CREATE UNIQUE INDEX job_i8 ON ${schema}.job (name, singleton_key) WHERE state IN ('active', 'retry', 'failed') AND policy = 'key_strict_fifo'$cmd$, tablename);
+            EXECUTE ${schema}.job_table_format($cmd$ALTER TABLE ${schema}.job ADD CONSTRAINT job_key_strict_fifo_singleton_key_check CHECK (NOT (policy = 'key_strict_fifo' AND singleton_key IS NULL))$cmd$, tablename);
+          END IF;
+
+          EXECUTE format('ALTER TABLE ${schema}.%I ADD CONSTRAINT cjc CHECK (name=%L)', tablename, queue_name);
+          EXECUTE format('ALTER TABLE ${schema}.job ATTACH PARTITION ${schema}.%I FOR VALUES IN (%L)', tablename, queue_name);
+        END;
+        $$
+        LANGUAGE plpgsql;
+        `,
+        `SELECT ${schema}.job_table_run($cmd$DROP INDEX IF EXISTS ${schema}.job_i5$cmd$)`,
+        `SELECT ${schema}.job_table_run($cmd$CREATE INDEX job_i5 ON ${schema}.job (name, start_after) INCLUDE (priority, created_on, id) WHERE state < 'active'$cmd$)`,
+        `ALTER TABLE ${schema}.job DROP COLUMN blocking`,
+        `ALTER TABLE ${schema}.job DROP COLUMN blocked`
+      ]
     }
   ]
 }

--- a/src/migrationStore.ts
+++ b/src/migrationStore.ts
@@ -828,6 +828,7 @@ function getAll (schema: string): types.Migration[] {
       install: [
         `ALTER TABLE ${schema}.job ADD COLUMN blocked boolean NOT NULL DEFAULT false`,
         `ALTER TABLE ${schema}.job ADD COLUMN blocking boolean NOT NULL DEFAULT false`,
+        `ALTER TABLE ${schema}.job ADD COLUMN pending_dependencies int NOT NULL DEFAULT 0`,
         `
         CREATE TABLE IF NOT EXISTS ${schema}.job_dependency (
           child_name text NOT NULL,
@@ -922,85 +923,9 @@ function getAll (schema: string): types.Migration[] {
         END;
         $$
         LANGUAGE plpgsql;
-        `,
-        `
-        CREATE OR REPLACE FUNCTION ${schema}.complete_jobs(
-          queue_name text,
-          job_table text,
-          job_ids uuid[],
-          job_output jsonb,
-          include_queued boolean DEFAULT false
-        )
-        RETURNS bigint AS
-        $$
-        DECLARE
-          completed_count bigint;
-          has_blocking boolean;
-        BEGIN
-          EXECUTE format(
-            'CREATE TEMP TABLE _completed ON COMMIT DROP AS
-             WITH results AS (
-               UPDATE %I.%I
-               SET completed_on = now(),
-                   state = ''completed'',
-                   output = $1
-               WHERE name = $2
-                 AND id IN (SELECT UNNEST($3))
-                 AND %s
-               RETURNING *
-             )
-             SELECT * FROM results',
-            '${schema}', job_table,
-            CASE WHEN include_queued
-              THEN 'state < ''completed'''
-              ELSE 'state = ''active'''
-            END
-          ) USING job_output, queue_name, job_ids;
-
-          SELECT COUNT(*) INTO completed_count FROM _completed;
-
-          IF completed_count = 0 THEN
-            RETURN 0;
-          END IF;
-
-          SELECT EXISTS(SELECT 1 FROM _completed WHERE blocking = true)
-            INTO has_blocking;
-
-          IF has_blocking THEN
-            EXECUTE format(
-              'UPDATE %I.job j
-               SET blocked = false
-               FROM (
-                 SELECT DISTINCT d.child_name, d.child_id
-                 FROM %I.job_dependency d
-                 JOIN _completed c ON c.name = d.parent_name AND c.id = d.parent_id
-                 WHERE c.blocking = true
-               ) ct
-               WHERE j.name = ct.child_name
-                 AND j.id = ct.child_id
-                 AND j.blocked = true
-                 AND NOT EXISTS (
-                   SELECT 1
-                   FROM %I.job_dependency d2
-                   JOIN %I.job p ON p.name = d2.parent_name AND p.id = d2.parent_id
-                   LEFT JOIN _completed r ON r.name = p.name AND r.id = p.id
-                   WHERE d2.child_name = ct.child_name
-                     AND d2.child_id = ct.child_id
-                     AND p.state <> ''completed''
-                     AND r.id IS NULL
-                 )',
-              '${schema}', '${schema}', '${schema}', '${schema}'
-            );
-          END IF;
-
-          RETURN completed_count;
-        END;
-        $$
-        LANGUAGE plpgsql;
         `
       ],
       uninstall: [
-        `DROP FUNCTION IF EXISTS ${schema}.complete_jobs`,
         `DROP INDEX IF EXISTS ${schema}.job_dep_parent_idx`,
         `DROP TABLE IF EXISTS ${schema}.job_dependency`,
         `
@@ -1088,6 +1013,7 @@ function getAll (schema: string): types.Migration[] {
         `,
         `SELECT ${schema}.job_table_run($cmd$DROP INDEX IF EXISTS ${schema}.job_i5$cmd$)`,
         `SELECT ${schema}.job_table_run($cmd$CREATE INDEX job_i5 ON ${schema}.job (name, start_after) INCLUDE (priority, created_on, id) WHERE state < 'active'$cmd$)`,
+        `ALTER TABLE ${schema}.job DROP COLUMN pending_dependencies`,
         `ALTER TABLE ${schema}.job DROP COLUMN blocking`,
         `ALTER TABLE ${schema}.job DROP COLUMN blocked`
       ]

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -44,7 +44,7 @@ const QUEUE_DEFAULTS = {
 
 const COMMON_JOB_TABLE = 'job_common'
 
-function create (schema: string, version: number, options?: { createSchema?: boolean }) {
+function create(schema: string, version: number, options?: { createSchema?: boolean }) {
   const commands = [
     options?.createSchema ? createSchema(schema) : '',
     createEnumJobState(schema),
@@ -67,8 +67,12 @@ function create (schema: string, version: number, options?: { createSchema?: boo
     createTableWarning(schema),
     createIndexWarning(schema),
 
+    createTableJobDependency(schema),
+    createIndexJobDependencyParent(schema),
+
     createQueueFunction(schema),
     deleteQueueFunction(schema),
+    createCompleteJobsFunction(schema),
 
     insertVersion(schema, version)
   ]
@@ -76,11 +80,11 @@ function create (schema: string, version: number, options?: { createSchema?: boo
   return locked(schema, commands)
 }
 
-function createSchema (schema: string) {
+function createSchema(schema: string) {
   return `CREATE SCHEMA IF NOT EXISTS ${schema}`
 }
 
-function createEnumJobState (schema: string) {
+function createEnumJobState(schema: string) {
   // ENUM definition order is important
   // base type is numeric and first values are less than last values
   return `
@@ -95,7 +99,7 @@ function createEnumJobState (schema: string) {
   `
 }
 
-function createTableVersion (schema: string) {
+function createTableVersion(schema: string) {
   return `
     CREATE TABLE ${schema}.version (
       version int primary key,
@@ -105,7 +109,7 @@ function createTableVersion (schema: string) {
   `
 }
 
-function createTableQueue (schema: string) {
+function createTableQueue(schema: string) {
   return `
     CREATE TABLE ${schema}.queue (
       name text NOT NULL,
@@ -136,7 +140,7 @@ function createTableQueue (schema: string) {
   `
 }
 
-function createTableSchedule (schema: string) {
+function createTableSchedule(schema: string) {
   return `
     CREATE TABLE ${schema}.schedule (
       name text REFERENCES ${schema}.queue ON DELETE CASCADE,
@@ -152,7 +156,7 @@ function createTableSchedule (schema: string) {
   `
 }
 
-function createTableSubscription (schema: string) {
+function createTableSubscription(schema: string) {
   return `
     CREATE TABLE ${schema}.subscription (
       event text not null,
@@ -164,7 +168,7 @@ function createTableSubscription (schema: string) {
   `
 }
 
-function createTableBam (schema: string) {
+function createTableBam(schema: string) {
   return `
     CREATE TABLE ${schema}.bam (
       id uuid PRIMARY KEY default gen_random_uuid(),
@@ -182,7 +186,7 @@ function createTableBam (schema: string) {
   `
 }
 
-function createTableWarning (schema: string) {
+function createTableWarning(schema: string) {
   return `
     CREATE TABLE ${schema}.warning (
       id uuid PRIMARY KEY default gen_random_uuid(),
@@ -194,11 +198,27 @@ function createTableWarning (schema: string) {
   `
 }
 
-function createIndexWarning (schema: string) {
+function createIndexWarning(schema: string) {
   return `CREATE INDEX warning_i1 ON ${schema}.warning (created_on DESC)`
 }
 
-function jobTableFormatFunction (schema: string) {
+function createTableJobDependency(schema: string) {
+  return `
+    CREATE TABLE ${schema}.job_dependency (
+      child_name text NOT NULL,
+      child_id uuid NOT NULL,
+      parent_name text NOT NULL,
+      parent_id uuid NOT NULL,
+      PRIMARY KEY (child_name, child_id, parent_name, parent_id)
+    )
+  `
+}
+
+function createIndexJobDependencyParent(schema: string) {
+  return `CREATE INDEX job_dep_parent_idx ON ${schema}.job_dependency (parent_name, parent_id)`
+}
+
+function jobTableFormatFunction(schema: string) {
   return `
     CREATE FUNCTION ${schema}.job_table_format(command text, table_name text)
     RETURNS text AS
@@ -215,7 +235,7 @@ function jobTableFormatFunction (schema: string) {
   `
 }
 
-function jobTableRunFunction (schema: string) {
+function jobTableRunFunction(schema: string) {
   return `
     CREATE FUNCTION ${schema}.job_table_run(command text, tbl_name text DEFAULT NULL, queue_name text DEFAULT NULL)
     RETURNS VOID AS
@@ -244,7 +264,7 @@ function jobTableRunFunction (schema: string) {
   `
 }
 
-function jobTableRunAsyncFunction (schema: string) {
+function jobTableRunAsyncFunction(schema: string) {
   return `
     CREATE FUNCTION ${schema}.job_table_run_async(command_name text, version int, command text, tbl_name text DEFAULT NULL, queue_name text DEFAULT NULL)
     RETURNS VOID AS
@@ -291,7 +311,7 @@ function jobTableRunAsyncFunction (schema: string) {
   `
 }
 
-function createTableJob (schema: string) {
+function createTableJob(schema: string) {
   return `
     CREATE TABLE ${schema}.job (
       id uuid not null default gen_random_uuid(),
@@ -319,7 +339,9 @@ function createTableJob (schema: string) {
       dead_letter text,
       policy text,
       heartbeat_on timestamp with time zone,
-      heartbeat_seconds int
+      heartbeat_seconds int,
+      blocked boolean not null default false,
+      blocking boolean not null default false
     ) PARTITION BY LIST (name)
   `
 }
@@ -344,10 +366,12 @@ const JOB_COLUMNS_ALL = `${JOB_COLUMNS_MIN},
   completed_on as "completedOn",
   keep_until as "keepUntil",
   dead_letter as "deadLetter",
+  blocked,
+  blocking,
   output
 `
 
-function createTableJobCommon (schema: string) {
+function createTableJobCommon(schema: string) {
   return `
     CREATE TABLE ${schema}.${COMMON_JOB_TABLE} (LIKE ${schema}.job INCLUDING GENERATED INCLUDING DEFAULTS);
 
@@ -368,7 +392,7 @@ function createTableJobCommon (schema: string) {
   `
 }
 
-function createQueueFunction (schema: string) {
+function createQueueFunction(schema: string) {
   return `
     CREATE FUNCTION ${schema}.create_queue(queue_name text, options jsonb)
     RETURNS VOID AS
@@ -454,7 +478,7 @@ function createQueueFunction (schema: string) {
   `
 }
 
-function deleteQueueFunction (schema: string) {
+function deleteQueueFunction(schema: string) {
   return `
     CREATE FUNCTION ${schema}.delete_queue(queue_name text)
     RETURNS VOID AS
@@ -481,81 +505,81 @@ function deleteQueueFunction (schema: string) {
   `
 }
 
-function createQueue (schema: string, name: string, options: unknown) {
+function createQueue(schema: string, name: string, options: unknown) {
   const sql = `SELECT ${schema}.create_queue('${name}', '${JSON.stringify(options)}'::jsonb)`
   return locked(schema, sql, 'create-queue')
 }
 
-function deleteQueue (schema: string, name: string) {
+function deleteQueue(schema: string, name: string) {
   const sql = `SELECT ${schema}.delete_queue('${name}')`
   return locked(schema, sql, 'delete-queue')
 }
 
-function createPrimaryKeyJob (schema: string) {
+function createPrimaryKeyJob(schema: string) {
   return `ALTER TABLE ${schema}.job ADD PRIMARY KEY (name, id)`
 }
 
-function createQueueForeignKeyJob (schema: string) {
+function createQueueForeignKeyJob(schema: string) {
   return `ALTER TABLE ${schema}.job ADD CONSTRAINT q_fkey FOREIGN KEY (name) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED`
 }
 
-function createQueueForeignKeyJobDeadLetter (schema: string) {
+function createQueueForeignKeyJobDeadLetter(schema: string) {
   return `ALTER TABLE ${schema}.job ADD CONSTRAINT dlq_fkey FOREIGN KEY (dead_letter) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED`
 }
 
-function createIndexJobPolicyShort (schema: string) {
+function createIndexJobPolicyShort(schema: string) {
   return `CREATE UNIQUE INDEX job_i1 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state = '${JOB_STATES.created}' AND policy = '${QUEUE_POLICIES.short}'`
 }
 
-function createIndexJobPolicySingleton (schema: string) {
+function createIndexJobPolicySingleton(schema: string) {
   return `CREATE UNIQUE INDEX job_i2 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state = '${JOB_STATES.active}' AND policy = '${QUEUE_POLICIES.singleton}'`
 }
 
-function createIndexJobPolicyStately (schema: string) {
+function createIndexJobPolicyStately(schema: string) {
   return `CREATE UNIQUE INDEX job_i3 ON ${schema}.job (name, state, COALESCE(singleton_key, '')) WHERE state <= '${JOB_STATES.active}' AND policy = '${QUEUE_POLICIES.stately}'`
 }
 
-function createIndexJobThrottle (schema: string) {
+function createIndexJobThrottle(schema: string) {
   return `CREATE UNIQUE INDEX job_i4 ON ${schema}.job (name, singleton_on, COALESCE(singleton_key, '')) WHERE state <> '${JOB_STATES.cancelled}' AND singleton_on IS NOT NULL`
 }
 
-function createIndexJobFetch (schema: string) {
-  return `CREATE INDEX job_i5 ON ${schema}.job (name, start_after) INCLUDE (priority, created_on, id) WHERE state < '${JOB_STATES.active}'`
+function createIndexJobFetch(schema: string) {
+  return `CREATE INDEX job_i5 ON ${schema}.job (name, start_after) INCLUDE (priority, created_on, id) WHERE state < '${JOB_STATES.active}' AND NOT blocked`
 }
 
-function createIndexJobPolicyExclusive (schema: string) {
+function createIndexJobPolicyExclusive(schema: string) {
   return `CREATE UNIQUE INDEX job_i6 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state <= '${JOB_STATES.active}' AND policy = '${QUEUE_POLICIES.exclusive}'`
 }
 
-function createIndexJobPolicyKeyStrictFifo (schema: string) {
+function createIndexJobPolicyKeyStrictFifo(schema: string) {
   return `CREATE UNIQUE INDEX job_i8 ON ${schema}.job (name, singleton_key) WHERE state IN ('${JOB_STATES.active}', '${JOB_STATES.retry}', '${JOB_STATES.failed}') AND policy = '${QUEUE_POLICIES.key_strict_fifo}'`
 }
 
-function createCheckConstraintKeyStrictFifo (schema: string) {
+function createCheckConstraintKeyStrictFifo(schema: string) {
   return `ALTER TABLE ${schema}.job ADD CONSTRAINT job_key_strict_fifo_singleton_key_check CHECK (NOT (policy = '${QUEUE_POLICIES.key_strict_fifo}' AND singleton_key IS NULL))`
 }
 
-function createIndexJobGroupConcurrency (schema: string) {
+function createIndexJobGroupConcurrency(schema: string) {
   return `CREATE INDEX job_i7 ON ${schema}.job (name, group_id) WHERE state = '${JOB_STATES.active}' AND group_id IS NOT NULL`
 }
 
-function trySetQueueMonitorTime (schema: string, queues: string[], seconds: number): SqlQuery {
+function trySetQueueMonitorTime(schema: string, queues: string[], seconds: number): SqlQuery {
   return trySetQueueTimestamp(schema, queues, 'monitor_on', seconds)
 }
 
-function trySetQueueDeletionTime (schema: string, queues: string[], seconds: number): SqlQuery {
+function trySetQueueDeletionTime(schema: string, queues: string[], seconds: number): SqlQuery {
   return trySetQueueTimestamp(schema, queues, 'maintain_on', seconds)
 }
 
-function trySetCronTime (schema: string, seconds: number) {
+function trySetCronTime(schema: string, seconds: number) {
   return trySetTimestamp(schema, 'cron_on', seconds)
 }
 
-function trySetBamTime (schema: string, seconds: number) {
+function trySetBamTime(schema: string, seconds: number) {
   return trySetTimestamp(schema, 'bam_on', seconds)
 }
 
-function trySetTimestamp (schema: string, column: string, seconds: number) {
+function trySetTimestamp(schema: string, column: string, seconds: number) {
   return `
     UPDATE ${schema}.version
     SET ${column} = now()
@@ -564,7 +588,7 @@ function trySetTimestamp (schema: string, column: string, seconds: number) {
   `
 }
 
-function trySetQueueTimestamp (schema: string, queues: string[], column: string, seconds: number): SqlQuery {
+function trySetQueueTimestamp(schema: string, queues: string[], column: string, seconds: number): SqlQuery {
   return {
     text: `
     UPDATE ${schema}.queue
@@ -577,7 +601,7 @@ function trySetQueueTimestamp (schema: string, queues: string[], column: string,
   }
 }
 
-function updateQueue (schema: string, { deadLetter }: UpdateQueueOptions = {}) {
+function updateQueue(schema: string, { deadLetter }: UpdateQueueOptions = {}) {
   return `
     WITH options as (SELECT $2::jsonb as data)
     UPDATE ${schema}.queue SET
@@ -594,18 +618,17 @@ function updateQueue (schema: string, { deadLetter }: UpdateQueueOptions = {}) {
       heartbeat_seconds = CASE WHEN o.data ? 'heartbeatSeconds'
         THEN (o.data->>'heartbeatSeconds')::int
         ELSE heartbeat_seconds END,
-      ${
-        deadLetter === undefined
-          ? ''
-          : `dead_letter = CASE WHEN '${deadLetter}' IS DISTINCT FROM dead_letter THEN '${deadLetter}' ELSE dead_letter END,`
-      }
+      ${deadLetter === undefined
+      ? ''
+      : `dead_letter = CASE WHEN '${deadLetter}' IS DISTINCT FROM dead_letter THEN '${deadLetter}' ELSE dead_letter END,`
+    }
       updated_on = now()
     FROM options o
     WHERE name = $1
   `
 }
 
-function getQueues (schema: string, names?: string[]): SqlQuery {
+function getQueues(schema: string, names?: string[]): SqlQuery {
   const hasNames = names && names.length > 0
   return {
     text: `
@@ -638,7 +661,7 @@ function getQueues (schema: string, names?: string[]): SqlQuery {
   }
 }
 
-function deleteJobsById (schema: string, table: string) {
+function deleteJobsById(schema: string, table: string) {
   return `
     WITH results as (
       DELETE FROM ${schema}.${table}
@@ -650,31 +673,31 @@ function deleteJobsById (schema: string, table: string) {
   `
 }
 
-function deleteQueuedJobs (schema: string, table: string) {
+function deleteQueuedJobs(schema: string, table: string) {
   return `DELETE from ${schema}.${table} WHERE name = $1 and state < '${JOB_STATES.active}'`
 }
 
-function deleteStoredJobs (schema: string, table: string) {
+function deleteStoredJobs(schema: string, table: string) {
   return `DELETE from ${schema}.${table} WHERE name = $1 and state > '${JOB_STATES.active}'`
 }
 
-function truncateTable (schema: string, table: string) {
+function truncateTable(schema: string, table: string) {
   return `TRUNCATE ${schema}.${table}`
 }
 
-function deleteAllJobs (schema: string, table: string) {
+function deleteAllJobs(schema: string, table: string) {
   return `DELETE from ${schema}.${table} WHERE name = $1`
 }
 
-function getSchedules (schema: string) {
+function getSchedules(schema: string) {
   return `SELECT * FROM ${schema}.schedule ORDER BY name, key`
 }
 
-function getSchedulesByQueue (schema: string) {
+function getSchedulesByQueue(schema: string) {
   return `SELECT * FROM ${schema}.schedule WHERE name = $1 AND COALESCE(key, '') = $2`
 }
 
-function schedule (schema: string) {
+function schedule(schema: string) {
   return `
     INSERT INTO ${schema}.schedule (name, key, cron, timezone, data, options)
     VALUES ($1, $2, $3, $4, $5, $6)
@@ -687,7 +710,7 @@ function schedule (schema: string) {
   `
 }
 
-function unschedule (schema: string) {
+function unschedule(schema: string) {
   return `
     DELETE FROM ${schema}.schedule
     WHERE name = $1
@@ -695,7 +718,7 @@ function unschedule (schema: string) {
   `
 }
 
-function subscribe (schema: string) {
+function subscribe(schema: string) {
   return `
     INSERT INTO ${schema}.subscription (event, name)
     VALUES ($1, $2)
@@ -706,32 +729,32 @@ function subscribe (schema: string) {
   `
 }
 
-function unsubscribe (schema: string) {
+function unsubscribe(schema: string) {
   return `
     DELETE FROM ${schema}.subscription
     WHERE event = $1 and name = $2
   `
 }
 
-function getQueuesForEvent (schema: string) {
+function getQueuesForEvent(schema: string) {
   return `
     SELECT name FROM ${schema}.subscription
     WHERE event = $1
   `
 }
 
-function getTime () {
+function getTime() {
   return "SELECT round(date_part('epoch', now()) * 1000) as time"
 }
 
-function insertWarning (schema: string) {
+function insertWarning(schema: string) {
   return `
     INSERT INTO ${schema}.warning (type, message, data)
     VALUES ($1, $2, $3)
   `
 }
 
-function getWarnings (schema: string): string {
+function getWarnings(schema: string): string {
   return `
     SELECT
       id,
@@ -746,7 +769,7 @@ function getWarnings (schema: string): string {
   `
 }
 
-function getWarningsCount (schema: string): string {
+function getWarningsCount(schema: string): string {
   return `
     SELECT COUNT(*)::int as count
     FROM ${schema}.warning
@@ -754,26 +777,26 @@ function getWarningsCount (schema: string): string {
   `
 }
 
-function deleteOldWarnings (schema: string, days: number): string {
+function deleteOldWarnings(schema: string, days: number): string {
   return `
     DELETE FROM ${schema}.warning
     WHERE created_on < now() - interval '${days} days'
   `
 }
 
-function getVersion (schema: string) {
+function getVersion(schema: string) {
   return `SELECT version from ${schema}.version`
 }
 
-function setVersion (schema: string, version: number) {
+function setVersion(schema: string, version: number) {
   return `UPDATE ${schema}.version SET version = '${version}'`
 }
 
-function versionTableExists (schema: string) {
+function versionTableExists(schema: string) {
   return `SELECT to_regclass('${schema}.version') as name`
 }
 
-function insertVersion (schema: string, version: number) {
+function insertVersion(schema: string, version: number) {
   return `INSERT INTO ${schema}.version(version) VALUES ('${version}')`
 }
 
@@ -809,7 +832,7 @@ interface FetchQueryParams {
   maxPriorityParam: string
 }
 
-function buildFetchParams (options: FetchJobOptions): FetchQueryParams {
+function buildFetchParams(options: FetchJobOptions): FetchQueryParams {
   const { ignoreSingletons, ignoreGroups, groupConcurrency, minPriority, maxPriority } = options
   const hasIgnoreSingletons = ignoreSingletons != null && ignoreSingletons.length > 0
   const hasIgnoreGroups = ignoreGroups != null && ignoreGroups.length > 0
@@ -869,7 +892,7 @@ function buildFetchParams (options: FetchJobOptions): FetchQueryParams {
   return { values, ignoreSingletonsParam, ignoreGroupsParam, defaultGroupLimitParam, tiersParam, minPriorityParam, maxPriorityParam }
 }
 
-function fetchNextJob (options: FetchJobOptions): SqlQuery {
+function fetchNextJob(options: FetchJobOptions): SqlQuery {
   const { schema, table, name, policy, limit, includeMetadata, priority = true, orderByCreatedOn = true, ignoreStartAfter = false, groupConcurrency, minPriority, maxPriority } = options
 
   const singletonFetch = limit > 1 && (policy === QUEUE_POLICIES.singleton || policy === QUEUE_POLICIES.stately)
@@ -911,6 +934,7 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
   const whereConditions = [
     `j.name = '${name}'`,
     `j.state < '${JOB_STATES.active}'`,
+    'NOT j.blocked',
     !ignoreStartAfter ? 'j.start_after < now()' : '',
     hasIgnoreSingletons ? `j.singleton_key <> ALL(${params.ignoreSingletonsParam})` : '',
     hasIgnoreGroups ? `(j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : '',
@@ -920,8 +944,8 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
       ? `(j.group_id IS NULL
             OR agc.active_cnt IS NULL
             OR agc.active_cnt < ${hasTiers
-              ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
-              : params.defaultGroupLimitParam})`
+        ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
+        : params.defaultGroupLimitParam})`
       : ''
   ].filter(Boolean).join('\n          AND ')
 
@@ -961,16 +985,16 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
         SELECT id FROM group_ranking
         WHERE group_id IS NULL
           OR (active_cnt + group_rn) <= ${hasTiers
-          ? `COALESCE((${params.tiersParam} ->> group_tier)::int, ${params.defaultGroupLimitParam})`
-          : params.defaultGroupLimitParam}
+      ? `COALESCE((${params.tiersParam} ->> group_tier)::int, ${params.defaultGroupLimitParam})`
+      : params.defaultGroupLimitParam}
       )`
     : ''
 
   const finalCte = (hasGroupConcurrency)
     ? 'group_filtered'
     : (singletonFetch)
-        ? 'singleton_ranking'
-        : 'next'
+      ? 'singleton_ranking'
+      : 'next'
 
   return {
     text: `
@@ -993,27 +1017,89 @@ function fetchNextJob (options: FetchJobOptions): SqlQuery {
   }
 }
 
-function completeJobs (schema: string, table: string, includeQueued?: boolean) {
-  const stateFilter = includeQueued
-    ? `state < '${JOB_STATES.completed}'`
-    : `state = '${JOB_STATES.active}'`
-
+function createCompleteJobsFunction(schema: string) {
   return `
-    WITH results AS (
-      UPDATE ${schema}.${table}
-      SET completed_on = now(),
-        state = '${JOB_STATES.completed}',
-        output = $3::jsonb
-      WHERE name = $1
-        AND id IN (SELECT UNNEST($2::uuid[]))
-        AND ${stateFilter}
-      RETURNING *
+    CREATE OR REPLACE FUNCTION ${schema}.complete_jobs(
+      queue_name text,
+      job_table text,
+      job_ids uuid[],
+      job_output jsonb,
+      include_queued boolean DEFAULT false
     )
-    SELECT COUNT(*) FROM results
+    RETURNS bigint AS
+    $$
+    DECLARE
+      completed_count bigint;
+      has_blocking boolean;
+    BEGIN
+      EXECUTE format(
+        'CREATE TEMP TABLE _completed ON COMMIT DROP AS
+         WITH results AS (
+           UPDATE %I.%I
+           SET completed_on = now(),
+               state = ''${JOB_STATES.completed}'',
+               output = $1
+           WHERE name = $2
+             AND id IN (SELECT UNNEST($3))
+             AND %s
+           RETURNING *
+         )
+         SELECT * FROM results',
+        '${schema}', job_table,
+        CASE WHEN include_queued
+          THEN 'state < ''${JOB_STATES.completed}'''
+          ELSE 'state = ''${JOB_STATES.active}'''
+        END
+      ) USING job_output, queue_name, job_ids;
+
+      SELECT COUNT(*) INTO completed_count FROM _completed;
+
+      IF completed_count = 0 THEN
+        RETURN 0;
+      END IF;
+
+      SELECT EXISTS(SELECT 1 FROM _completed WHERE blocking = true)
+        INTO has_blocking;
+
+      IF has_blocking THEN
+        EXECUTE format(
+          'UPDATE %I.job j
+           SET blocked = false
+           FROM (
+             SELECT DISTINCT d.child_name, d.child_id
+             FROM %I.job_dependency d
+             JOIN _completed c ON c.name = d.parent_name AND c.id = d.parent_id
+             WHERE c.blocking = true
+           ) ct
+           WHERE j.name = ct.child_name
+             AND j.id = ct.child_id
+             AND j.blocked = true
+             AND NOT EXISTS (
+               SELECT 1
+               FROM %I.job_dependency d2
+               JOIN %I.job p ON p.name = d2.parent_name AND p.id = d2.parent_id
+               LEFT JOIN _completed r ON r.name = p.name AND r.id = p.id
+               WHERE d2.child_name = ct.child_name
+                 AND d2.child_id = ct.child_id
+                 AND p.state <> ''${JOB_STATES.completed}''
+                 AND r.id IS NULL
+             )',
+          '${schema}', '${schema}', '${schema}', '${schema}'
+        );
+      END IF;
+
+      RETURN completed_count;
+    END;
+    $$
+    LANGUAGE plpgsql;
   `
 }
 
-function cancelJobs (schema: string, table: string) {
+function completeJobs(schema: string, table: string, includeQueued?: boolean) {
+  return `SELECT ${schema}.complete_jobs($1::text, '${table}'::text, $2::uuid[], $3::jsonb, ${includeQueued || false}::boolean) as count`
+}
+
+function cancelJobs(schema: string, table: string) {
   return `
     WITH results as (
       UPDATE ${schema}.${table}
@@ -1028,7 +1114,7 @@ function cancelJobs (schema: string, table: string) {
   `
 }
 
-function resumeJobs (schema: string, table: string) {
+function resumeJobs(schema: string, table: string) {
   return `
     WITH results as (
       UPDATE ${schema}.${table}
@@ -1043,7 +1129,7 @@ function resumeJobs (schema: string, table: string) {
   `
 }
 
-function restoreJobs (schema: string, table: string) {
+function restoreJobs(schema: string, table: string) {
   return `
     UPDATE ${schema}.${table}
     SET state = '${JOB_STATES.created}',
@@ -1060,7 +1146,7 @@ interface InsertJobsOptions {
   returnId?: boolean
 }
 
-function insertJobs (schema: string, { table, name, returnId = true }: InsertJobsOptions) {
+function insertJobs(schema: string, { table, name, returnId = true }: InsertJobsOptions) {
   const sql = `
     INSERT INTO ${schema}.${table} (
       id,
@@ -1081,7 +1167,9 @@ function insertJobs (schema: string, { table, name, returnId = true }: InsertJob
       retry_delay_max,
       policy,
       dead_letter,
-      heartbeat_seconds
+      heartbeat_seconds,
+      blocked,
+      blocking
     )
     SELECT
       COALESCE(id, gen_random_uuid()) as id,
@@ -1105,7 +1193,9 @@ function insertJobs (schema: string, { table, name, returnId = true }: InsertJob
       COALESCE("retryDelayMax", q.retry_delay_max) as retry_delay_max,
       q.policy,
       COALESCE("deadLetter", q.dead_letter) as dead_letter,
-      COALESCE("heartbeatSeconds", q.heartbeat_seconds) as heartbeat_seconds
+      COALESCE("heartbeatSeconds", q.heartbeat_seconds) as heartbeat_seconds,
+      COALESCE(blocked, false) as blocked,
+      COALESCE(blocking, false) as blocking
     FROM (
       SELECT *,
         CASE
@@ -1130,7 +1220,9 @@ function insertJobs (schema: string, { table, name, returnId = true }: InsertJob
         "deleteAfterSeconds" integer,
         "retentionSeconds" integer,
         "deadLetter" text,
-        "heartbeatSeconds" integer
+        "heartbeatSeconds" integer,
+        blocked boolean,
+        blocking boolean
       )
     ) j
     JOIN ${schema}.queue q ON q.name = '${name}'
@@ -1141,14 +1233,14 @@ function insertJobs (schema: string, { table, name, returnId = true }: InsertJob
   return sql
 }
 
-function failJobsById (schema: string, table: string) {
+function failJobsById(schema: string, table: string) {
   const where = `name = $1 AND id IN (SELECT UNNEST($2::uuid[])) AND state < '${JOB_STATES.completed}'`
   const output = '$3::jsonb'
 
   return failJobs(schema, table, where, output)
 }
 
-function failJobsByTimeout (schema: string, table: string, queues: string[]): string {
+function failJobsByTimeout(schema: string, table: string, queues: string[]): string {
   const where = `state = '${JOB_STATES.active}'
             AND (started_on + expire_seconds * interval '1s') < now()
             AND name = ANY(${serializeArrayParam(queues)})`
@@ -1158,7 +1250,7 @@ function failJobsByTimeout (schema: string, table: string, queues: string[]): st
   return locked(schema, failJobs(schema, table, where, output), table + 'failJobsByTimeout')
 }
 
-function failJobsByHeartbeat (schema: string, table: string, queues: string[]): string {
+function failJobsByHeartbeat(schema: string, table: string, queues: string[]): string {
   const where = `state = '${JOB_STATES.active}'
             AND heartbeat_seconds IS NOT NULL
             AND (heartbeat_on + heartbeat_seconds * interval '1s') < now()
@@ -1169,7 +1261,7 @@ function failJobsByHeartbeat (schema: string, table: string, queues: string[]): 
   return locked(schema, failJobs(schema, table, where, output), table + 'failJobsByHeartbeat')
 }
 
-function touchJobs (schema: string, table: string) {
+function touchJobs(schema: string, table: string) {
   return `
     WITH results AS (
       UPDATE ${schema}.${table}
@@ -1183,7 +1275,7 @@ function touchJobs (schema: string, table: string) {
   `
 }
 
-function failJobs (schema: string, table: string, where: string, output: string) {
+function failJobs(schema: string, table: string, where: string, output: string) {
   return `
     WITH deleted_jobs AS (
       DELETE FROM ${schema}.${table}
@@ -1217,7 +1309,9 @@ function failJobs (schema: string, table: string, where: string, output: string)
         output,
         dead_letter,
         heartbeat_on,
-        heartbeat_seconds
+        heartbeat_seconds,
+        blocked,
+        blocking
       )
       SELECT
         id,
@@ -1257,7 +1351,9 @@ function failJobs (schema: string, table: string, where: string, output: string)
         ${output},
         dead_letter,
         NULL as heartbeat_on,
-        heartbeat_seconds
+        heartbeat_seconds,
+        blocked,
+        blocking
       FROM deleted_jobs
       ON CONFLICT DO NOTHING
       RETURNING *
@@ -1289,7 +1385,9 @@ function failJobs (schema: string, table: string, where: string, output: string)
         output,
         dead_letter,
         heartbeat_on,
-        heartbeat_seconds
+        heartbeat_seconds,
+        blocked,
+        blocking
       )
       SELECT
         id,
@@ -1317,7 +1415,9 @@ function failJobs (schema: string, table: string, where: string, output: string)
         ${output},
         dead_letter,
         NULL as heartbeat_on,
-        heartbeat_seconds
+        heartbeat_seconds,
+        blocked,
+        blocking
       FROM deleted_jobs
       WHERE id NOT IN (SELECT id from retried_jobs)
       RETURNING *
@@ -1346,7 +1446,7 @@ function failJobs (schema: string, table: string, where: string, output: string)
   `
 }
 
-function deletion (schema: string, table: string, queues: string[]): string {
+function deletion(schema: string, table: string, queues: string[]): string {
   const sql = `
     DELETE FROM ${schema}.${table}
     WHERE name = ANY(${serializeArrayParam(queues)})
@@ -1361,7 +1461,7 @@ function deletion (schema: string, table: string, queues: string[]): string {
   return locked(schema, sql, table + 'deletion')
 }
 
-function retryJobs (schema: string, table: string) {
+function retryJobs(schema: string, table: string) {
   return `
     WITH results as (
       UPDATE ${schema}.job
@@ -1376,7 +1476,7 @@ function retryJobs (schema: string, table: string) {
   `
 }
 
-function getQueueStats (schema: string, table: string, queues: string[]): SqlQuery {
+function getQueueStats(schema: string, table: string, queues: string[]): SqlQuery {
   return {
     text: `
     SELECT
@@ -1394,7 +1494,7 @@ function getQueueStats (schema: string, table: string, queues: string[]): SqlQue
   }
 }
 
-function cacheQueueStats (schema: string, table: string, queues: string[]): string {
+function cacheQueueStats(schema: string, table: string, queues: string[]): string {
   const statsQuery = getQueueStats(schema, table, queues)
   // Serialize the $1 parameter for use in locked() multi-statement query
   const statsText = statsQuery.text.replace('$1::text[]', serializeArrayParam(queues))
@@ -1423,12 +1523,12 @@ function cacheQueueStats (schema: string, table: string, queues: string[]): stri
 }
 
 // Serialize a string array for embedding directly in SQL as PostgreSQL array literal
-function serializeArrayParam (values: string[]): string {
+function serializeArrayParam(values: string[]): string {
   const escaped = values.map(v => `'${v.replace(SINGLE_QUOTE_REGEX, "''")}'`)
   return `ARRAY[${escaped.join(',')}]::text[]`
 }
 
-function locked (schema: string, query: string | string[], key?: string): string {
+function locked(schema: string, query: string | string[], key?: string): string {
   const sql = Array.isArray(query) ? query.join(';\n') : query
 
   return `
@@ -1441,18 +1541,18 @@ function locked (schema: string, query: string | string[], key?: string): string
   `
 }
 
-function advisoryLock (schema: string, key?: string) {
+function advisoryLock(schema: string, key?: string) {
   return `SELECT pg_advisory_xact_lock(
       ('x' || encode(sha224((current_database() || '.pgboss.${schema}${key || ''}')::bytea), 'hex'))::bit(64)::bigint
   )`
 }
 
-function assertMigration (schema: string, version: number) {
+function assertMigration(schema: string, version: number) {
   // raises 'division by zero' if already on desired schema version
   return `SELECT version::int/(version::int-${version}) from ${schema}.version`
 }
 
-function findJobs (schema: string, table: string, options: { queued: boolean, byKey: boolean, byData: boolean, byId: boolean }) {
+function findJobs(schema: string, table: string, options: { queued: boolean, byKey: boolean, byData: boolean, byId: boolean }) {
   const { queued, byKey, byData, byId } = options
 
   let paramIndex = 1
@@ -1485,7 +1585,7 @@ function findJobs (schema: string, table: string, options: { queued: boolean, by
     `
 }
 
-function getJobById (schema: string, table: string) {
+function getJobById(schema: string, table: string) {
   return `
     SELECT ${JOB_COLUMNS_ALL}
     FROM ${schema}.${table}
@@ -1494,7 +1594,73 @@ function getJobById (schema: string, table: string) {
     `
 }
 
-function getBlockedKeys (schema: string, table: string) {
+function insertDependencies(schema: string) {
+  return `
+    INSERT INTO ${schema}.job_dependency (child_name, child_id, parent_name, parent_id)
+    SELECT child_name, child_id, parent_name, parent_id
+    FROM json_to_recordset($1::json) AS x (
+      child_name text,
+      child_id uuid,
+      parent_name text,
+      parent_id uuid
+    )
+    ON CONFLICT DO NOTHING
+  `
+}
+
+function markJobsBlocking(schema: string): SqlQuery {
+  return {
+    text: `
+      UPDATE ${schema}.job
+      SET blocking = true
+      WHERE (name, id) IN (
+        SELECT parent_name, parent_id
+        FROM json_to_recordset($1::json) AS x (
+          parent_name text,
+          parent_id uuid
+        )
+      )
+      AND NOT blocking
+    `,
+    values: []
+  }
+}
+
+function getDependencies(schema: string) {
+  return `
+    SELECT parent_name as "parentName", parent_id as "parentId"
+    FROM ${schema}.job_dependency
+    WHERE child_name = $1 AND child_id = $2
+  `
+}
+
+function getDependents(schema: string) {
+  return `
+    SELECT child_name as "childName", child_id as "childId"
+    FROM ${schema}.job_dependency
+    WHERE parent_name = $1 AND parent_id = $2
+  `
+}
+
+function cleanupDependencies(schema: string, table: string, queues: string[]): string {
+  const sql = `
+    DELETE FROM ${schema}.job_dependency
+    WHERE (child_name = ANY(${serializeArrayParam(queues)})
+      AND NOT EXISTS (
+        SELECT 1 FROM ${schema}.${table} j
+        WHERE j.name = child_name AND j.id = child_id
+      ))
+    OR (parent_name = ANY(${serializeArrayParam(queues)})
+      AND NOT EXISTS (
+        SELECT 1 FROM ${schema}.${table} j
+        WHERE j.name = parent_name AND j.id = parent_id
+      ))
+  `
+
+  return locked(schema, sql, table + 'cleanupDependencies')
+}
+
+function getBlockedKeys(schema: string, table: string) {
   return `
     SELECT DISTINCT singleton_key as "singletonKey"
     FROM ${schema}.${table}
@@ -1504,7 +1670,7 @@ function getBlockedKeys (schema: string, table: string) {
     `
 }
 
-function getNextBamCommand (schema: string) {
+function getNextBamCommand(schema: string) {
   return `
     UPDATE ${schema}.bam
     SET status = 'in_progress', started_on = now()
@@ -1520,7 +1686,7 @@ function getNextBamCommand (schema: string) {
   `
 }
 
-function setBamCompleted (schema: string, id: string) {
+function setBamCompleted(schema: string, id: string) {
   return `
     UPDATE ${schema}.bam
     SET status = 'completed', completed_on = now()
@@ -1528,7 +1694,7 @@ function setBamCompleted (schema: string, id: string) {
   `
 }
 
-function setBamFailed (schema: string, id: string, error: string) {
+function setBamFailed(schema: string, id: string, error: string) {
   const escapedError = error.replace(/'/g, "''")
   return `
     UPDATE ${schema}.bam
@@ -1537,7 +1703,7 @@ function setBamFailed (schema: string, id: string, error: string) {
   `
 }
 
-function getBamStatus (schema: string) {
+function getBamStatus(schema: string) {
   return `
     SELECT status, count(*)::int as count, max(created_on) as "lastCreatedOn"
     FROM ${schema}.bam
@@ -1545,7 +1711,7 @@ function getBamStatus (schema: string) {
   `
 }
 
-function getBamEntries (schema: string) {
+function getBamEntries(schema: string) {
   return `
     SELECT id, name, version, status, queue, table_name as "table", command, error,
            created_on as "createdOn", started_on as "startedOn", completed_on as "completedOn"
@@ -1606,6 +1772,14 @@ export {
   createTableWarning,
   createIndexWarning,
   getBlockedKeys,
+  insertDependencies,
+  markJobsBlocking,
+  getDependencies,
+  getDependents,
+  cleanupDependencies,
+  createTableJobDependency,
+  createIndexJobDependencyParent,
+  createCompleteJobsFunction,
   getNextBamCommand,
   setBamCompleted,
   setBamFailed,

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -44,7 +44,7 @@ const QUEUE_DEFAULTS = {
 
 const COMMON_JOB_TABLE = 'job_common'
 
-function create(schema: string, version: number, options?: { createSchema?: boolean }) {
+function create (schema: string, version: number, options?: { createSchema?: boolean }) {
   const commands = [
     options?.createSchema ? createSchema(schema) : '',
     createEnumJobState(schema),
@@ -72,7 +72,6 @@ function create(schema: string, version: number, options?: { createSchema?: bool
 
     createQueueFunction(schema),
     deleteQueueFunction(schema),
-    createCompleteJobsFunction(schema),
 
     insertVersion(schema, version)
   ]
@@ -80,11 +79,11 @@ function create(schema: string, version: number, options?: { createSchema?: bool
   return locked(schema, commands)
 }
 
-function createSchema(schema: string) {
+function createSchema (schema: string) {
   return `CREATE SCHEMA IF NOT EXISTS ${schema}`
 }
 
-function createEnumJobState(schema: string) {
+function createEnumJobState (schema: string) {
   // ENUM definition order is important
   // base type is numeric and first values are less than last values
   return `
@@ -99,7 +98,7 @@ function createEnumJobState(schema: string) {
   `
 }
 
-function createTableVersion(schema: string) {
+function createTableVersion (schema: string) {
   return `
     CREATE TABLE ${schema}.version (
       version int primary key,
@@ -109,7 +108,7 @@ function createTableVersion(schema: string) {
   `
 }
 
-function createTableQueue(schema: string) {
+function createTableQueue (schema: string) {
   return `
     CREATE TABLE ${schema}.queue (
       name text NOT NULL,
@@ -140,7 +139,7 @@ function createTableQueue(schema: string) {
   `
 }
 
-function createTableSchedule(schema: string) {
+function createTableSchedule (schema: string) {
   return `
     CREATE TABLE ${schema}.schedule (
       name text REFERENCES ${schema}.queue ON DELETE CASCADE,
@@ -156,7 +155,7 @@ function createTableSchedule(schema: string) {
   `
 }
 
-function createTableSubscription(schema: string) {
+function createTableSubscription (schema: string) {
   return `
     CREATE TABLE ${schema}.subscription (
       event text not null,
@@ -168,7 +167,7 @@ function createTableSubscription(schema: string) {
   `
 }
 
-function createTableBam(schema: string) {
+function createTableBam (schema: string) {
   return `
     CREATE TABLE ${schema}.bam (
       id uuid PRIMARY KEY default gen_random_uuid(),
@@ -186,7 +185,7 @@ function createTableBam(schema: string) {
   `
 }
 
-function createTableWarning(schema: string) {
+function createTableWarning (schema: string) {
   return `
     CREATE TABLE ${schema}.warning (
       id uuid PRIMARY KEY default gen_random_uuid(),
@@ -198,11 +197,11 @@ function createTableWarning(schema: string) {
   `
 }
 
-function createIndexWarning(schema: string) {
+function createIndexWarning (schema: string) {
   return `CREATE INDEX warning_i1 ON ${schema}.warning (created_on DESC)`
 }
 
-function createTableJobDependency(schema: string) {
+function createTableJobDependency (schema: string) {
   return `
     CREATE TABLE ${schema}.job_dependency (
       child_name text NOT NULL,
@@ -214,11 +213,11 @@ function createTableJobDependency(schema: string) {
   `
 }
 
-function createIndexJobDependencyParent(schema: string) {
+function createIndexJobDependencyParent (schema: string) {
   return `CREATE INDEX job_dep_parent_idx ON ${schema}.job_dependency (parent_name, parent_id)`
 }
 
-function jobTableFormatFunction(schema: string) {
+function jobTableFormatFunction (schema: string) {
   return `
     CREATE FUNCTION ${schema}.job_table_format(command text, table_name text)
     RETURNS text AS
@@ -235,7 +234,7 @@ function jobTableFormatFunction(schema: string) {
   `
 }
 
-function jobTableRunFunction(schema: string) {
+function jobTableRunFunction (schema: string) {
   return `
     CREATE FUNCTION ${schema}.job_table_run(command text, tbl_name text DEFAULT NULL, queue_name text DEFAULT NULL)
     RETURNS VOID AS
@@ -264,7 +263,7 @@ function jobTableRunFunction(schema: string) {
   `
 }
 
-function jobTableRunAsyncFunction(schema: string) {
+function jobTableRunAsyncFunction (schema: string) {
   return `
     CREATE FUNCTION ${schema}.job_table_run_async(command_name text, version int, command text, tbl_name text DEFAULT NULL, queue_name text DEFAULT NULL)
     RETURNS VOID AS
@@ -311,7 +310,7 @@ function jobTableRunAsyncFunction(schema: string) {
   `
 }
 
-function createTableJob(schema: string) {
+function createTableJob (schema: string) {
   return `
     CREATE TABLE ${schema}.job (
       id uuid not null default gen_random_uuid(),
@@ -341,7 +340,8 @@ function createTableJob(schema: string) {
       heartbeat_on timestamp with time zone,
       heartbeat_seconds int,
       blocked boolean not null default false,
-      blocking boolean not null default false
+      blocking boolean not null default false,
+      pending_dependencies int not null default 0
     ) PARTITION BY LIST (name)
   `
 }
@@ -368,10 +368,11 @@ const JOB_COLUMNS_ALL = `${JOB_COLUMNS_MIN},
   dead_letter as "deadLetter",
   blocked,
   blocking,
+  pending_dependencies as "pendingDependencies",
   output
 `
 
-function createTableJobCommon(schema: string) {
+function createTableJobCommon (schema: string) {
   return `
     CREATE TABLE ${schema}.${COMMON_JOB_TABLE} (LIKE ${schema}.job INCLUDING GENERATED INCLUDING DEFAULTS);
 
@@ -392,7 +393,7 @@ function createTableJobCommon(schema: string) {
   `
 }
 
-function createQueueFunction(schema: string) {
+function createQueueFunction (schema: string) {
   return `
     CREATE FUNCTION ${schema}.create_queue(queue_name text, options jsonb)
     RETURNS VOID AS
@@ -478,7 +479,7 @@ function createQueueFunction(schema: string) {
   `
 }
 
-function deleteQueueFunction(schema: string) {
+function deleteQueueFunction (schema: string) {
   return `
     CREATE FUNCTION ${schema}.delete_queue(queue_name text)
     RETURNS VOID AS
@@ -505,81 +506,81 @@ function deleteQueueFunction(schema: string) {
   `
 }
 
-function createQueue(schema: string, name: string, options: unknown) {
+function createQueue (schema: string, name: string, options: unknown) {
   const sql = `SELECT ${schema}.create_queue('${name}', '${JSON.stringify(options)}'::jsonb)`
   return locked(schema, sql, 'create-queue')
 }
 
-function deleteQueue(schema: string, name: string) {
+function deleteQueue (schema: string, name: string) {
   const sql = `SELECT ${schema}.delete_queue('${name}')`
   return locked(schema, sql, 'delete-queue')
 }
 
-function createPrimaryKeyJob(schema: string) {
+function createPrimaryKeyJob (schema: string) {
   return `ALTER TABLE ${schema}.job ADD PRIMARY KEY (name, id)`
 }
 
-function createQueueForeignKeyJob(schema: string) {
+function createQueueForeignKeyJob (schema: string) {
   return `ALTER TABLE ${schema}.job ADD CONSTRAINT q_fkey FOREIGN KEY (name) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED`
 }
 
-function createQueueForeignKeyJobDeadLetter(schema: string) {
+function createQueueForeignKeyJobDeadLetter (schema: string) {
   return `ALTER TABLE ${schema}.job ADD CONSTRAINT dlq_fkey FOREIGN KEY (dead_letter) REFERENCES ${schema}.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED`
 }
 
-function createIndexJobPolicyShort(schema: string) {
+function createIndexJobPolicyShort (schema: string) {
   return `CREATE UNIQUE INDEX job_i1 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state = '${JOB_STATES.created}' AND policy = '${QUEUE_POLICIES.short}'`
 }
 
-function createIndexJobPolicySingleton(schema: string) {
+function createIndexJobPolicySingleton (schema: string) {
   return `CREATE UNIQUE INDEX job_i2 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state = '${JOB_STATES.active}' AND policy = '${QUEUE_POLICIES.singleton}'`
 }
 
-function createIndexJobPolicyStately(schema: string) {
+function createIndexJobPolicyStately (schema: string) {
   return `CREATE UNIQUE INDEX job_i3 ON ${schema}.job (name, state, COALESCE(singleton_key, '')) WHERE state <= '${JOB_STATES.active}' AND policy = '${QUEUE_POLICIES.stately}'`
 }
 
-function createIndexJobThrottle(schema: string) {
+function createIndexJobThrottle (schema: string) {
   return `CREATE UNIQUE INDEX job_i4 ON ${schema}.job (name, singleton_on, COALESCE(singleton_key, '')) WHERE state <> '${JOB_STATES.cancelled}' AND singleton_on IS NOT NULL`
 }
 
-function createIndexJobFetch(schema: string) {
+function createIndexJobFetch (schema: string) {
   return `CREATE INDEX job_i5 ON ${schema}.job (name, start_after) INCLUDE (priority, created_on, id) WHERE state < '${JOB_STATES.active}' AND NOT blocked`
 }
 
-function createIndexJobPolicyExclusive(schema: string) {
+function createIndexJobPolicyExclusive (schema: string) {
   return `CREATE UNIQUE INDEX job_i6 ON ${schema}.job (name, COALESCE(singleton_key, '')) WHERE state <= '${JOB_STATES.active}' AND policy = '${QUEUE_POLICIES.exclusive}'`
 }
 
-function createIndexJobPolicyKeyStrictFifo(schema: string) {
+function createIndexJobPolicyKeyStrictFifo (schema: string) {
   return `CREATE UNIQUE INDEX job_i8 ON ${schema}.job (name, singleton_key) WHERE state IN ('${JOB_STATES.active}', '${JOB_STATES.retry}', '${JOB_STATES.failed}') AND policy = '${QUEUE_POLICIES.key_strict_fifo}'`
 }
 
-function createCheckConstraintKeyStrictFifo(schema: string) {
+function createCheckConstraintKeyStrictFifo (schema: string) {
   return `ALTER TABLE ${schema}.job ADD CONSTRAINT job_key_strict_fifo_singleton_key_check CHECK (NOT (policy = '${QUEUE_POLICIES.key_strict_fifo}' AND singleton_key IS NULL))`
 }
 
-function createIndexJobGroupConcurrency(schema: string) {
+function createIndexJobGroupConcurrency (schema: string) {
   return `CREATE INDEX job_i7 ON ${schema}.job (name, group_id) WHERE state = '${JOB_STATES.active}' AND group_id IS NOT NULL`
 }
 
-function trySetQueueMonitorTime(schema: string, queues: string[], seconds: number): SqlQuery {
+function trySetQueueMonitorTime (schema: string, queues: string[], seconds: number): SqlQuery {
   return trySetQueueTimestamp(schema, queues, 'monitor_on', seconds)
 }
 
-function trySetQueueDeletionTime(schema: string, queues: string[], seconds: number): SqlQuery {
+function trySetQueueDeletionTime (schema: string, queues: string[], seconds: number): SqlQuery {
   return trySetQueueTimestamp(schema, queues, 'maintain_on', seconds)
 }
 
-function trySetCronTime(schema: string, seconds: number) {
+function trySetCronTime (schema: string, seconds: number) {
   return trySetTimestamp(schema, 'cron_on', seconds)
 }
 
-function trySetBamTime(schema: string, seconds: number) {
+function trySetBamTime (schema: string, seconds: number) {
   return trySetTimestamp(schema, 'bam_on', seconds)
 }
 
-function trySetTimestamp(schema: string, column: string, seconds: number) {
+function trySetTimestamp (schema: string, column: string, seconds: number) {
   return `
     UPDATE ${schema}.version
     SET ${column} = now()
@@ -588,7 +589,7 @@ function trySetTimestamp(schema: string, column: string, seconds: number) {
   `
 }
 
-function trySetQueueTimestamp(schema: string, queues: string[], column: string, seconds: number): SqlQuery {
+function trySetQueueTimestamp (schema: string, queues: string[], column: string, seconds: number): SqlQuery {
   return {
     text: `
     UPDATE ${schema}.queue
@@ -601,7 +602,7 @@ function trySetQueueTimestamp(schema: string, queues: string[], column: string, 
   }
 }
 
-function updateQueue(schema: string, { deadLetter }: UpdateQueueOptions = {}) {
+function updateQueue (schema: string, { deadLetter }: UpdateQueueOptions = {}) {
   return `
     WITH options as (SELECT $2::jsonb as data)
     UPDATE ${schema}.queue SET
@@ -619,16 +620,16 @@ function updateQueue(schema: string, { deadLetter }: UpdateQueueOptions = {}) {
         THEN (o.data->>'heartbeatSeconds')::int
         ELSE heartbeat_seconds END,
       ${deadLetter === undefined
-      ? ''
-      : `dead_letter = CASE WHEN '${deadLetter}' IS DISTINCT FROM dead_letter THEN '${deadLetter}' ELSE dead_letter END,`
-    }
+           ? ''
+           : `dead_letter = CASE WHEN '${deadLetter}' IS DISTINCT FROM dead_letter THEN '${deadLetter}' ELSE dead_letter END,`
+       }
       updated_on = now()
     FROM options o
     WHERE name = $1
   `
 }
 
-function getQueues(schema: string, names?: string[]): SqlQuery {
+function getQueues (schema: string, names?: string[]): SqlQuery {
   const hasNames = names && names.length > 0
   return {
     text: `
@@ -661,7 +662,7 @@ function getQueues(schema: string, names?: string[]): SqlQuery {
   }
 }
 
-function deleteJobsById(schema: string, table: string) {
+function deleteJobsById (schema: string, table: string) {
   return `
     WITH results as (
       DELETE FROM ${schema}.${table}
@@ -673,31 +674,31 @@ function deleteJobsById(schema: string, table: string) {
   `
 }
 
-function deleteQueuedJobs(schema: string, table: string) {
+function deleteQueuedJobs (schema: string, table: string) {
   return `DELETE from ${schema}.${table} WHERE name = $1 and state < '${JOB_STATES.active}'`
 }
 
-function deleteStoredJobs(schema: string, table: string) {
+function deleteStoredJobs (schema: string, table: string) {
   return `DELETE from ${schema}.${table} WHERE name = $1 and state > '${JOB_STATES.active}'`
 }
 
-function truncateTable(schema: string, table: string) {
+function truncateTable (schema: string, table: string) {
   return `TRUNCATE ${schema}.${table}`
 }
 
-function deleteAllJobs(schema: string, table: string) {
+function deleteAllJobs (schema: string, table: string) {
   return `DELETE from ${schema}.${table} WHERE name = $1`
 }
 
-function getSchedules(schema: string) {
+function getSchedules (schema: string) {
   return `SELECT * FROM ${schema}.schedule ORDER BY name, key`
 }
 
-function getSchedulesByQueue(schema: string) {
+function getSchedulesByQueue (schema: string) {
   return `SELECT * FROM ${schema}.schedule WHERE name = $1 AND COALESCE(key, '') = $2`
 }
 
-function schedule(schema: string) {
+function schedule (schema: string) {
   return `
     INSERT INTO ${schema}.schedule (name, key, cron, timezone, data, options)
     VALUES ($1, $2, $3, $4, $5, $6)
@@ -710,7 +711,7 @@ function schedule(schema: string) {
   `
 }
 
-function unschedule(schema: string) {
+function unschedule (schema: string) {
   return `
     DELETE FROM ${schema}.schedule
     WHERE name = $1
@@ -718,7 +719,7 @@ function unschedule(schema: string) {
   `
 }
 
-function subscribe(schema: string) {
+function subscribe (schema: string) {
   return `
     INSERT INTO ${schema}.subscription (event, name)
     VALUES ($1, $2)
@@ -729,32 +730,32 @@ function subscribe(schema: string) {
   `
 }
 
-function unsubscribe(schema: string) {
+function unsubscribe (schema: string) {
   return `
     DELETE FROM ${schema}.subscription
     WHERE event = $1 and name = $2
   `
 }
 
-function getQueuesForEvent(schema: string) {
+function getQueuesForEvent (schema: string) {
   return `
     SELECT name FROM ${schema}.subscription
     WHERE event = $1
   `
 }
 
-function getTime() {
+function getTime () {
   return "SELECT round(date_part('epoch', now()) * 1000) as time"
 }
 
-function insertWarning(schema: string) {
+function insertWarning (schema: string) {
   return `
     INSERT INTO ${schema}.warning (type, message, data)
     VALUES ($1, $2, $3)
   `
 }
 
-function getWarnings(schema: string): string {
+function getWarnings (schema: string): string {
   return `
     SELECT
       id,
@@ -769,7 +770,7 @@ function getWarnings(schema: string): string {
   `
 }
 
-function getWarningsCount(schema: string): string {
+function getWarningsCount (schema: string): string {
   return `
     SELECT COUNT(*)::int as count
     FROM ${schema}.warning
@@ -777,26 +778,26 @@ function getWarningsCount(schema: string): string {
   `
 }
 
-function deleteOldWarnings(schema: string, days: number): string {
+function deleteOldWarnings (schema: string, days: number): string {
   return `
     DELETE FROM ${schema}.warning
     WHERE created_on < now() - interval '${days} days'
   `
 }
 
-function getVersion(schema: string) {
+function getVersion (schema: string) {
   return `SELECT version from ${schema}.version`
 }
 
-function setVersion(schema: string, version: number) {
+function setVersion (schema: string, version: number) {
   return `UPDATE ${schema}.version SET version = '${version}'`
 }
 
-function versionTableExists(schema: string) {
+function versionTableExists (schema: string) {
   return `SELECT to_regclass('${schema}.version') as name`
 }
 
-function insertVersion(schema: string, version: number) {
+function insertVersion (schema: string, version: number) {
   return `INSERT INTO ${schema}.version(version) VALUES ('${version}')`
 }
 
@@ -832,7 +833,7 @@ interface FetchQueryParams {
   maxPriorityParam: string
 }
 
-function buildFetchParams(options: FetchJobOptions): FetchQueryParams {
+function buildFetchParams (options: FetchJobOptions): FetchQueryParams {
   const { ignoreSingletons, ignoreGroups, groupConcurrency, minPriority, maxPriority } = options
   const hasIgnoreSingletons = ignoreSingletons != null && ignoreSingletons.length > 0
   const hasIgnoreGroups = ignoreGroups != null && ignoreGroups.length > 0
@@ -892,7 +893,7 @@ function buildFetchParams(options: FetchJobOptions): FetchQueryParams {
   return { values, ignoreSingletonsParam, ignoreGroupsParam, defaultGroupLimitParam, tiersParam, minPriorityParam, maxPriorityParam }
 }
 
-function fetchNextJob(options: FetchJobOptions): SqlQuery {
+function fetchNextJob (options: FetchJobOptions): SqlQuery {
   const { schema, table, name, policy, limit, includeMetadata, priority = true, orderByCreatedOn = true, ignoreStartAfter = false, groupConcurrency, minPriority, maxPriority } = options
 
   const singletonFetch = limit > 1 && (policy === QUEUE_POLICIES.singleton || policy === QUEUE_POLICIES.stately)
@@ -944,8 +945,8 @@ function fetchNextJob(options: FetchJobOptions): SqlQuery {
       ? `(j.group_id IS NULL
             OR agc.active_cnt IS NULL
             OR agc.active_cnt < ${hasTiers
-        ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
-        : params.defaultGroupLimitParam})`
+               ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
+               : params.defaultGroupLimitParam})`
       : ''
   ].filter(Boolean).join('\n          AND ')
 
@@ -985,16 +986,16 @@ function fetchNextJob(options: FetchJobOptions): SqlQuery {
         SELECT id FROM group_ranking
         WHERE group_id IS NULL
           OR (active_cnt + group_rn) <= ${hasTiers
-      ? `COALESCE((${params.tiersParam} ->> group_tier)::int, ${params.defaultGroupLimitParam})`
-      : params.defaultGroupLimitParam}
+           ? `COALESCE((${params.tiersParam} ->> group_tier)::int, ${params.defaultGroupLimitParam})`
+           : params.defaultGroupLimitParam}
       )`
     : ''
 
   const finalCte = (hasGroupConcurrency)
     ? 'group_filtered'
     : (singletonFetch)
-      ? 'singleton_ranking'
-      : 'next'
+        ? 'singleton_ranking'
+        : 'next'
 
   return {
     text: `
@@ -1017,89 +1018,53 @@ function fetchNextJob(options: FetchJobOptions): SqlQuery {
   }
 }
 
-function createCompleteJobsFunction(schema: string) {
+function completeJobs (schema: string, table: string, includeQueued?: boolean) {
   return `
-    CREATE OR REPLACE FUNCTION ${schema}.complete_jobs(
-      queue_name text,
-      job_table text,
-      job_ids uuid[],
-      job_output jsonb,
-      include_queued boolean DEFAULT false
+    WITH completed AS (
+      UPDATE ${schema}.${table}
+      SET completed_on = now(),
+         state = '${JOB_STATES.completed}',
+          output = $3,
+          blocked = ${includeQueued ? 'false' : 'blocked'},
+          pending_dependencies = ${includeQueued ? '0' : 'pending_dependencies'}
+      WHERE name = $1
+        AND id IN (SELECT UNNEST($2::uuid[]))
+        AND ${includeQueued
+          ? `state < '${JOB_STATES.completed}'`
+          : `state = '${JOB_STATES.active}'`
+        }
+      RETURNING name, id, blocking
+    ),
+    decremented AS (
+      SELECT d.child_name, d.child_id, COUNT(*)::int AS n
+      FROM ${schema}.job_dependency d
+      JOIN completed c ON c.blocking
+        AND d.parent_name = c.name
+        AND d.parent_id = c.id
+      GROUP BY d.child_name, d.child_id
+    ),
+    locked_children AS (
+      SELECT j.name, j.id, d.n
+      FROM ${schema}.job j
+      JOIN decremented d ON d.child_name = j.name
+        AND d.child_id = j.id
+      WHERE j.blocked
+      FOR UPDATE OF j
+    ),
+    unblocked AS (
+      UPDATE ${schema}.job j
+      SET pending_dependencies = GREATEST(j.pending_dependencies - lc.n, 0),
+          blocked = GREATEST(j.pending_dependencies - lc.n, 0) > 0
+      FROM locked_children lc
+      WHERE j.name = lc.name
+        AND j.id = lc.id
+      RETURNING 1
     )
-    RETURNS bigint AS
-    $$
-    DECLARE
-      completed_count bigint;
-      has_blocking boolean;
-    BEGIN
-      EXECUTE format(
-        'CREATE TEMP TABLE _completed ON COMMIT DROP AS
-         WITH results AS (
-           UPDATE %I.%I
-           SET completed_on = now(),
-               state = ''${JOB_STATES.completed}'',
-               output = $1
-           WHERE name = $2
-             AND id IN (SELECT UNNEST($3))
-             AND %s
-           RETURNING *
-         )
-         SELECT * FROM results',
-        '${schema}', job_table,
-        CASE WHEN include_queued
-          THEN 'state < ''${JOB_STATES.completed}'''
-          ELSE 'state = ''${JOB_STATES.active}'''
-        END
-      ) USING job_output, queue_name, job_ids;
-
-      SELECT COUNT(*) INTO completed_count FROM _completed;
-
-      IF completed_count = 0 THEN
-        RETURN 0;
-      END IF;
-
-      SELECT EXISTS(SELECT 1 FROM _completed WHERE blocking = true)
-        INTO has_blocking;
-
-      IF has_blocking THEN
-        EXECUTE format(
-          'UPDATE %I.job j
-           SET blocked = false
-           FROM (
-             SELECT DISTINCT d.child_name, d.child_id
-             FROM %I.job_dependency d
-             JOIN _completed c ON c.name = d.parent_name AND c.id = d.parent_id
-             WHERE c.blocking = true
-           ) ct
-           WHERE j.name = ct.child_name
-             AND j.id = ct.child_id
-             AND j.blocked = true
-             AND NOT EXISTS (
-               SELECT 1
-               FROM %I.job_dependency d2
-               JOIN %I.job p ON p.name = d2.parent_name AND p.id = d2.parent_id
-               LEFT JOIN _completed r ON r.name = p.name AND r.id = p.id
-               WHERE d2.child_name = ct.child_name
-                 AND d2.child_id = ct.child_id
-                 AND p.state <> ''${JOB_STATES.completed}''
-                 AND r.id IS NULL
-             )',
-          '${schema}', '${schema}', '${schema}', '${schema}'
-        );
-      END IF;
-
-      RETURN completed_count;
-    END;
-    $$
-    LANGUAGE plpgsql;
+    SELECT COUNT(*) FROM completed
   `
 }
 
-function completeJobs(schema: string, table: string, includeQueued?: boolean) {
-  return `SELECT ${schema}.complete_jobs($1::text, '${table}'::text, $2::uuid[], $3::jsonb, ${includeQueued || false}::boolean) as count`
-}
-
-function cancelJobs(schema: string, table: string) {
+function cancelJobs (schema: string, table: string) {
   return `
     WITH results as (
       UPDATE ${schema}.${table}
@@ -1114,7 +1079,7 @@ function cancelJobs(schema: string, table: string) {
   `
 }
 
-function resumeJobs(schema: string, table: string) {
+function resumeJobs (schema: string, table: string) {
   return `
     WITH results as (
       UPDATE ${schema}.${table}
@@ -1129,7 +1094,7 @@ function resumeJobs(schema: string, table: string) {
   `
 }
 
-function restoreJobs(schema: string, table: string) {
+function restoreJobs (schema: string, table: string) {
   return `
     UPDATE ${schema}.${table}
     SET state = '${JOB_STATES.created}',
@@ -1146,7 +1111,7 @@ interface InsertJobsOptions {
   returnId?: boolean
 }
 
-function insertJobs(schema: string, { table, name, returnId = true }: InsertJobsOptions) {
+function insertJobs (schema: string, { table, name, returnId = true }: InsertJobsOptions) {
   const sql = `
     INSERT INTO ${schema}.${table} (
       id,
@@ -1169,7 +1134,8 @@ function insertJobs(schema: string, { table, name, returnId = true }: InsertJobs
       dead_letter,
       heartbeat_seconds,
       blocked,
-      blocking
+      blocking,
+      pending_dependencies
     )
     SELECT
       COALESCE(id, gen_random_uuid()) as id,
@@ -1195,7 +1161,8 @@ function insertJobs(schema: string, { table, name, returnId = true }: InsertJobs
       COALESCE("deadLetter", q.dead_letter) as dead_letter,
       COALESCE("heartbeatSeconds", q.heartbeat_seconds) as heartbeat_seconds,
       COALESCE(blocked, false) as blocked,
-      COALESCE(blocking, false) as blocking
+      COALESCE(blocking, false) as blocking,
+      COALESCE("pendingDependencies", 0) as pending_dependencies
     FROM (
       SELECT *,
         CASE
@@ -1222,7 +1189,8 @@ function insertJobs(schema: string, { table, name, returnId = true }: InsertJobs
         "deadLetter" text,
         "heartbeatSeconds" integer,
         blocked boolean,
-        blocking boolean
+        blocking boolean,
+        "pendingDependencies" integer
       )
     ) j
     JOIN ${schema}.queue q ON q.name = '${name}'
@@ -1233,14 +1201,14 @@ function insertJobs(schema: string, { table, name, returnId = true }: InsertJobs
   return sql
 }
 
-function failJobsById(schema: string, table: string) {
+function failJobsById (schema: string, table: string) {
   const where = `name = $1 AND id IN (SELECT UNNEST($2::uuid[])) AND state < '${JOB_STATES.completed}'`
   const output = '$3::jsonb'
 
   return failJobs(schema, table, where, output)
 }
 
-function failJobsByTimeout(schema: string, table: string, queues: string[]): string {
+function failJobsByTimeout (schema: string, table: string, queues: string[]): string {
   const where = `state = '${JOB_STATES.active}'
             AND (started_on + expire_seconds * interval '1s') < now()
             AND name = ANY(${serializeArrayParam(queues)})`
@@ -1250,7 +1218,7 @@ function failJobsByTimeout(schema: string, table: string, queues: string[]): str
   return locked(schema, failJobs(schema, table, where, output), table + 'failJobsByTimeout')
 }
 
-function failJobsByHeartbeat(schema: string, table: string, queues: string[]): string {
+function failJobsByHeartbeat (schema: string, table: string, queues: string[]): string {
   const where = `state = '${JOB_STATES.active}'
             AND heartbeat_seconds IS NOT NULL
             AND (heartbeat_on + heartbeat_seconds * interval '1s') < now()
@@ -1261,7 +1229,7 @@ function failJobsByHeartbeat(schema: string, table: string, queues: string[]): s
   return locked(schema, failJobs(schema, table, where, output), table + 'failJobsByHeartbeat')
 }
 
-function touchJobs(schema: string, table: string) {
+function touchJobs (schema: string, table: string) {
   return `
     WITH results AS (
       UPDATE ${schema}.${table}
@@ -1275,7 +1243,7 @@ function touchJobs(schema: string, table: string) {
   `
 }
 
-function failJobs(schema: string, table: string, where: string, output: string) {
+function failJobs (schema: string, table: string, where: string, output: string) {
   return `
     WITH deleted_jobs AS (
       DELETE FROM ${schema}.${table}
@@ -1311,7 +1279,8 @@ function failJobs(schema: string, table: string, where: string, output: string) 
         heartbeat_on,
         heartbeat_seconds,
         blocked,
-        blocking
+        blocking,
+        pending_dependencies
       )
       SELECT
         id,
@@ -1353,7 +1322,8 @@ function failJobs(schema: string, table: string, where: string, output: string) 
         NULL as heartbeat_on,
         heartbeat_seconds,
         blocked,
-        blocking
+        blocking,
+        pending_dependencies
       FROM deleted_jobs
       ON CONFLICT DO NOTHING
       RETURNING *
@@ -1387,7 +1357,8 @@ function failJobs(schema: string, table: string, where: string, output: string) 
         heartbeat_on,
         heartbeat_seconds,
         blocked,
-        blocking
+        blocking,
+        pending_dependencies
       )
       SELECT
         id,
@@ -1417,7 +1388,8 @@ function failJobs(schema: string, table: string, where: string, output: string) 
         NULL as heartbeat_on,
         heartbeat_seconds,
         blocked,
-        blocking
+        blocking,
+        pending_dependencies
       FROM deleted_jobs
       WHERE id NOT IN (SELECT id from retried_jobs)
       RETURNING *
@@ -1446,7 +1418,7 @@ function failJobs(schema: string, table: string, where: string, output: string) 
   `
 }
 
-function deletion(schema: string, table: string, queues: string[]): string {
+function deletion (schema: string, table: string, queues: string[]): string {
   const sql = `
     DELETE FROM ${schema}.${table}
     WHERE name = ANY(${serializeArrayParam(queues)})
@@ -1461,7 +1433,7 @@ function deletion(schema: string, table: string, queues: string[]): string {
   return locked(schema, sql, table + 'deletion')
 }
 
-function retryJobs(schema: string, table: string) {
+function retryJobs (schema: string, table: string) {
   return `
     WITH results as (
       UPDATE ${schema}.job
@@ -1476,7 +1448,7 @@ function retryJobs(schema: string, table: string) {
   `
 }
 
-function getQueueStats(schema: string, table: string, queues: string[]): SqlQuery {
+function getQueueStats (schema: string, table: string, queues: string[]): SqlQuery {
   return {
     text: `
     SELECT
@@ -1494,7 +1466,7 @@ function getQueueStats(schema: string, table: string, queues: string[]): SqlQuer
   }
 }
 
-function cacheQueueStats(schema: string, table: string, queues: string[]): string {
+function cacheQueueStats (schema: string, table: string, queues: string[]): string {
   const statsQuery = getQueueStats(schema, table, queues)
   // Serialize the $1 parameter for use in locked() multi-statement query
   const statsText = statsQuery.text.replace('$1::text[]', serializeArrayParam(queues))
@@ -1523,12 +1495,12 @@ function cacheQueueStats(schema: string, table: string, queues: string[]): strin
 }
 
 // Serialize a string array for embedding directly in SQL as PostgreSQL array literal
-function serializeArrayParam(values: string[]): string {
+function serializeArrayParam (values: string[]): string {
   const escaped = values.map(v => `'${v.replace(SINGLE_QUOTE_REGEX, "''")}'`)
   return `ARRAY[${escaped.join(',')}]::text[]`
 }
 
-function locked(schema: string, query: string | string[], key?: string): string {
+function locked (schema: string, query: string | string[], key?: string): string {
   const sql = Array.isArray(query) ? query.join(';\n') : query
 
   return `
@@ -1541,18 +1513,18 @@ function locked(schema: string, query: string | string[], key?: string): string 
   `
 }
 
-function advisoryLock(schema: string, key?: string) {
+function advisoryLock (schema: string, key?: string) {
   return `SELECT pg_advisory_xact_lock(
       ('x' || encode(sha224((current_database() || '.pgboss.${schema}${key || ''}')::bytea), 'hex'))::bit(64)::bigint
   )`
 }
 
-function assertMigration(schema: string, version: number) {
+function assertMigration (schema: string, version: number) {
   // raises 'division by zero' if already on desired schema version
   return `SELECT version::int/(version::int-${version}) from ${schema}.version`
 }
 
-function findJobs(schema: string, table: string, options: { queued: boolean, byKey: boolean, byData: boolean, byId: boolean }) {
+function findJobs (schema: string, table: string, options: { queued: boolean, byKey: boolean, byData: boolean, byId: boolean }) {
   const { queued, byKey, byData, byId } = options
 
   let paramIndex = 1
@@ -1585,7 +1557,7 @@ function findJobs(schema: string, table: string, options: { queued: boolean, byK
     `
 }
 
-function getJobById(schema: string, table: string) {
+function getJobById (schema: string, table: string) {
   return `
     SELECT ${JOB_COLUMNS_ALL}
     FROM ${schema}.${table}
@@ -1594,7 +1566,7 @@ function getJobById(schema: string, table: string) {
     `
 }
 
-function insertDependencies(schema: string) {
+function insertDependencies (schema: string) {
   return `
     INSERT INTO ${schema}.job_dependency (child_name, child_id, parent_name, parent_id)
     SELECT child_name, child_id, parent_name, parent_id
@@ -1608,25 +1580,7 @@ function insertDependencies(schema: string) {
   `
 }
 
-function markJobsBlocking(schema: string): SqlQuery {
-  return {
-    text: `
-      UPDATE ${schema}.job
-      SET blocking = true
-      WHERE (name, id) IN (
-        SELECT parent_name, parent_id
-        FROM json_to_recordset($1::json) AS x (
-          parent_name text,
-          parent_id uuid
-        )
-      )
-      AND NOT blocking
-    `,
-    values: []
-  }
-}
-
-function getDependencies(schema: string) {
+function getDependencies (schema: string) {
   return `
     SELECT parent_name as "parentName", parent_id as "parentId"
     FROM ${schema}.job_dependency
@@ -1634,7 +1588,7 @@ function getDependencies(schema: string) {
   `
 }
 
-function getDependents(schema: string) {
+function getDependents (schema: string) {
   return `
     SELECT child_name as "childName", child_id as "childId"
     FROM ${schema}.job_dependency
@@ -1642,7 +1596,7 @@ function getDependents(schema: string) {
   `
 }
 
-function cleanupDependencies(schema: string, table: string, queues: string[]): string {
+function cleanupDependencies (schema: string, table: string, queues: string[]): string {
   const sql = `
     DELETE FROM ${schema}.job_dependency
     WHERE (child_name = ANY(${serializeArrayParam(queues)})
@@ -1660,7 +1614,7 @@ function cleanupDependencies(schema: string, table: string, queues: string[]): s
   return locked(schema, sql, table + 'cleanupDependencies')
 }
 
-function getBlockedKeys(schema: string, table: string) {
+function getBlockedKeys (schema: string, table: string) {
   return `
     SELECT DISTINCT singleton_key as "singletonKey"
     FROM ${schema}.${table}
@@ -1670,7 +1624,7 @@ function getBlockedKeys(schema: string, table: string) {
     `
 }
 
-function getNextBamCommand(schema: string) {
+function getNextBamCommand (schema: string) {
   return `
     UPDATE ${schema}.bam
     SET status = 'in_progress', started_on = now()
@@ -1686,7 +1640,7 @@ function getNextBamCommand(schema: string) {
   `
 }
 
-function setBamCompleted(schema: string, id: string) {
+function setBamCompleted (schema: string, id: string) {
   return `
     UPDATE ${schema}.bam
     SET status = 'completed', completed_on = now()
@@ -1694,7 +1648,7 @@ function setBamCompleted(schema: string, id: string) {
   `
 }
 
-function setBamFailed(schema: string, id: string, error: string) {
+function setBamFailed (schema: string, id: string, error: string) {
   const escapedError = error.replace(/'/g, "''")
   return `
     UPDATE ${schema}.bam
@@ -1703,7 +1657,7 @@ function setBamFailed(schema: string, id: string, error: string) {
   `
 }
 
-function getBamStatus(schema: string) {
+function getBamStatus (schema: string) {
   return `
     SELECT status, count(*)::int as count, max(created_on) as "lastCreatedOn"
     FROM ${schema}.bam
@@ -1711,7 +1665,7 @@ function getBamStatus(schema: string) {
   `
 }
 
-function getBamEntries(schema: string) {
+function getBamEntries (schema: string) {
   return `
     SELECT id, name, version, status, queue, table_name as "table", command, error,
            created_on as "createdOn", started_on as "startedOn", completed_on as "completedOn"
@@ -1773,13 +1727,11 @@ export {
   createIndexWarning,
   getBlockedKeys,
   insertDependencies,
-  markJobsBlocking,
   getDependencies,
   getDependents,
   cleanupDependencies,
   createTableJobDependency,
   createIndexJobDependencyParent,
-  createCompleteJobsFunction,
   getNextBamCommand,
   setBamCompleted,
   setBamFailed,

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,11 @@ export interface GroupOptions {
   tier?: string;
 }
 
+export interface DependencyRef {
+  name: string;
+  id: string;
+}
+
 export interface GroupConcurrencyConfig {
   default: number;
   tiers?: Record<string, number>;
@@ -186,6 +191,14 @@ export interface JobOptions {
   keepUntil?: number | string | Date;
   group?: GroupOptions;
   deadLetter?: string;
+}
+
+export interface FlowJob {
+  ref: string;
+  name: string;
+  data?: object;
+  options?: Omit<JobInsert, 'data'>;
+  dependsOn?: string[];
 }
 
 export interface ConnectionOptions {
@@ -421,6 +434,8 @@ export interface JobWithMetadata<T = object> extends Job<T> {
   policy: QueuePolicy;
   heartbeatOn: Date | null;
   heartbeatSeconds: number | null;
+  blocked: boolean;
+  blocking: boolean;
   deadLetter: string;
   output: object;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -436,6 +436,7 @@ export interface JobWithMetadata<T = object> extends Job<T> {
   heartbeatSeconds: number | null;
   blocked: boolean;
   blocking: boolean;
+  pendingDependencies: number;
   deadLetter: string;
   output: object;
 }

--- a/test/dependencyTest.ts
+++ b/test/dependencyTest.ts
@@ -1,0 +1,330 @@
+import { expect } from 'vitest'
+import * as helper from './testHelper.ts'
+import { assertTruthy } from './testHelper.ts'
+import { ctx } from './hooks.ts'
+import { PgBoss } from '../src/index.ts'
+
+describe('dependencies', function () {
+  it('should block a job until its parent completes', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'parent', name: ctx.schema },
+      { ref: 'child', name: ctx.schema, data: { child: true }, dependsOn: ['parent'] }
+    ])
+
+    const parentId = flow.parent
+    const childId = flow.child
+
+    const childJob = await ctx.boss.getJobById(ctx.schema, childId)
+    assertTruthy(childJob)
+    expect(childJob.blocked).toBe(true)
+
+    const parentJob = await ctx.boss.getJobById(ctx.schema, parentId)
+    assertTruthy(parentJob)
+    expect(parentJob.blocking).toBe(true)
+
+    const fetched1 = await ctx.boss.fetch(ctx.schema)
+    expect(fetched1.length).toBe(1)
+    expect(fetched1[0].id).toBe(parentId)
+
+    await ctx.boss.complete(ctx.schema, parentId)
+
+    const fetched2 = await ctx.boss.fetch(ctx.schema)
+    expect(fetched2.length).toBe(1)
+    expect(fetched2[0].id).toBe(childId)
+  })
+
+  it('should support fan-in: child waits for multiple parents', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'p1', name: ctx.schema, data: { step: 1 } },
+      { ref: 'p2', name: ctx.schema, data: { step: 2 } },
+      { ref: 'child', name: ctx.schema, data: { step: 'aggregate' }, dependsOn: ['p1', 'p2'] }
+    ])
+
+    const parentId1 = flow.p1
+    const parentId2 = flow.p2
+    const childId = flow.child
+
+    const parent1Job = await ctx.boss.getJobById(ctx.schema, parentId1)
+    const parent2Job = await ctx.boss.getJobById(ctx.schema, parentId2)
+    assertTruthy(parent1Job)
+    assertTruthy(parent2Job)
+    expect(parent1Job.blocking).toBe(true)
+    expect(parent2Job.blocking).toBe(true)
+
+    const [job1] = await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.complete(ctx.schema, job1.id)
+
+    const childAfterOne = await ctx.boss.getJobById(ctx.schema, childId)
+    assertTruthy(childAfterOne)
+    expect(childAfterOne.blocked).toBe(true)
+
+    const [job2] = await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.complete(ctx.schema, job2.id)
+
+    const childAfterAll = await ctx.boss.getJobById(ctx.schema, childId)
+    assertTruthy(childAfterAll)
+    expect(childAfterAll.blocked).toBe(false)
+
+    const fetched = await ctx.boss.fetch(ctx.schema)
+    expect(fetched.length).toBe(1)
+    expect(fetched[0].id).toBe(childId)
+  })
+
+  it('should allow getDependencies and getDependents', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'parent', name: ctx.schema, data: { role: 'parent' } },
+      { ref: 'child', name: ctx.schema, data: { role: 'child' }, dependsOn: ['parent'] }
+    ])
+
+    const parentId = flow.parent
+    const childId = flow.child
+
+    const deps = await ctx.boss.getDependencies(ctx.schema, childId)
+    expect(deps.length).toBe(1)
+    expect(deps[0].name).toBe(ctx.schema)
+    expect(deps[0].id).toBe(parentId)
+
+    const dependents = await ctx.boss.getDependents(ctx.schema, parentId)
+    expect(dependents.length).toBe(1)
+    expect(dependents[0].name).toBe(ctx.schema)
+    expect(dependents[0].id).toBe(childId)
+  })
+
+  it('should keep child blocked when parent fails permanently', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'parent', name: ctx.schema, options: { retryLimit: 0 } },
+      { ref: 'child', name: ctx.schema, dependsOn: ['parent'] }
+    ])
+
+    const parentId = flow.parent
+    const childId = flow.child
+
+    const [job] = await ctx.boss.fetch(ctx.schema)
+    expect(job.id).toBe(parentId)
+    await ctx.boss.fail(ctx.schema, parentId, new Error('permanent failure'))
+
+    const childJob = await ctx.boss.getJobById(ctx.schema, childId)
+    assertTruthy(childJob)
+    expect(childJob.blocked).toBe(true)
+
+    const fetched = await ctx.boss.fetch(ctx.schema)
+    expect(fetched.length).toBe(0)
+  })
+
+  it('should keep child blocked when parent is cancelled', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'parent', name: ctx.schema },
+      { ref: 'child', name: ctx.schema, dependsOn: ['parent'] }
+    ])
+
+    const parentId = flow.parent
+    const childId = flow.child
+
+    await ctx.boss.cancel(ctx.schema, parentId)
+
+    const childJob = await ctx.boss.getJobById(ctx.schema, childId)
+    assertTruthy(childJob)
+    expect(childJob.blocked).toBe(true)
+
+    const fetched = await ctx.boss.fetch(ctx.schema)
+    expect(fetched.length).toBe(0)
+  })
+
+  it('should support cross-queue dependencies', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+    const queue1 = ctx.schema + '-q1'
+    const queue2 = ctx.schema + '-q2'
+
+    await ctx.boss.createQueue(queue1)
+    await ctx.boss.createQueue(queue2)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'parent', name: queue1, data: { role: 'parent' } },
+      { ref: 'child', name: queue2, data: { role: 'child' }, dependsOn: ['parent'] }
+    ])
+
+    const parentId = flow.parent
+    const childId = flow.child
+
+    const fetched1 = await ctx.boss.fetch(queue2)
+    expect(fetched1.length).toBe(0)
+
+    const [job] = await ctx.boss.fetch(queue1)
+    expect(job.id).toBe(parentId)
+    await ctx.boss.complete(queue1, parentId)
+
+    const fetched2 = await ctx.boss.fetch(queue2)
+    expect(fetched2.length).toBe(1)
+    expect(fetched2[0].id).toBe(childId)
+  })
+
+  it('should reject invalid createFlow input', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await expect(async () => {
+      await ctx.boss!.createFlow([
+        { ref: 'a', name: ctx.schema }
+      ])
+    }).rejects.toThrow('createFlow requires at least 2 jobs')
+
+    await expect(async () => {
+      await ctx.boss!.createFlow([
+        { ref: 'a', name: ctx.schema },
+        { ref: 'a', name: ctx.schema }
+      ])
+    }).rejects.toThrow('duplicate ref')
+
+    await expect(async () => {
+      await ctx.boss!.createFlow([
+        { ref: 'a', name: ctx.schema },
+        { ref: 'b', name: ctx.schema, dependsOn: ['missing'] }
+      ])
+    }).rejects.toThrow('not found in flow')
+
+    await expect(async () => {
+      await ctx.boss!.createFlow([
+        { ref: 'a', name: ctx.schema },
+        { ref: 'b', name: ctx.schema }
+      ])
+    }).rejects.toThrow('createFlow requires at least one job with dependsOn')
+
+    await expect(async () => {
+      await ctx.boss!.createFlow([
+        { ref: 'x', name: ctx.schema },
+        { ref: 'z', name: ctx.schema },
+        { ref: 'y', name: ctx.schema, dependsOn: ['x', 'z'] },
+        { ref: 'a', name: ctx.schema, dependsOn: ['b'] },
+        { ref: 'b', name: ctx.schema, dependsOn: ['a'] }
+      ])
+    }).rejects.toThrow('createFlow contains a dependency cycle: a -> b -> a')
+  })
+
+  it('should support createFlow with a provided db', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const db = await helper.getDb()
+    const calls: string[] = []
+
+    try {
+      const flow = await ctx.boss.createFlow([
+        { ref: 'parent', name: ctx.schema },
+        { ref: 'child', name: ctx.schema, dependsOn: ['parent'] }
+      ], {
+        db: {
+          async executeSql (sql, values) {
+            calls.push(sql)
+            return db.executeSql(sql, values)
+          }
+        }
+      })
+
+      const childJob = await ctx.boss.getJobById(ctx.schema, flow.child)
+      assertTruthy(childJob)
+      expect(childJob.blocked).toBe(true)
+      expect(calls.length).toBeGreaterThan(0)
+    } finally {
+      await db.close()
+    }
+  })
+
+  it('should support createFlow with a constructor-provided db', async function () {
+    const db = await helper.getDb()
+    const calls: string[] = []
+
+    try {
+      ctx.boss = new PgBoss({
+        ...ctx.bossConfig,
+        db: {
+          async executeSql (sql, values) {
+            calls.push(sql)
+            return db.executeSql(sql, values)
+          }
+        }
+      })
+
+      await ctx.boss.start()
+      await ctx.boss.createQueue(ctx.schema)
+
+      const flow = await ctx.boss.createFlow([
+        { ref: 'parent', name: ctx.schema },
+        { ref: 'child', name: ctx.schema, dependsOn: ['parent'] }
+      ])
+
+      const childJob = await ctx.boss.getJobById(ctx.schema, flow.child)
+      assertTruthy(childJob)
+      expect(childJob.blocked).toBe(true)
+      expect(calls.length).toBeGreaterThan(0)
+    } finally {
+      await ctx.boss?.stop({ close: false })
+      await db.close()
+    }
+  })
+
+  it('should roll back createFlow when job creation fails', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await expect(async () => {
+      await ctx.boss!.createFlow([
+        { ref: 'parent', name: ctx.schema, options: { id: 'not-a-uuid' } },
+        { ref: 'child', name: ctx.schema, dependsOn: ['parent'] }
+      ])
+    }).rejects.toThrow('invalid input syntax for type uuid')
+
+    const fetched = await ctx.boss.fetch(ctx.schema, { batchSize: 10 })
+    expect(fetched.length).toBe(0)
+  })
+
+  it('should honor startAfter on a dependent job', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'parent', name: ctx.schema },
+      { ref: 'child', name: ctx.schema, options: { startAfter: 3600 }, dependsOn: ['parent'] }
+    ])
+
+    const parentId = flow.parent
+    const childId = flow.child
+
+    const [job] = await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.complete(ctx.schema, job.id)
+
+    const childJob = await ctx.boss.getJobById(ctx.schema, childId)
+    assertTruthy(childJob)
+    expect(childJob.blocked).toBe(false)
+
+    const fetched = await ctx.boss.fetch(ctx.schema)
+    expect(fetched.length).toBe(0)
+  })
+
+  it('should complete batch including dependency unblock', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'p1', name: ctx.schema, data: { p: 1 } },
+      { ref: 'p2', name: ctx.schema, data: { p: 2 } },
+      { ref: 'c1', name: ctx.schema, data: { c: 1 }, dependsOn: ['p1'] },
+      { ref: 'c2', name: ctx.schema, data: { c: 2 }, dependsOn: ['p2'] }
+    ])
+
+    const parents = await ctx.boss.fetch(ctx.schema, { batchSize: 10 })
+    expect(parents.length).toBe(2)
+
+    await ctx.boss.complete(ctx.schema, parents.map(j => j.id))
+
+    const children = await ctx.boss.fetch(ctx.schema, { batchSize: 10 })
+    expect(children.length).toBe(2)
+    const childIds = children.map(j => j.id).sort()
+    expect(childIds).toEqual([flow.c1, flow.c2].sort())
+  })
+})

--- a/test/dependencyTest.ts
+++ b/test/dependencyTest.ts
@@ -1,8 +1,9 @@
+import { randomUUID } from 'node:crypto'
 import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { assertTruthy } from './testHelper.ts'
 import { ctx } from './hooks.ts'
-import { PgBoss } from '../src/index.ts'
+import { PgBoss, states } from '../src/index.ts'
 
 describe('dependencies', function () {
   it('should block a job until its parent completes', async function () {
@@ -293,7 +294,6 @@ describe('dependencies', function () {
       { ref: 'child', name: ctx.schema, options: { startAfter: 3600 }, dependsOn: ['parent'] }
     ])
 
-    const parentId = flow.parent
     const childId = flow.child
 
     const [job] = await ctx.boss.fetch(ctx.schema)
@@ -326,5 +326,108 @@ describe('dependencies', function () {
     expect(children.length).toBe(2)
     const childIds = children.map(j => j.id).sort()
     expect(childIds).toEqual([flow.c1, flow.c2].sort())
+  })
+
+  it('should unblock fan-in child when sibling parents complete concurrently', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+    const db1 = await helper.getDb()
+    const db2 = await helper.getDb()
+
+    try {
+      const flow = await ctx.boss.createFlow([
+        { ref: 'p1', name: ctx.schema },
+        { ref: 'p2', name: ctx.schema },
+        { ref: 'child', name: ctx.schema, dependsOn: ['p1', 'p2'] }
+      ])
+
+      const parents = await ctx.boss.fetch(ctx.schema, { batchSize: 2 })
+      expect(parents.length).toBe(2)
+
+      await Promise.all([
+        ctx.boss.complete(ctx.schema, flow.p1, null, { db: db1 }),
+        ctx.boss.complete(ctx.schema, flow.p2, null, { db: db2 })
+      ])
+
+      const childJob = await ctx.boss.getJobById(ctx.schema, flow.child)
+      assertTruthy(childJob)
+      expect(childJob.blocked).toBe(false)
+      expect(childJob.pendingDependencies).toBe(0)
+
+      const fetched = await ctx.boss.fetch(ctx.schema)
+      expect(fetched.length).toBe(1)
+      expect(fetched[0].id).toBe(flow.child)
+    } finally {
+      await db1.close()
+      await db2.close()
+    }
+  })
+
+  it('should roll back createFlow when an insert conflict skips a job', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+    const id = randomUUID()
+
+    await expect(async () => {
+      await ctx.boss!.createFlow([
+        { ref: 'parent', name: ctx.schema, options: { id } },
+        { ref: 'child', name: ctx.schema, options: { id }, dependsOn: ['parent'] }
+      ])
+    }).rejects.toThrow('createFlow failed to insert all jobs')
+
+    const jobCount = await helper.countJobs(ctx.schema, 'job', 'name = $1', [ctx.schema])
+    const dependencyCount = await helper.countJobs(ctx.schema, 'job_dependency', 'true')
+    expect(jobCount).toBe(0)
+    expect(dependencyCount).toBe(0)
+  })
+
+  it('should support two complete calls in one transaction', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+    const db = await helper.getDb()
+
+    try {
+      const flow = await ctx.boss.createFlow([
+        { ref: 'parent', name: ctx.schema },
+        { ref: 'child', name: ctx.schema, dependsOn: ['parent'] }
+      ])
+
+      const [parent] = await ctx.boss.fetch(ctx.schema)
+      expect(parent.id).toBe(flow.parent)
+
+      await db.withTransaction(async txDb => {
+        const parentResult = await ctx.boss!.complete(ctx.schema, flow.parent, null, { db: txDb })
+        expect(parentResult.affected).toBe(1)
+
+        const childResult = await ctx.boss!.complete(ctx.schema, flow.child, null, { db: txDb, includeQueued: true })
+        expect(childResult.affected).toBe(1)
+      })
+
+      const childJob = await ctx.boss.getJobById(ctx.schema, flow.child)
+      assertTruthy(childJob)
+      expect(childJob.blocked).toBe(false)
+      expect(childJob.pendingDependencies).toBe(0)
+      expect(childJob.state).toBe(states.completed)
+    } finally {
+      await db.close()
+    }
+  })
+
+  it('should complete a blocked child with its parent when includeQueued is true', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const flow = await ctx.boss.createFlow([
+      { ref: 'parent', name: ctx.schema },
+      { ref: 'child', name: ctx.schema, dependsOn: ['parent'] }
+    ])
+
+    const result = await ctx.boss.complete(ctx.schema, [flow.parent, flow.child], null, { includeQueued: true })
+    expect(result.affected).toBe(2)
+
+    const parentJob = await ctx.boss.getJobById(ctx.schema, flow.parent)
+    const childJob = await ctx.boss.getJobById(ctx.schema, flow.child)
+    assertTruthy(parentJob)
+    assertTruthy(childJob)
+    expect(parentJob.state).toBe(states.completed)
+    expect(childJob.state).toBe(states.completed)
+    expect(childJob.blocked).toBe(false)
+    expect(childJob.pendingDependencies).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

- Added `createFlow(jobs, options)` for atomic dependency graph creation.
- Added transaction support to the internal `Db` class via `withTransaction()`.
- Added validation for:
  - duplicate refs
  - missing dependency refs
  - self-dependencies
  - dependency cycles, including the detected cycle in the error message
- Updated dependency tests to use `createFlow()`.
- Updated docs to describe `createFlow()` as the dependency API.

## Example

```js
const flow = await boss.createFlow([
  { ref: 'extract-a', name: 'extract', data: { file: '1.csv' } },
  { ref: 'extract-b', name: 'extract', data: { file: '2.csv' } },
  {
    ref: 'load',
    name: 'load',
    data: { output: 'report.csv' },
    dependsOn: ['extract-a', 'extract-b']
  }
])

const loadJobId = flow.load
```
Resolves https://github.com/timgit/pg-boss/issues/745