### PR TITLE
fix: remove implicit `@types/pg` dependency from public constructor types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import type pg from 'pg'
-
 export type JobStates = {
   created: 'created',
   retry: 'retry',
@@ -21,9 +19,19 @@ export interface IDatabase {
   executeSql(text: string, values?: unknown[]): Promise<{ rows: any[] }>;
 }
 
-export interface DatabaseOptions extends pg.PoolConfig {
+export interface DatabaseOptions {
+  application_name?: string;
+  database?: string;
+  user?: string;
+  password?: string | (() => string | Promise<string>);
+  host?: string;
+  port?: number;
   schema?: string;
+  ssl?: any;
+  connectionString?: string;
+  max?: number;
   db?: IDatabase;
+  connectionTimeoutMillis?: number;
   /** @internal */
   debug?: boolean;
 }


### PR DESCRIPTION
Fixes https://github.com/timgit/pg-boss/issues/776

--- 

Replace `extends pg.PoolConfig` with a locally-defined `PoolConfig` interface that mirrors the relevant pool properties.

Code changes: 
- The `password` type now matches the type of `password` on the `pg.ClientConfig` type ([reference](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/de9d7a2a0f0fa222ad71babffd3144df176d3410/types/pg/index.d.ts#L15)).

