### PR TITLE
Add filters to the dashboard Jobs page

### DIFF
--- a/packages/dashboard/app/components/jobs-filter-bar.tsx
+++ b/packages/dashboard/app/components/jobs-filter-bar.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useRef, useState } from 'react'
+import { Plus, X } from 'lucide-react'
+import { Button } from '~/components/ui/button'
+import { FilterSelect } from '~/components/ui/filter-select'
+import { QueueMultiSelect } from '~/components/ui/queue-multiselect'
+import {
+  cn,
+  JOB_STATE_OPTIONS,
+  MAX_JSON_FILTER_PAIRS,
+  type JobStateFilter,
+  type JsonFilterPair,
+} from '~/lib/utils'
+
+export interface JobsFilters {
+  state: JobStateFilter
+  id: string
+  queues: string[]
+  minRetries: string
+  data: JsonFilterPair[]
+  output: JsonFilterPair[]
+}
+
+interface JobsFilterBarProps {
+  filters: JobsFilters
+  queueOptions: string[]
+  onChange: (next: JobsFilters) => void
+}
+
+// Filter controls for the global Jobs page. Pure presentation: keeps the id /
+// minRetries inputs in local state so typing is responsive, then commits via
+// onChange on Enter or blur. The route owns the URL-synced state.
+export function JobsFilterBar ({ filters, queueOptions, onChange }: JobsFilterBarProps) {
+  const [idInput, setIdInput] = useState(filters.id)
+  const [minRetriesInput, setMinRetriesInput] = useState(filters.minRetries)
+  // Local pair lists so half-typed rows ({ key: '', value: '' }) can render
+  // before they're complete enough to commit to the URL-backed filters.
+  const [dataPairs, setDataPairs] = useState<JsonFilterPair[]>(filters.data)
+  const [outputPairs, setOutputPairs] = useState<JsonFilterPair[]>(filters.output)
+  const [advancedOpen, setAdvancedOpen] = useState(
+    filters.data.length > 0 || filters.output.length > 0
+  )
+
+  // Track the last set of pairs WE committed to the URL so we can distinguish
+  // our own echo (props === lastCommitted) from external changes like Clear All
+  // or browser navigation. Without this, the moment a user clears the only
+  // letter of a value the props sync back to [] and wipe their half-typed row.
+  const lastCommittedDataRef = useRef<JsonFilterPair[]>(filters.data)
+  const lastCommittedOutputRef = useRef<JsonFilterPair[]>(filters.output)
+
+  // Sync local input state when filters change from the outside (e.g. URL nav,
+  // "Clear all"). Without this the inputs would show stale text after a reset.
+  useEffect(() => { setIdInput(filters.id) }, [filters.id])
+  useEffect(() => { setMinRetriesInput(filters.minRetries) }, [filters.minRetries])
+  useEffect(() => {
+    if (!pairsEqual(filters.data, lastCommittedDataRef.current)) {
+      setDataPairs(filters.data)
+      lastCommittedDataRef.current = filters.data
+    }
+  }, [filters.data])
+  useEffect(() => {
+    if (!pairsEqual(filters.output, lastCommittedOutputRef.current)) {
+      setOutputPairs(filters.output)
+      lastCommittedOutputRef.current = filters.output
+    }
+  }, [filters.output])
+
+  const commitId = () => {
+    if (idInput === filters.id) return
+    onChange({ ...filters, id: idInput.trim() })
+  }
+
+  const commitMinRetries = () => {
+    if (minRetriesInput === filters.minRetries) return
+    const trimmed = minRetriesInput.trim()
+    const valid = trimmed === '' || (/^\d+$/.test(trimmed) && Number(trimmed) >= 0)
+    onChange({ ...filters, minRetries: valid ? trimmed : '' })
+    if (!valid) setMinRetriesInput('')
+  }
+
+  const handleDataChange = (next: JsonFilterPair[]) => {
+    setDataPairs(next)
+    const valid = next.filter(p => p.key && p.value !== '')
+    // Only commit when the set of valid pairs actually changes — otherwise
+    // typing an empty key would trigger an unnecessary navigation.
+    if (!pairsEqual(valid, lastCommittedDataRef.current)) {
+      lastCommittedDataRef.current = valid
+      onChange({ ...filters, data: valid })
+    }
+  }
+
+  const handleOutputChange = (next: JsonFilterPair[]) => {
+    setOutputPairs(next)
+    const valid = next.filter(p => p.key && p.value !== '')
+    if (!pairsEqual(valid, lastCommittedOutputRef.current)) {
+      lastCommittedOutputRef.current = valid
+      onChange({ ...filters, output: valid })
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="flex-1">
+          <div className="relative">
+            <input
+              type="text"
+              placeholder="Filter by job ID (UUID)..."
+              value={idInput}
+              onChange={(e) => setIdInput(e.target.value)}
+              onBlur={commitId}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  commitId()
+                }
+              }}
+              className={cn(
+                'w-full px-4 py-2 pl-10 rounded-lg border shadow-sm font-mono text-sm',
+                'bg-white border-gray-300 text-gray-900 placeholder-gray-500',
+                'dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400',
+                'focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600',
+                'dark:focus:ring-primary-500 dark:focus:border-primary-500'
+              )}
+            />
+            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
+            {idInput && (
+              <button
+                type="button"
+                onClick={() => {
+                  setIdInput('')
+                  onChange({ ...filters, id: '' })
+                }}
+                aria-label="Clear job id filter"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            )}
+          </div>
+        </div>
+        <QueueMultiSelect
+          options={queueOptions}
+          value={filters.queues}
+          onChange={(next) => onChange({ ...filters, queues: next })}
+        />
+        <FilterSelect
+          value={filters.state}
+          options={JOB_STATE_OPTIONS}
+          onChange={(value) => onChange({ ...filters, state: value as JobStateFilter })}
+        />
+        <input
+          type="number"
+          min={0}
+          inputMode="numeric"
+          placeholder="Min retries"
+          aria-label="Minimum retries"
+          value={minRetriesInput}
+          onChange={(e) => setMinRetriesInput(e.target.value)}
+          onBlur={commitMinRetries}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              commitMinRetries()
+            }
+          }}
+          className={cn(
+            'w-32 px-3 py-2 text-sm rounded-lg border shadow-sm',
+            'bg-white border-gray-300 text-gray-900 placeholder-gray-500',
+            'dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400',
+            'focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600',
+            'dark:focus:ring-primary-500 dark:focus:border-primary-500'
+          )}
+        />
+      </div>
+
+      <div>
+        <button
+          type="button"
+          onClick={() => setAdvancedOpen(o => !o)}
+          aria-expanded={advancedOpen}
+          className="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 cursor-pointer"
+        >
+          {advancedOpen ? 'Hide advanced filters' : 'Show advanced filters'}
+        </button>
+
+        {advancedOpen && (
+          <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <PairFilterGroup
+              title="Data"
+              hint="key=value pairs match against the job's data column (jsonb @>)."
+              pairs={dataPairs}
+              onChange={handleDataChange}
+            />
+            <PairFilterGroup
+              title="Output"
+              hint="key=value pairs match against the job's output column."
+              pairs={outputPairs}
+              onChange={handleOutputChange}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface PairFilterGroupProps {
+  title: string
+  hint: string
+  pairs: JsonFilterPair[]
+  onChange: (pairs: JsonFilterPair[]) => void
+}
+
+function PairFilterGroup ({ title, hint, pairs, onChange }: PairFilterGroupProps) {
+  const updatePair = (index: number, patch: Partial<JsonFilterPair>) => {
+    onChange(pairs.map((p, i) => i === index ? { ...p, ...patch } : p))
+  }
+  const removePair = (index: number) => {
+    onChange(pairs.filter((_, i) => i !== index))
+  }
+  const addPair = () => {
+    if (pairs.length >= MAX_JSON_FILTER_PAIRS) return
+    onChange([...pairs, { key: '', value: '' }])
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-3 space-y-2">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">{title}</h3>
+        <span className="text-xs text-gray-500 dark:text-gray-400">{hint}</span>
+      </div>
+      {pairs.length === 0 && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 italic">No {title.toLowerCase()} filters</p>
+      )}
+      {pairs.map((pair, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <input
+            type="text"
+            placeholder="key"
+            aria-label={`${title} filter key ${index + 1}`}
+            value={pair.key}
+            onChange={(e) => updatePair(index, { key: e.target.value })}
+            className={cn(
+              'flex-1 px-2 py-1 text-sm rounded border font-mono',
+              'bg-white border-gray-300 text-gray-900 placeholder-gray-500',
+              'dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400',
+              'focus:outline-none focus:ring-1 focus:ring-primary-600'
+            )}
+          />
+          <span className="text-gray-400">=</span>
+          <input
+            type="text"
+            placeholder="value"
+            aria-label={`${title} filter value ${index + 1}`}
+            value={pair.value}
+            onChange={(e) => updatePair(index, { value: e.target.value })}
+            className={cn(
+              'flex-1 px-2 py-1 text-sm rounded border font-mono',
+              'bg-white border-gray-300 text-gray-900 placeholder-gray-500',
+              'dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400',
+              'focus:outline-none focus:ring-1 focus:ring-primary-600'
+            )}
+          />
+          <button
+            type="button"
+            onClick={() => removePair(index)}
+            aria-label={`Remove ${title.toLowerCase()} filter ${index + 1}`}
+            className="p-1 text-gray-400 hover:text-red-600 cursor-pointer"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={addPair}
+        disabled={pairs.length >= MAX_JSON_FILTER_PAIRS}
+      >
+        <Plus className="h-4 w-4 mr-1" /> Add {title.toLowerCase()} filter
+      </Button>
+    </div>
+  )
+}
+
+function pairsEqual (a: JsonFilterPair[], b: JsonFilterPair[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].key !== b[i].key || a[i].value !== b[i].value) return false
+  }
+  return true
+}
+
+function SearchIcon ({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+      />
+    </svg>
+  )
+}

--- a/packages/dashboard/app/components/ui/queue-multiselect.tsx
+++ b/packages/dashboard/app/components/ui/queue-multiselect.tsx
@@ -1,0 +1,127 @@
+import { useMemo, useState } from 'react'
+import { Check, ChevronDown } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+} from '~/components/ui/dropdown-menu'
+import { cn } from '~/lib/utils'
+
+interface QueueMultiSelectProps {
+  options: string[]
+  value: string[]
+  onChange: (value: string[]) => void
+  placeholder?: string
+  className?: string
+}
+
+// Searchable multi-select for queue names. Wraps the existing dropdown-menu
+// primitive so the popup styling matches the rest of the dashboard.
+export function QueueMultiSelect ({
+  options,
+  value,
+  onChange,
+  placeholder = 'All Queues',
+  className,
+}: QueueMultiSelectProps) {
+  const [search, setSearch] = useState('')
+  const selected = useMemo(() => new Set(value), [value])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return options
+    return options.filter(name => name.toLowerCase().includes(q))
+  }, [options, search])
+
+  const toggle = (name: string) => {
+    if (selected.has(name)) {
+      onChange(value.filter(v => v !== name))
+    } else {
+      onChange([...value, name])
+    }
+  }
+
+  const triggerLabel = value.length === 0
+    ? placeholder
+    : value.length === 1
+      ? value[0]
+      : `${value.length} queues`
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className={cn(
+          'inline-flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-lg shadow-sm min-w-[12rem]',
+          'bg-white border border-gray-300 text-gray-900',
+          'dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100',
+          'focus:outline-none focus:ring-2 focus:ring-primary-600 focus:ring-offset-2',
+          'dark:focus:ring-offset-gray-900',
+          'cursor-pointer',
+          className
+        )}
+      >
+        <span className={cn('truncate', value.length === 0 && 'text-gray-500 dark:text-gray-400')}>
+          {triggerLabel}
+        </span>
+        <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-[16rem] max-h-80 overflow-hidden flex flex-col">
+        <div className="p-2 border-b border-gray-200 dark:border-gray-800">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search queues..."
+            className={cn(
+              'w-full px-2 py-1 text-sm rounded border',
+              'bg-white border-gray-300 text-gray-900 placeholder-gray-500',
+              'dark:bg-gray-950 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400',
+              'focus:outline-none focus:ring-1 focus:ring-primary-600'
+            )}
+          />
+        </div>
+        <div className="overflow-y-auto py-1" role="listbox" aria-multiselectable="true">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 text-center">
+              No queues match
+            </div>
+          ) : (
+            filtered.map(name => {
+              const isSelected = selected.has(name)
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => toggle(name)}
+                  className={cn(
+                    'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left',
+                    'hover:bg-gray-100 dark:hover:bg-gray-800',
+                    'cursor-pointer'
+                  )}
+                >
+                  <span className="w-4 h-4 inline-flex items-center justify-center">
+                    {isSelected && <Check className="h-4 w-4 text-primary-600" />}
+                  </span>
+                  <span className="truncate flex-1">{name}</span>
+                </button>
+              )
+            })
+          )}
+        </div>
+        {value.length > 0 && (
+          <div className="border-t border-gray-200 dark:border-gray-800 p-2">
+            <button
+              type="button"
+              onClick={() => onChange([])}
+              className="text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 cursor-pointer"
+            >
+              Clear selection
+            </button>
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/dashboard/app/lib/queries.server.ts
+++ b/packages/dashboard/app/lib/queries.server.ts
@@ -1,4 +1,5 @@
 import { query, queryOne } from './db.server'
+import type { JobStateFilter } from './utils'
 import type {
   QueueResult,
   JobResult,
@@ -217,52 +218,136 @@ export async function getQueue (
   return queryOne<QueueResult>(dbUrl, sql, [name])
 }
 
+// UUID v1-v8 / nil — used to short-circuit the id filter on garbage input rather
+// than letting Postgres throw 22P02. Mirrors the strictness of the existing
+// validateIdentifier helper above.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export interface RecentJobsFilterOptions {
+  state?: JobStateFilter | null;
+  id?: string | null;
+  queues?: string[] | null;
+  minRetries?: number | null;
+  data?: Record<string, unknown> | null;
+  output?: Record<string, unknown> | null;
+}
+
+// Build the shared WHERE fragment used by getRecentJobs and getRecentJobsCount.
+// Returns the assembled clause (with leading WHERE if any conditions exist) plus
+// the bound params. The caller appends its own LIMIT/OFFSET params after these.
+function buildRecentJobsWhere (
+  schema: string,
+  options: RecentJobsFilterOptions
+): { clause: string; params: unknown[]; impossible: boolean } {
+  const conditions: string[] = []
+  const params: unknown[] = []
+  let paramIndex = 1
+
+  const { state = null, id = null, queues = null, minRetries = null, data = null, output = null } = options
+
+  if (state === 'pending') {
+    conditions.push("state < 'completed'")
+  } else if (state && state !== 'all') {
+    conditions.push(`state = $${paramIndex}::${schema}.job_state`)
+    params.push(state)
+    paramIndex++
+  }
+
+  if (id != null && id !== '') {
+    if (!UUID_REGEX.test(id)) {
+      // No row will ever match a malformed UUID — short-circuit so callers can
+      // skip the query entirely.
+      return { clause: '', params: [], impossible: true }
+    }
+    conditions.push(`id = $${paramIndex}::uuid`)
+    params.push(id)
+    paramIndex++
+  }
+
+  if (queues && queues.length > 0) {
+    conditions.push(`name = ANY($${paramIndex}::text[])`)
+    params.push(queues)
+    paramIndex++
+  }
+
+  if (minRetries != null && minRetries > 0) {
+    conditions.push(`retry_count >= $${paramIndex}::int`)
+    params.push(minRetries)
+    paramIndex++
+  }
+
+  if (data && Object.keys(data).length > 0) {
+    conditions.push(`data @> $${paramIndex}::jsonb`)
+    params.push(JSON.stringify(data))
+    paramIndex++
+  }
+
+  if (output && Object.keys(output).length > 0) {
+    conditions.push(`output @> $${paramIndex}::jsonb`)
+    params.push(JSON.stringify(output))
+    paramIndex++
+  }
+
+  const clause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  return { clause, params, impossible: false }
+}
+
 // Get recent jobs across all queues with pagination
 // Uses lightweight columns and includes queue name
 export async function getRecentJobs (
   dbUrl: string,
   schema: string,
-  options: {
-    state?: string | null;
+  options: RecentJobsFilterOptions & {
     limit?: number;
     offset?: number;
   } = {}
 ): Promise<JobResult[]> {
   const s = validateIdentifier(schema)
-  const { state = null, limit = 20, offset = 0 } = options
+  const { limit = 20, offset = 0, ...filters } = options
 
-  // Handle 'pending' filter for non-final states
-  if (state === 'pending') {
-    const sql = `
-      SELECT ${JOB_LIST_COLUMNS}
-      FROM ${s}.job
-      WHERE state < 'completed'
-      ORDER BY created_on DESC
-      LIMIT $1 OFFSET $2
-    `
-    return query<JobResult>(dbUrl, sql, [limit, offset])
-  }
+  const { clause, params, impossible } = buildRecentJobsWhere(s, filters)
+  if (impossible) return []
 
-  // Handle 'all' filter or null - no state filtering
-  if (state === 'all' || state === null) {
-    const sql = `
-      SELECT ${JOB_LIST_COLUMNS}
-      FROM ${s}.job
-      ORDER BY created_on DESC
-      LIMIT $1 OFFSET $2
-    `
-    return query<JobResult>(dbUrl, sql, [limit, offset])
-  }
+  const limitPlaceholder = `$${params.length + 1}`
+  const offsetPlaceholder = `$${params.length + 2}`
 
-  // Filter by specific state
   const sql = `
     SELECT ${JOB_LIST_COLUMNS}
     FROM ${s}.job
-    WHERE state = $1::${s}.job_state
+    ${clause}
     ORDER BY created_on DESC
-    LIMIT $2 OFFSET $3
+    LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}
   `
-  return query<JobResult>(dbUrl, sql, [state, limit, offset])
+  return query<JobResult>(dbUrl, sql, [...params, limit, offset])
+}
+
+// Count of jobs matching the same filters as getRecentJobs. Intentionally
+// separate so the loader can skip it when no filter is active (an unfiltered
+// COUNT(*) on the job table is expensive on large deployments).
+export async function getRecentJobsCount (
+  dbUrl: string,
+  schema: string,
+  options: RecentJobsFilterOptions = {}
+): Promise<number> {
+  const s = validateIdentifier(schema)
+  const { clause, params, impossible } = buildRecentJobsWhere(s, options)
+  if (impossible) return 0
+
+  const sql = `SELECT COUNT(*)::int as count FROM ${s}.job ${clause}`
+  const result = await queryOne<{ count: number }>(dbUrl, sql, params)
+  return result?.count ?? 0
+}
+
+// Lightweight name-only listing of queues for filter dropdowns. Kept separate
+// from getQueues so the multi-select doesn't pull stat columns it never uses.
+export async function getQueueNames (
+  dbUrl: string,
+  schema: string
+): Promise<string[]> {
+  const s = validateIdentifier(schema)
+  const sql = `SELECT name FROM ${s}.queue ORDER BY name`
+  const rows = await query<{ name: string }>(dbUrl, sql)
+  return rows.map(r => r.name)
 }
 
 // Get jobs for a queue with pagination and filtering

--- a/packages/dashboard/app/lib/utils.ts
+++ b/packages/dashboard/app/lib/utils.ts
@@ -107,6 +107,59 @@ export const JOB_STATE_OPTIONS: { value: JobStateFilter; label: string }[] = [
   })),
 ]
 
