### PR TITLE
Dashboard: support dynamic credentials via a config module

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -44,6 +44,7 @@ The dashboard is configured via environment variables:
 |----------|-------------|---------|
 | `DATABASE_URL` | PostgreSQL connection string(s) | `postgres://localhost/pgboss` |
 | `PGBOSS_SCHEMA` | pg-boss schema name(s) | `pgboss` |
+| `PGBOSS_DASHBOARD_CONFIG` | Path to a JS config module (optional, overrides `DATABASE_URL`/`PGBOSS_SCHEMA`) | - |
 | `PORT` | Server port | `3000` |
 | `PGBOSS_DASHBOARD_AUTH_USERNAME` | Basic auth username (optional) | - |
 | `PGBOSS_DASHBOARD_AUTH_PASSWORD` | Basic auth password (optional) | - |
@@ -84,6 +85,42 @@ npx pg-boss-dashboard
 ```
 
 When multiple databases are configured, a database selector appears in the sidebar. The selected database is persisted in the URL via the `db` query parameter, making it easy to share links to specific database views.
+
+### Config File (Dynamic Credentials)
+
+Connection strings can't express everything — most notably credentials that have to be generated at connection time, such as AWS RDS IAM auth tokens (which expire after 15 minutes). For these cases, point `PGBOSS_DASHBOARD_CONFIG` at a JS module that default-exports an array of database entries:
+
+```bash
+PGBOSS_DASHBOARD_CONFIG=./dashboard-config.mjs npx pg-boss-dashboard
+```
+
+```js
+// dashboard-config.mjs
+import { Signer } from '@aws-sdk/rds-signer'
+
+const signer = new Signer({
+  hostname: 'mydb.abc123.us-east-1.rds.amazonaws.com',
+  port: 5432,
+  username: 'dashboard',
+  region: 'us-east-1',
+})
+
+export default [
+  {
+    name: 'Production',
+    url: 'postgres://dashboard@mydb.abc123.us-east-1.rds.amazonaws.com:5432/mydb',
+    schema: 'pgboss',
+    options: {
+      // password may be a function (sync or async) — node-postgres calls it
+      // for every new connection, so short-lived tokens always stay fresh
+      password: () => signer.getAuthToken(),
+      ssl: { rejectUnauthorized: false },
+    },
+  },
+]
+```
+
+Each entry takes `name`, `url`, `schema`, and `options`. Anything in `options` is merged into the `pg.Pool` and pg-boss constructor config for that database, taking precedence over values parsed from `url`. When `PGBOSS_DASHBOARD_CONFIG` is set, `DATABASE_URL` and `PGBOSS_SCHEMA` are ignored.
 
 ## Production Deployment
 

--- a/packages/dashboard/app/lib/boss.server.ts
+++ b/packages/dashboard/app/lib/boss.server.ts
@@ -1,4 +1,5 @@
 import { PgBoss } from 'pg-boss'
+import { getConnectionConfig } from './config.server'
 import type { SendOptions, ScheduleOptions, JobWithMetadata } from './types'
 
 // Cache pg-boss instances by connection string + schema
@@ -24,13 +25,13 @@ async function getInstance (dbUrl: string, schema: string): Promise<PgBoss> {
   }
 
   const boss = new PgBoss({
-    connectionString: dbUrl,
+    ...getConnectionConfig(dbUrl),
     schema,
     schedule: false,
     supervise: false,
     migrate: false,
     createSchema: false,
-  })
+  } as ConstructorParameters<typeof PgBoss>[0])
 
   const startPromise = boss.start().then(() => {
     instances.set(key, boss)

--- a/packages/dashboard/app/lib/config.server.ts
+++ b/packages/dashboard/app/lib/config.server.ts
@@ -1,12 +1,34 @@
 // Multi-database configuration support
 // Format: "name1=postgres://host1/db1|name2=postgres://host2/db2"
 // Or simply: "postgres://host1/db1|postgres://host2/db2" (names derived from database)
+//
+// Alternatively, PGBOSS_DASHBOARD_CONFIG can point to a JS module exporting
+// database entries with extra connection options (e.g. a password function
+// for dynamic credentials like AWS RDS IAM auth) that are passed through to
+// pg-boss and pg.
+
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+import { parse as parseConnectionString } from 'pg-connection-string'
+
+// Extra connection options merged into the pg.Pool / pg-boss constructor
+// config for a database. Notably `password` may be a function so credentials
+// can be minted per connection (short-lived auth tokens).
+export type ConnectionOptions = Record<string, unknown>
 
 export interface DatabaseConfig {
   id: string;      // URL-safe identifier
   name: string;    // Display name
   url: string;     // Connection string
   schema: string;  // pg-boss schema
+  options?: ConnectionOptions; // Extra pg / pg-boss connection options
+}
+
+export interface DatabaseConfigFileEntry {
+  name?: string;
+  url: string;
+  schema?: string;
+  options?: ConnectionOptions;
 }
 
 const SEPARATOR = '|'
@@ -74,6 +96,40 @@ function generateId (name: string, index: number): string {
 }
 
 /**
+ * Load database configurations from a JS module (PGBOSS_DASHBOARD_CONFIG).
+ * The module's default export is an array of entries with optional extra
+ * connection options that can't be expressed in a connection string, such as
+ * a password function for dynamically minted credentials.
+ */
+export async function loadConfigFile (path: string): Promise<DatabaseConfig[]> {
+  let mod: { default?: DatabaseConfigFileEntry[] }
+  try {
+    mod = await import(/* @vite-ignore */ pathToFileURL(resolve(path)).href)
+  } catch (err) {
+    throw new Error(`Failed to load PGBOSS_DASHBOARD_CONFIG module at "${path}": ${err instanceof Error ? err.message : err}`)
+  }
+
+  const entries = mod.default
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error(`PGBOSS_DASHBOARD_CONFIG module at "${path}" must default-export a non-empty array of database entries`)
+  }
+
+  return entries.map((entry, index) => {
+    if (!entry || typeof entry.url !== 'string' || !entry.url) {
+      throw new Error(`PGBOSS_DASHBOARD_CONFIG entry at index ${index} is missing a "url"`)
+    }
+    const name = entry.name || extractDatabaseName(entry.url) || `Database ${index + 1}`
+    return {
+      id: generateId(name, index),
+      name,
+      url: entry.url,
+      schema: entry.schema || DEFAULT_SCHEMA,
+      options: entry.options,
+    }
+  })
+}
+
+/**
  * Find a database config by ID
  */
 export function findDatabaseById (
@@ -84,14 +140,59 @@ export function findDatabaseById (
   return configs.find(c => c.id === id) || configs[0] || null
 }
 
+// Config file entries (if any) are loaded once at startup so the rest of the
+// app can keep reading configuration synchronously.
+const configFilePath = process.env.PGBOSS_DASHBOARD_CONFIG
+const fileConfigs: DatabaseConfig[] | null = configFilePath
+  ? await loadConfigFile(configFilePath)
+  : null
+
 // Cached config to avoid re-parsing on every request
 let cachedConfig: DatabaseConfig[] | null = null
 
 export function getDatabaseConfigs (): DatabaseConfig[] {
   if (!cachedConfig) {
-    cachedConfig = parseDatabaseConfig()
+    cachedConfig = fileConfigs || parseDatabaseConfig()
   }
   return cachedConfig
+}
+
+/**
+ * Build a pg connection config from a URL plus extra options. node-postgres
+ * only honors a `password` function when discrete fields are used (it is
+ * ignored alongside `connectionString`), so when options are present the URL
+ * is parsed into fields and the options merged on top.
+ */
+export function buildConnectionConfig (
+  url: string,
+  options?: ConnectionOptions
+): Record<string, unknown> {
+  if (!options) {
+    return { connectionString: url }
+  }
+
+  const parsed = parseConnectionString(url)
+  const config: Record<string, unknown> = {
+    host: parsed.host ?? undefined,
+    port: parsed.port ? Number(parsed.port) : undefined,
+    database: parsed.database ?? undefined,
+    user: parsed.user ?? undefined,
+    password: parsed.password ?? undefined,
+    ssl: parsed.ssl ?? undefined,
+  }
+  for (const key of Object.keys(config)) {
+    if (config[key] === undefined) delete config[key]
+  }
+
+  return { ...config, ...options }
+}
+
+/**
+ * Connection config for a database, looked up by its connection string.
+ * Used wherever a pool or pg-boss instance is created from a URL.
+ */
+export function getConnectionConfig (url: string): Record<string, unknown> {
+  return buildConnectionConfig(url, getDatabaseConfigs().find(c => c.url === url)?.options)
 }
 
 // For testing - reset cache

--- a/packages/dashboard/app/lib/db.server.ts
+++ b/packages/dashboard/app/lib/db.server.ts
@@ -1,4 +1,5 @@
 import pg from 'pg'
+import { getConnectionConfig } from './config.server'
 
 const { Pool } = pg
 
@@ -15,8 +16,8 @@ export function getPool (connectionString: string): pg.Pool {
   let pool = pools.get(connectionString)
   if (!pool) {
     pool = new Pool({
-      connectionString,
       max: 10,
+      ...getConnectionConfig(connectionString),
     })
 
     // Handle pool errors to prevent unhandled rejections

--- a/packages/dashboard/tests/server/config.test.ts
+++ b/packages/dashboard/tests/server/config.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { loadConfigFile, buildConnectionConfig } from '~/lib/config.server'
+
+describe('loadConfigFile', () => {
+  const dirs: string[] = []
+
+  function writeConfig (contents: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'pgboss-dashboard-config-'))
+    dirs.push(dir)
+    const path = join(dir, 'config.mjs')
+    writeFileSync(path, contents)
+    return path
+  }
+
+  afterEach(() => {
+    while (dirs.length) {
+      rmSync(dirs.pop()!, { recursive: true, force: true })
+    }
+  })
+
+  it('loads database entries with connection options', async () => {
+    const path = writeConfig(`
+      export default [
+        {
+          name: 'Production',
+          url: 'postgres://user@host:5432/proddb',
+          schema: 'jobs',
+          options: {
+            password: () => 'generated-token',
+            ssl: { rejectUnauthorized: false },
+          },
+        },
+        {
+          url: 'postgres://user@host:5432/stagedb',
+        },
+      ]
+    `)
+
+    const configs = await loadConfigFile(path)
+
+    expect(configs).toHaveLength(2)
+    expect(configs[0]).toMatchObject({
+      id: 'production',
+      name: 'Production',
+      url: 'postgres://user@host:5432/proddb',
+      schema: 'jobs',
+    })
+    expect(typeof (configs[0].options as any).password).toBe('function')
+    expect((configs[0].options as any).password()).toBe('generated-token')
+    expect((configs[0].options as any).ssl).toEqual({ rejectUnauthorized: false })
+
+    // Name derived from database, schema defaulted, no options
+    expect(configs[1]).toMatchObject({
+      name: 'stagedb',
+      schema: 'pgboss',
+    })
+    expect(configs[1].options).toBeUndefined()
+  })
+
+  it('rejects a module that does not export an array', async () => {
+    const path = writeConfig('export default { url: "postgres://host/db" }')
+    await expect(loadConfigFile(path)).rejects.toThrow(/non-empty array/)
+  })
+
+  it('rejects entries without a url', async () => {
+    const path = writeConfig('export default [{ name: "broken" }]')
+    await expect(loadConfigFile(path)).rejects.toThrow(/missing a "url"/)
+  })
+
+  it('rejects an unreadable module path', async () => {
+    await expect(loadConfigFile('/nonexistent/config.mjs')).rejects.toThrow(/Failed to load/)
+  })
+})
+
+describe('buildConnectionConfig', () => {
+  it('passes the url through when there are no options', () => {
+    expect(buildConnectionConfig('postgres://host/db')).toEqual({
+      connectionString: 'postgres://host/db',
+    })
+  })
+
+  it('parses the url into discrete fields when options are present', () => {
+    // node-postgres ignores a password function next to connectionString,
+    // so options force the discrete-field form
+    const password = () => 'token'
+    const config = buildConnectionConfig('postgres://user:unused@host:5433/db', { password })
+
+    expect(config).toMatchObject({
+      host: 'host',
+      port: 5433,
+      database: 'db',
+      user: 'user',
+      password,
+    })
+    expect(config.connectionString).toBeUndefined()
+  })
+
+  it('lets options override fields parsed from the url', () => {
+    const config = buildConnectionConfig('postgres://user@host:5432/db', { user: 'other' })
+    expect(config.user).toBe('other')
+  })
+})


### PR DESCRIPTION
This is still WIP, will verify before I mark it as non-draft.

We run the dashboard against AWS RDS using IAM authentication, where the database password is a short-lived token (15 minutes) minted per connection. The dashboard currently only accepts a static `DATABASE_URL`, so any connection opened after the token expires fails. pg-boss itself handles this fine since node-postgres accepts `password` as a function, but there's no way to get a function through an environment variable.

This adds an optional `PGBOSS_DASHBOARD_CONFIG` env var pointing to a JS module that default-exports the database list, where each entry can carry extra connection options (password function, ssl, etc.) that are merged into the `pg.Pool` and pg-boss configs. When the variable isn't set, nothing changes — `DATABASE_URL`/`PGBOSS_SCHEMA` parsing is untouched.

Related: #730 (middleware mode) would also solve this class of problem, but connection options felt like a much smaller change.