+// Maximum number of key=value rows accepted per JSON filter (data / output).
+// Bounded to keep the resulting JSONB payload and URL length reasonable.
+export const MAX_JSON_FILTER_PAIRS = 10
+
+export interface JsonFilterPair {
+  key: string;
+  value: string;
+}
+
+/**
+ * Parse JSONB filter rows from URL search params for a given prefix
+ * (e.g. 'data' → reads every `data.<key>` param). Order is stable based on
+ * URLSearchParams insertion order so the UI can re-render the same pair list.
+ */
+export function parseJsonFilterPairs (
+  searchParams: URLSearchParams,
+  prefix: 'data' | 'output'
+): JsonFilterPair[] {
+  const pairs: JsonFilterPair[] = []
+  const dotPrefix = `${prefix}.`
+  for (const [paramKey, paramValue] of searchParams.entries()) {
+    if (!paramKey.startsWith(dotPrefix)) continue
+    const key = paramKey.slice(dotPrefix.length)
+    if (!key) continue
+    pairs.push({ key, value: paramValue })
+    if (pairs.length >= MAX_JSON_FILTER_PAIRS) break
+  }
+  return pairs
+}
+
+/**
+ * Convert key=value rows to the object passed to the server's @> filter.
+ * Numeric and boolean strings are coerced so `value=1234` matches the wrapped
+ * `{"value": 1234}` payload pg-boss stores for primitive job data.
+ */
+export function jsonFilterPairsToObject (pairs: JsonFilterPair[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const { key, value } of pairs) {
+    if (!key) continue
+    out[key] = coerceJsonScalar(value)
+  }
+  return out
+}
+
+function coerceJsonScalar (value: string): string | number | boolean {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  if (value !== '' && !isNaN(Number(value)) && /^-?\d+(\.\d+)?$/.test(value)) {
+    return Number(value)
+  }
+  return value
+}
+
 // Valid warning types
 export const WARNING_TYPES = [
   'slow_query',

--- a/packages/dashboard/app/routes/jobs.tsx
+++ b/packages/dashboard/app/routes/jobs.tsx
@@ -3,8 +3,11 @@ import { DbLink } from '~/components/db-link'
 import type { Route } from './+types/jobs'
 import {
   getRecentJobs,
+  getRecentJobsCount,
+  getQueueNames,
+  type RecentJobsFilterOptions,
 } from '~/lib/queries.server'
-import { Card, CardHeader, CardTitle, CardContent } from '~/components/ui/card'
+import { Card, CardContent } from '~/components/ui/card'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
 import {
@@ -16,45 +19,125 @@ import {
   TableCell,
 } from '~/components/ui/table'
 import { Pagination } from '~/components/ui/pagination'
-import { FilterSelect } from '~/components/ui/filter-select'
 import { ErrorCard } from '~/components/error-card'
+import { JobsFilterBar, type JobsFilters } from '~/components/jobs-filter-bar'
 import type { JobResult } from '~/lib/types'
 import {
   parsePageNumber,
   formatDate,
   JOB_STATE_VARIANTS,
-  JOB_STATE_OPTIONS,
   isValidJobState,
   DEFAULT_STATE_FILTER,
+  ALL_STATES_FILTER,
+  parseJsonFilterPairs,
+  jsonFilterPairsToObject,
+  type JobStateFilter,
 } from '~/lib/utils'
+
+interface ParsedFilters extends JobsFilters {
+  serverFilters: RecentJobsFilterOptions
+  hasActiveFilters: boolean
+  shouldRunCount: boolean
+}
+
+function parseFiltersFromUrl (searchParams: URLSearchParams): ParsedFilters {
+  const stateParam = searchParams.get('state')
+  const state: JobStateFilter = stateParam !== null && isValidJobState(stateParam)
+    ? (stateParam as JobStateFilter)
+    : DEFAULT_STATE_FILTER
+
+  const id = (searchParams.get('id') || '').trim()
+  const queuesRaw = (searchParams.get('queues') || '').trim()
+  const queues = queuesRaw ? queuesRaw.split(',').filter(Boolean) : []
+  const minRetriesRaw = (searchParams.get('minRetries') || '').trim()
+  const minRetries = /^\d+$/.test(minRetriesRaw) ? minRetriesRaw : ''
+
+  const dataPairs = parseJsonFilterPairs(searchParams, 'data')
+  const outputPairs = parseJsonFilterPairs(searchParams, 'output')
+  const dataObject = jsonFilterPairsToObject(dataPairs.filter(p => p.key && p.value !== ''))
+  const outputObject = jsonFilterPairsToObject(outputPairs.filter(p => p.key && p.value !== ''))
+
+  // Cosmetic vs cost-bearing distinction:
+  //   hasActiveFilters drives the "X jobs found" subtitle and the chip strip.
+  //   shouldRunCount gates the COUNT(*) — we only run it when there's a WHERE
+  //   that actually shrinks the scan. state='all' alone adds no WHERE and would
+  //   force a full table scan to count every row, which is exactly what we
+  //   wanted to avoid by skipping the count for the default view.
+  const hasNarrowingFilters =
+    id !== '' ||
+    queues.length > 0 ||
+    minRetries !== '' ||
+    Object.keys(dataObject).length > 0 ||
+    Object.keys(outputObject).length > 0
+
+  const hasActiveFilters = hasNarrowingFilters || state !== DEFAULT_STATE_FILTER
+  const shouldRunCount = hasNarrowingFilters || (state !== DEFAULT_STATE_FILTER && state !== 'all')
+
+  const serverFilters: RecentJobsFilterOptions = {
+    state,
+    id: id || null,
+    queues: queues.length > 0 ? queues : null,
+    minRetries: minRetries !== '' ? Number(minRetries) : null,
+    data: Object.keys(dataObject).length > 0 ? dataObject : null,
+    output: Object.keys(outputObject).length > 0 ? outputObject : null,
+  }
+
+  return {
+    state,
+    id,
+    queues,
+    minRetries,
+    data: dataPairs,
+    output: outputPairs,
+    serverFilters,
+    hasActiveFilters,
+    shouldRunCount,
+  }
+}
 
 export async function loader ({ request, context }: Route.LoaderArgs) {
   const url = new URL(request.url)
-  const stateParam = url.searchParams.get('state')
-
-  // Default to 'pending' filter to avoid showing completed/failed jobs
-  // Users can explicitly select 'all' to see all jobs
-  const stateFilter = stateParam !== null && isValidJobState(stateParam)
-    ? stateParam
-    : DEFAULT_STATE_FILTER
+  const parsed = parseFiltersFromUrl(url.searchParams)
 
   const page = parsePageNumber(url.searchParams.get('page'))
   const limit = 20
   const offset = (page - 1) * limit
 
-  const recentJobs = await getRecentJobs(context.DB_URL, context.SCHEMA, {
-    state: stateFilter,
-    limit,
-    offset,
-  })
+  const [recentJobs, queueNames, totalCount] = await Promise.all([
+    getRecentJobs(context.DB_URL, context.SCHEMA, {
+      ...parsed.serverFilters,
+      limit,
+      offset,
+    }),
+    getQueueNames(context.DB_URL, context.SCHEMA),
+    // Count is best-effort: a failure here would block the entire page even
+    // though the result list already loaded. Degrade to a null count so the
+    // subtitle silently falls back to the next-page heuristic.
+    parsed.shouldRunCount
+      ? getRecentJobsCount(context.DB_URL, context.SCHEMA, parsed.serverFilters)
+        .catch(() => null)
+      : Promise.resolve<number | null>(null),
+  ])
 
-  const hasNextPage = recentJobs.length === limit
+  const hasNextPage = totalCount != null
+    ? page * limit < totalCount
+    : recentJobs.length === limit
   const hasPrevPage = page > 1
 
   return {
     recentJobs,
+    queueNames,
+    totalCount,
     page,
-    stateFilter,
+    filters: {
+      state: parsed.state,
+      id: parsed.id,
+      queues: parsed.queues,
+      minRetries: parsed.minRetries,
+      data: parsed.data,
+      output: parsed.output,
+    } satisfies JobsFilters,
+    hasActiveFilters: parsed.hasActiveFilters,
     hasNextPage,
     hasPrevPage,
   }
@@ -64,26 +147,55 @@ export function ErrorBoundary () {
   return <ErrorCard title="Failed to load jobs" />
 }
 
-export default function Jobs ({ loaderData }: Route.ComponentProps) {
-  const { recentJobs, page, stateFilter, hasNextPage, hasPrevPage } = loaderData
-  const [searchParams, setSearchParams] = useSearchParams()
+function buildSearchParams (filters: JobsFilters): URLSearchParams {
+  const params = new URLSearchParams()
 
-  const handleFilterChange = (key: string, value: string | null) => {
-    const params = new URLSearchParams(searchParams)
-    if (value) {
-      params.set(key, value)
-    } else {
-      params.delete(key)
-    }
-    params.delete('page')
-    setSearchParams(params)
+  if (filters.state !== DEFAULT_STATE_FILTER) {
+    params.set('state', filters.state)
+  }
+  if (filters.id) params.set('id', filters.id)
+  if (filters.queues.length > 0) params.set('queues', filters.queues.join(','))
+  if (filters.minRetries) params.set('minRetries', filters.minRetries)
+  for (const pair of filters.data) {
+    if (pair.key && pair.value !== '') params.append(`data.${pair.key}`, pair.value)
+  }
+  for (const pair of filters.output) {
+    if (pair.key && pair.value !== '') params.append(`output.${pair.key}`, pair.value)
+  }
+
+  return params
+}
+
+export default function Jobs ({ loaderData }: Route.ComponentProps) {
+  const {
+    recentJobs,
+    queueNames,
+    totalCount,
+    page,
+    filters,
+    hasActiveFilters,
+    hasNextPage,
+    hasPrevPage,
+  } = loaderData
+  const [, setSearchParams] = useSearchParams()
+
+  const handleFiltersChange = (next: JobsFilters) => {
+    setSearchParams(buildSearchParams(next))
   }
 
   const handlePageChange = (newPage: number) => {
-    const params = new URLSearchParams(searchParams)
-    params.set('page', newPage.toString())
+    const params = buildSearchParams(filters)
+    if (newPage > 1) params.set('page', newPage.toString())
     setSearchParams(params)
   }
+
+  const clearAll = () => {
+    setSearchParams(new URLSearchParams())
+  }
+
+  const subtitle = hasActiveFilters && totalCount != null
+    ? `${totalCount.toLocaleString()} job${totalCount === 1 ? '' : 's'} found`
+    : 'Recently created jobs across all queues'
 
   return (
     <div className="space-y-6">
@@ -91,7 +203,7 @@ export default function Jobs ({ loaderData }: Route.ComponentProps) {
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Jobs</h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Recently created jobs across all queues
+            {subtitle}
           </p>
         </div>
         <DbLink to="/send">
@@ -99,15 +211,21 @@ export default function Jobs ({ loaderData }: Route.ComponentProps) {
         </DbLink>
       </div>
 
+      <JobsFilterBar
+        filters={filters}
+        queueOptions={queueNames}
+        onChange={handleFiltersChange}
+      />
+
+      {hasActiveFilters && (
+        <ActiveFilterChips
+          filters={filters}
+          onChange={handleFiltersChange}
+          onClearAll={clearAll}
+        />
+      )}
+
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Jobs</CardTitle>
-          <FilterSelect
-            value={stateFilter}
-            options={JOB_STATE_OPTIONS}
-            onChange={(value) => handleFilterChange('state', value)}
-          />
-        </CardHeader>
         <CardContent className="p-0">
           <Table>
             <TableHeader>
@@ -167,5 +285,102 @@ export default function Jobs ({ loaderData }: Route.ComponentProps) {
         />
       </Card>
     </div>
+  )
+}
+
+interface ActiveFilterChipsProps {
+  filters: JobsFilters
+  onChange: (next: JobsFilters) => void
+  onClearAll: () => void
+}
+
+function ActiveFilterChips ({ filters, onChange, onClearAll }: ActiveFilterChipsProps) {
+  const stateLabel = filters.state === ALL_STATES_FILTER
+    ? 'All States'
+    : filters.state.charAt(0).toUpperCase() + filters.state.slice(1)
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-sm text-gray-500 dark:text-gray-400">Active filters:</span>
+
+      {filters.state !== DEFAULT_STATE_FILTER && (
+        <Chip
+          label={`State: ${stateLabel}`}
+          onRemove={() => onChange({ ...filters, state: DEFAULT_STATE_FILTER })}
+        />
+      )}
+
+      {filters.id && (
+        <Chip
+          label={`ID: ${filters.id.slice(0, 8)}...`}
+          onRemove={() => onChange({ ...filters, id: '' })}
+        />
+      )}
+
+      {filters.queues.map((q) => (
+        <Chip
+          key={q}
+          label={`Queue: ${q}`}
+          onRemove={() => onChange({ ...filters, queues: filters.queues.filter(x => x !== q) })}
+        />
+      ))}
+
+      {filters.minRetries && (
+        <Chip
+          label={`Retries ≥ ${filters.minRetries}`}
+          onRemove={() => onChange({ ...filters, minRetries: '' })}
+        />
+      )}
+
+      {filters.data
+        .filter(p => p.key && p.value !== '')
+        .map((p, i) => (
+          <Chip
+            key={`data-${p.key}-${i}`}
+            label={`data.${p.key}=${p.value}`}
+            onRemove={() => onChange({
+              ...filters,
+              data: filters.data.filter((x) => !(x.key === p.key && x.value === p.value)),
+            })}
+          />
+        ))}
+
+      {filters.output
+        .filter(p => p.key && p.value !== '')
+        .map((p, i) => (
+          <Chip
+            key={`output-${p.key}-${i}`}
+            label={`output.${p.key}=${p.value}`}
+            onRemove={() => onChange({
+              ...filters,
+              output: filters.output.filter((x) => !(x.key === p.key && x.value === p.value)),
+            })}
+          />
+        ))}
+
+      <button
+        type="button"
+        onClick={onClearAll}
+        className="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 cursor-pointer"
+      >
+        Clear all
+      </button>
+    </div>
+  )
+}
+
+function Chip ({ label, onRemove }: { label: string; onRemove: () => void }) {
+  return (
+    <Badge variant="primary" size="sm">
+      {label}
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove filter ${label}`}
+        className="ml-1 hover:text-primary-700 cursor-pointer"
+      >
+        ×
+      </button>
+    </Badge>
   )
 }

--- a/packages/dashboard/tests/frontend/jobs-filter-bar.test.tsx
+++ b/packages/dashboard/tests/frontend/jobs-filter-bar.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { JobsFilterBar, type JobsFilters } from '~/components/jobs-filter-bar'
+import { DEFAULT_STATE_FILTER } from '~/lib/utils'
+
+const baseFilters: JobsFilters = {
+  state: DEFAULT_STATE_FILTER,
+  id: '',
+  queues: [],
+  minRetries: '',
+  data: [],
+  output: [],
+}
+
+const VALID_UUID = '7c6f6849-1b6f-4afe-95a7-7548e996a417'
+
+describe('JobsFilterBar', () => {
+  it('renders the id, queue, state and min-retries controls', () => {
+    render(
+      <JobsFilterBar
+        filters={baseFilters}
+        queueOptions={['transcription', 'audio-processing']}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByPlaceholderText(/Filter by job ID/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Minimum retries/i)).toBeInTheDocument()
+    expect(screen.getByRole('combobox')).toBeInTheDocument() // state FilterSelect
+  })
+
+  it('commits the id filter on Enter', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <JobsFilterBar filters={baseFilters} queueOptions={[]} onChange={onChange} />
+    )
+
+    const input = screen.getByPlaceholderText(/Filter by job ID/i)
+    await user.type(input, VALID_UUID)
+    await user.keyboard('{Enter}')
+
+    expect(onChange).toHaveBeenCalled()
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0]
+    expect(lastCall.id).toBe(VALID_UUID)
+  })
+
+  it('clears the id filter via the clear button', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <JobsFilterBar
+        filters={{ ...baseFilters, id: VALID_UUID }}
+        queueOptions={[]}
+        onChange={onChange}
+      />
+    )
+
+    await user.click(screen.getByLabelText(/Clear job id filter/i))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ id: '' }))
+  })
+
+  it('rejects non-numeric min retries input', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <JobsFilterBar filters={baseFilters} queueOptions={[]} onChange={onChange} />
+    )
+
+    const minRetries = screen.getByLabelText(/Minimum retries/i)
+    // The input is type=number so the browser already filters letters in
+    // userEvent's simulation, but we still verify the commit logic ignores junk.
+    await user.type(minRetries, '3')
+    await user.keyboard('{Enter}')
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ minRetries: '3' }))
+  })
+
+  it('shows advanced filters when toggled', async () => {
+    const user = userEvent.setup()
+    render(
+      <JobsFilterBar filters={baseFilters} queueOptions={[]} onChange={vi.fn()} />
+    )
+
+    expect(screen.queryByText(/Add data filter/i)).not.toBeInTheDocument()
+    await user.click(screen.getByText(/Show advanced filters/i))
+    expect(screen.getByText(/Add data filter/i)).toBeInTheDocument()
+    expect(screen.getByText(/Add output filter/i)).toBeInTheDocument()
+  })
+
+  it('starts with advanced filters open when data or output pairs exist', () => {
+    render(
+      <JobsFilterBar
+        filters={{ ...baseFilters, data: [{ key: 'sessionId', value: 'abc' }] }}
+        queueOptions={[]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/Hide advanced filters/i)).toBeInTheDocument()
+    expect(screen.getByDisplayValue('sessionId')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('abc')).toBeInTheDocument()
+  })
+
+  it('renders a new empty row when "Add data filter" is clicked but does not commit it', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <JobsFilterBar
+        filters={{ ...baseFilters, data: [{ key: 'sessionId', value: 'abc' }] }}
+        queueOptions={[]}
+        onChange={onChange}
+      />
+    )
+
+    await user.click(screen.getByText(/Add data filter/i))
+    // Empty rows are local UI state — they don't push to the URL until
+    // both the key and value are filled in.
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByLabelText(/Data filter key 2/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Data filter value 2/i)).toBeInTheDocument()
+  })
+
+  it('removes a committed row and notifies onChange', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <JobsFilterBar
+        filters={{ ...baseFilters, data: [{ key: 'sessionId', value: 'abc' }] }}
+        queueOptions={[]}
+        onChange={onChange}
+      />
+    )
+
+    await user.click(screen.getByLabelText(/Remove data filter 1/i))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ data: [] }))
+  })
+
+  it('keeps a half-edited row visible after the user clears its value (regression: prop sync should not wipe local state)', async () => {
+    // Simulates the real route: parent owns filters, JobsFilterBar drives them
+    // via onChange. When the user clears the value, the committed pairs go
+    // from [{sessionId:abc}] to [], the parent re-renders with data=[], and
+    // the row should NOT vanish — the user is still typing.
+    function Host () {
+      const [filters, setFilters] = useState<JobsFilters>({
+        ...baseFilters,
+        data: [{ key: 'sessionId', value: 'abc' }],
+      })
+      return (
+        <JobsFilterBar filters={filters} queueOptions={[]} onChange={setFilters} />
+      )
+    }
+
+    const user = userEvent.setup()
+    render(<Host />)
+
+    const valueInput = screen.getByLabelText(/Data filter value 1/i)
+    await user.clear(valueInput)
+
+    // Row stays mounted with key preserved and value empty
+    expect(screen.getByLabelText(/Data filter key 1/i)).toHaveValue('sessionId')
+    expect(screen.getByLabelText(/Data filter value 1/i)).toHaveValue('')
+
+    // User can now retype the value
+    await user.type(screen.getByLabelText(/Data filter value 1/i), 'xyz')
+    expect(screen.getByLabelText(/Data filter value 1/i)).toHaveValue('xyz')
+  })
+
+  it('commits a data row only after both key and value are filled in', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <JobsFilterBar filters={baseFilters} queueOptions={[]} onChange={onChange} />
+    )
+
+    await user.click(screen.getByText(/Show advanced filters/i))
+    await user.click(screen.getByText(/Add data filter/i))
+
+    const keyInput = screen.getByLabelText(/Data filter key 1/i)
+    const valueInput = screen.getByLabelText(/Data filter value 1/i)
+
+    await user.type(keyInput, 'sessionId')
+    expect(onChange).not.toHaveBeenCalled() // value still empty
+
+    await user.type(valueInput, 'abc')
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: [{ key: 'sessionId', value: 'abc' }],
+      })
+    )
+  })
+})

--- a/packages/dashboard/tests/frontend/queue-multiselect.test.tsx
+++ b/packages/dashboard/tests/frontend/queue-multiselect.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueueMultiSelect } from '~/components/ui/queue-multiselect'
+
+// The dropdown popup is rendered via base-ui's Portal so it is not present in
+// the DOM until the trigger is opened (which the headless test environment
+// doesn't fully animate). These tests cover what's reachable: trigger label,
+// placeholder, and the props contract.
+
+describe('QueueMultiSelect', () => {
+  it('shows the placeholder when no value is selected', () => {
+    render(
+      <QueueMultiSelect
+        options={['alpha', 'beta']}
+        value={[]}
+        onChange={vi.fn()}
+      />
+    )
+    expect(screen.getByText('All Queues')).toBeInTheDocument()
+  })
+
+  it('shows the queue name when a single value is selected', () => {
+    render(
+      <QueueMultiSelect
+        options={['alpha', 'beta']}
+        value={['alpha']}
+        onChange={vi.fn()}
+      />
+    )
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+  })
+
+  it('summarises with a count when multiple values are selected', () => {
+    render(
+      <QueueMultiSelect
+        options={['alpha', 'beta', 'gamma']}
+        value={['alpha', 'beta']}
+        onChange={vi.fn()}
+      />
+    )
+    expect(screen.getByText('2 queues')).toBeInTheDocument()
+  })
+
+  it('honours a custom placeholder', () => {
+    render(
+      <QueueMultiSelect
+        options={[]}
+        value={[]}
+        onChange={vi.fn()}
+        placeholder="Pick one"
+      />
+    )
+    expect(screen.getByText('Pick one')).toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/tests/server/queries.test.ts
+++ b/packages/dashboard/tests/server/queries.test.ts
@@ -18,6 +18,8 @@ import {
   getProblemQueuesCount,
   getTopQueues,
   getRecentJobs,
+  getRecentJobsCount,
+  getQueueNames,
   getJobs,
   getJobCountFromQueue,
   getJobById,
@@ -424,6 +426,183 @@ describe('Job Queries', () => {
 
       const secondPage = await getRecentJobs(ctx.connectionString, ctx.schema, { limit: 2, offset: 2 })
       expect(secondPage).toHaveLength(1)
+    })
+
+    describe('filters', () => {
+      it('filters by exact job id', async () => {
+        await createTestQueue('test-queue')
+        const targetId = await sendTestJob('test-queue', { task: 'target' })
+        await sendTestJob('test-queue', { task: 'other' })
+
+        const jobs = await getRecentJobs(ctx.connectionString, ctx.schema, { id: targetId })
+        expect(jobs).toHaveLength(1)
+        expect(jobs[0].id).toBe(targetId)
+      })
+
+      it('returns empty when id is not a valid UUID without hitting Postgres', async () => {
+        await createTestQueue('test-queue')
+        await sendTestJob('test-queue', { task: 'whatever' })
+
+        const jobs = await getRecentJobs(ctx.connectionString, ctx.schema, { id: 'not-a-uuid' })
+        expect(jobs).toEqual([])
+      })
+
+      it('filters by a list of queue names', async () => {
+        await createTestQueue('alpha')
+        await createTestQueue('beta')
+        await createTestQueue('gamma')
+        await sendTestJob('alpha', { task: 'a' })
+        await sendTestJob('beta', { task: 'b' })
+        await sendTestJob('gamma', { task: 'c' })
+
+        const jobs = await getRecentJobs(ctx.connectionString, ctx.schema, { queues: ['alpha', 'beta'] })
+        expect(jobs).toHaveLength(2)
+        expect(jobs.map((j) => j.name).sort()).toEqual(['alpha', 'beta'])
+      })
+
+      it('filters by minimum retry count', async () => {
+        await createTestQueue('test-queue')
+        const flakyId = await sendTestJob('test-queue', { task: 'flaky' })
+        await sendTestJob('test-queue', { task: 'fresh' })
+
+        // Manually bump retry_count to simulate a job that has been retried.
+        // We can't easily trigger the real retry flow inside a single test, but
+        // the SQL check is just retry_count >= N regardless of how it got there.
+        const { Pool } = pg
+        const pool = new Pool({ connectionString: ctx.connectionString })
+        try {
+          await pool.query(`UPDATE ${ctx.schema}.job SET retry_count = 2 WHERE id = $1`, [flakyId])
+        } finally {
+          await pool.end()
+        }
+
+        const jobs = await getRecentJobs(ctx.connectionString, ctx.schema, { minRetries: 1 })
+        expect(jobs).toHaveLength(1)
+        expect(jobs[0].id).toBe(flakyId)
+      })
+
+      it('filters by data containment with object payload', async () => {
+        await createTestQueue('test-queue')
+        const sessionId = '6dff4e1b-9c74-4d53-9969-1991d887e7ca'
+        const targetId = await sendTestJob('test-queue', { sessionId, extension: 'webm' })
+        await sendTestJob('test-queue', { sessionId: 'something-else', extension: 'webm' })
+
+        const jobs = await getRecentJobs(ctx.connectionString, ctx.schema, {
+          data: { sessionId },
+        })
+        expect(jobs).toHaveLength(1)
+        expect(jobs[0].id).toBe(targetId)
+      })
+
+      it('filters by output containment', async () => {
+        await createTestQueue('test-queue')
+        await sendTestJob('test-queue', { task: 'one' })
+        await sendTestJob('test-queue', { task: 'two' })
+
+        const fetched1 = await fetchTestJob('test-queue')
+        const fetched2 = await fetchTestJob('test-queue')
+        if (!fetched1 || !fetched2) throw new Error('expected fetched jobs')
+
+        await completeTestJob('test-queue', fetched1.id, { status: 'ok' })
+        await completeTestJob('test-queue', fetched2.id, { status: 'fail' })
+
+        const jobs = await getRecentJobs(ctx.connectionString, ctx.schema, {
+          state: 'all',
+          output: { status: 'ok' },
+        })
+        expect(jobs).toHaveLength(1)
+        expect(jobs[0].id).toBe(fetched1.id)
+      })
+
+      it('filters by output containment for primitive return values (wrapped as {value})', async () => {
+        await createTestQueue('test-queue')
+        await sendTestJob('test-queue', { task: 'one' })
+        await sendTestJob('test-queue', { task: 'two' })
+
+        const fetched1 = await fetchTestJob('test-queue')
+        const fetched2 = await fetchTestJob('test-queue')
+        if (!fetched1 || !fetched2) throw new Error('expected fetched jobs')
+
+        // pg-boss wraps primitive output as {"value": x} (manager.ts
+        // mapCompletionDataArg). The dashboard relies on this so users can
+        // filter by `value=42` and still find jobs whose handler returned 42.
+        await completeTestJob('test-queue', fetched1.id, 42 as unknown as object)
+        await completeTestJob('test-queue', fetched2.id, 99 as unknown as object)
+
+        const jobs = await getRecentJobs(ctx.connectionString, ctx.schema, {
+          state: 'all',
+          output: { value: 42 },
+        })
+        expect(jobs).toHaveLength(1)
+        expect(jobs[0].id).toBe(fetched1.id)
+      })
+
+      it('combines multiple filters with AND', async () => {
+        await createTestQueue('queue-a')
+        await createTestQueue('queue-b')
+        const targetId = await sendTestJob('queue-a', { sessionId: 'abc', priority: 'high' })
+        await sendTestJob('queue-a', { sessionId: 'def', priority: 'high' })
+        await sendTestJob('queue-b', { sessionId: 'abc', priority: 'high' })
+
+        const jobs = await getRecentJobs(ctx.connectionString, ctx.schema, {
+          queues: ['queue-a'],
+          data: { sessionId: 'abc' },
+        })
+        expect(jobs).toHaveLength(1)
+        expect(jobs[0].id).toBe(targetId)
+      })
+    })
+  })
+
+  describe('getRecentJobsCount', () => {
+    it('returns 0 when no jobs exist', async () => {
+      const count = await getRecentJobsCount(ctx.connectionString, ctx.schema)
+      expect(count).toBe(0)
+    })
+
+    it('counts all jobs when no filters are set', async () => {
+      await createTestQueue('test-queue')
+      await sendTestJob('test-queue', { task: '1' })
+      await sendTestJob('test-queue', { task: '2' })
+      await sendTestJob('test-queue', { task: '3' })
+
+      const count = await getRecentJobsCount(ctx.connectionString, ctx.schema)
+      expect(count).toBe(3)
+    })
+
+    it('respects filters', async () => {
+      await createTestQueue('alpha')
+      await createTestQueue('beta')
+      await sendTestJob('alpha', { task: 'a1' })
+      await sendTestJob('alpha', { task: 'a2' })
+      await sendTestJob('beta', { task: 'b1' })
+
+      const count = await getRecentJobsCount(ctx.connectionString, ctx.schema, { queues: ['alpha'] })
+      expect(count).toBe(2)
+    })
+
+    it('returns 0 when id filter is malformed', async () => {
+      await createTestQueue('test-queue')
+      await sendTestJob('test-queue', { task: '1' })
+
+      const count = await getRecentJobsCount(ctx.connectionString, ctx.schema, { id: 'nope' })
+      expect(count).toBe(0)
+    })
+  })
+
+  describe('getQueueNames', () => {
+    it('returns an empty list when no queues exist', async () => {
+      const names = await getQueueNames(ctx.connectionString, ctx.schema)
+      expect(names).toEqual([])
+    })
+
+    it('returns queue names sorted alphabetically', async () => {
+      await createTestQueue('charlie')
+      await createTestQueue('alpha')
+      await createTestQueue('bravo')
+
+      const names = await getQueueNames(ctx.connectionString, ctx.schema)
+      expect(names).toEqual(['alpha', 'bravo', 'charlie'])
     })
   })
 

--- a/packages/dashboard/tests/server/utils.test.ts
+++ b/packages/dashboard/tests/server/utils.test.ts
@@ -9,6 +9,9 @@ import {
   isValidWarningType,
   JOB_STATES,
   WARNING_TYPES,
+  parseJsonFilterPairs,
+  jsonFilterPairsToObject,
+  MAX_JSON_FILTER_PAIRS,
 } from '~/lib/utils'
 
 describe('utils', () => {
@@ -202,6 +205,73 @@ describe('utils', () => {
     it('returns JSON for unknown object structure', () => {
       const data = { unknownField: 'value' }
       expect(formatWarningData(data)).toBe('{"unknownField":"value"}')
+    })
+  })
+
+  describe('parseJsonFilterPairs', () => {
+    it('returns an empty list when no matching params exist', () => {
+      const params = new URLSearchParams('foo=bar&state=active')
+      expect(parseJsonFilterPairs(params, 'data')).toEqual([])
+    })
+
+    it('extracts pairs for the requested prefix only', () => {
+      const params = new URLSearchParams('data.sessionId=abc&data.tier=hi&output.status=ok')
+      expect(parseJsonFilterPairs(params, 'data')).toEqual([
+        { key: 'sessionId', value: 'abc' },
+        { key: 'tier', value: 'hi' },
+      ])
+      expect(parseJsonFilterPairs(params, 'output')).toEqual([
+        { key: 'status', value: 'ok' },
+      ])
+    })
+
+    it('skips entries whose key is empty after the prefix', () => {
+      const params = new URLSearchParams('data.=lonely')
+      expect(parseJsonFilterPairs(params, 'data')).toEqual([])
+    })
+
+    it(`caps the result at MAX_JSON_FILTER_PAIRS (${MAX_JSON_FILTER_PAIRS})`, () => {
+      const parts: string[] = []
+      for (let i = 0; i < MAX_JSON_FILTER_PAIRS + 5; i++) {
+        parts.push(`data.k${i}=${i}`)
+      }
+      const params = new URLSearchParams(parts.join('&'))
+      expect(parseJsonFilterPairs(params, 'data')).toHaveLength(MAX_JSON_FILTER_PAIRS)
+    })
+  })
+
+  describe('jsonFilterPairsToObject', () => {
+    it('returns an empty object for no pairs', () => {
+      expect(jsonFilterPairsToObject([])).toEqual({})
+    })
+
+    it('coerces numeric strings to numbers', () => {
+      expect(jsonFilterPairsToObject([{ key: 'value', value: '1234' }]))
+        .toEqual({ value: 1234 })
+      expect(jsonFilterPairsToObject([{ key: 'temp', value: '-3.5' }]))
+        .toEqual({ temp: -3.5 })
+    })
+
+    it('coerces boolean strings to booleans', () => {
+      expect(jsonFilterPairsToObject([{ key: 'enabled', value: 'true' }]))
+        .toEqual({ enabled: true })
+      expect(jsonFilterPairsToObject([{ key: 'enabled', value: 'false' }]))
+        .toEqual({ enabled: false })
+    })
+
+    it('keeps non-numeric strings as strings', () => {
+      expect(jsonFilterPairsToObject([
+        { key: 'sessionId', value: '6dff4e1b-9c74-4d53-9969-1991d887e7ca' },
+      ])).toEqual({
+        sessionId: '6dff4e1b-9c74-4d53-9969-1991d887e7ca',
+      })
+    })
+
+    it('skips pairs with empty keys', () => {
+      expect(jsonFilterPairsToObject([
+        { key: '', value: 'x' },
+        { key: 'k', value: 'y' },
+      ])).toEqual({ k: 'y' })
     })
   })
 })


### PR DESCRIPTION
The dashboard's global /jobs page only had a state filter, so once a database
has a few hundred jobs across multiple queues it gets really hard to find
anything specific. This PR adds the filters I kept wishing were there:

- Filter by job id (exact UUID)
- Filter by one or more queue names (searchable multi-select sourced from the
  queue table)
- Filter by minimum retry count, useful for finding jobs that have retried
- Filter by data and output payload contents using key=value rows that compile
  down to a single `data @> $::jsonb` containment query

Each active filter shows as a dismissible chip below the filter bar (same
pattern as routes/queues._index.tsx), and the URL stays in sync so shared
links and bookmarks survive a refresh.

On the server side getRecentJobs() now uses a shared WHERE-builder (same
shape as the existing one in getQueues), and a new getRecentJobsCount()
powers a "N jobs found" subtitle when a filter is active. The count is
intentionally skipped when no filter actually narrows the scan, so the
default view doesn't pay for an unbounded COUNT(*) against the whole job
table.

No schema changes, no new dependencies. The only new UI primitive is a small
QueueMultiSelect that wraps the existing DropdownMenu.

## Testing

From packages/dashboard:

- `npm run typecheck` — clean
- `npx vitest run --config vitest.config.frontend.ts` — 175/175 pass
- `DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/pgboss npx vitest run --config vitest.config.server.ts` — 175/175 pass
- `npm run cover:frontend` — 80.67% lines / 76.62% funcs (over the 70/70 thresholds)
- `npm run cover:server` — 95.65% lines / 88.33% funcs (over the 90/85 thresholds)

Also smoke-tested in a browser against a real database with two queues to
confirm URL state, chips, advanced section toggle, and clear-all all behave
correctly across reloads and back/forward navigation.