### PR TITLE
minor: Fixes the issue where results come back as an array of objects, instead of a single object

### DIFF
--- a/src/adapters/drizzle.ts
+++ b/src/adapters/drizzle.ts
@@ -1,8 +1,9 @@
 import type { IDatabase } from '../types.ts'
 import { parsePlaceholders } from './placeholders.ts'
+import { unwrapSQLResult } from '../tools.js'
 
 export interface DrizzleTransactionLike {
-  execute(query: unknown): Promise<{ rows: any[] }>
+  execute(query: unknown): Promise<{ rows: any[] } | { rows: any[] }[]>
 }
 
 export interface DrizzleSqlTagLike {
@@ -31,7 +32,7 @@ export function fromDrizzle (tx: DrizzleTransactionLike, sql: DrizzleSqlTagLike)
     async executeSql (text: string, values?: unknown[]) {
       const { parts, reordered } = parsePlaceholders(text, values)
       const strings = Object.assign([...parts], { raw: [...parts] }) as TemplateStringsArray
-      return tx.execute(sql(strings, ...reordered))
+      return unwrapSQLResult(await tx.execute(sql(strings, ...reordered)))
     }
   }
 }

--- a/src/adapters/knex.ts
+++ b/src/adapters/knex.ts
@@ -1,8 +1,9 @@
 import type { IDatabase } from '../types.ts'
 import { parsePlaceholders } from './placeholders.ts'
+import { unwrapSQLResult } from '../tools.js'
 
 export interface KnexTransactionLike {
-  raw<T = any>(sql: string, bindings?: readonly unknown[]): Promise<{ rows: T[] }>
+  raw<T = any>(sql: string, bindings?: readonly unknown[]): Promise<{ rows: T[] } | { rows: any[] }[]>
 }
 
 export function fromKnex (trx: KnexTransactionLike): IDatabase {
@@ -13,8 +14,7 @@ export function fromKnex (trx: KnexTransactionLike): IDatabase {
       // mapped to its own ? with the value duplicated in textual order.
       const { parts, reordered } = parsePlaceholders(text, values)
       const knexSql = parts.join('?')
-      const result = await trx.raw(knexSql, reordered)
-      return { rows: result.rows }
+      return unwrapSQLResult(await trx.raw(knexSql, reordered))
     }
   }
 }

--- a/test/adapterTest.ts
+++ b/test/adapterTest.ts
@@ -98,6 +98,22 @@ describe('knex adapter', () => {
     expect(result.rows[0]?.b).toBe(10)
     expect(result.rows[0]?.c).toBe(20)
   })
+
+  it('should handle results as an array instead of object', async () => {
+    ctx.boss = await helper.start(ctx.bossConfig)
+    if (!db) db = knex({ client: 'pg', connection: connString })
+
+    const result = await db.transaction(async (trx) => {
+      const adapter = fromKnex(trx)
+      return adapter.executeSql('BEGIN; SELECT 1 as select1; SELECT 2 as select2; COMMIT;')
+    })
+
+    expect(result).toHaveProperty('rows')
+    expect(result.rows).toStrictEqual([
+      { select1: 1 },
+      { select2: 2 },
+    ])
+  })
 })
 
 describe('kysely adapter', () => {
@@ -287,6 +303,23 @@ describe('drizzle adapter', () => {
     expect(result.rows[0]?.a).toBe(20)
     expect(result.rows[0]?.b).toBe(10)
     expect(result.rows[0]?.c).toBe(20)
+  })
+
+  it('should handle results as an array instead of object', async () => {
+    ctx.boss = await helper.start(ctx.bossConfig)
+    if (!pool) pool = new pg.Pool({ connectionString: connString })
+    const db = drizzle({ client: pool })
+
+    const result = await db.transaction(async (tx) => {
+      const adapter = fromDrizzle(tx, drizzleSql)
+      return adapter.executeSql('BEGIN;\nSELECT 1 as select1;\nSELECT 2 as select2;\nCOMMIT;')
+    })
+
+    expect(result).toHaveProperty('rows')
+    expect(result.rows).toStrictEqual([
+      { select1: 1 },
+      { select2: 2 },
+    ])
   })
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "stripInternal": true,
     "resolveJsonModule": true,
     "noEmit": true,
-    "rootDir": "./src",
+    "rootDir": "./",
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
When multiple SELECT statements are executed in a single `raw()` query string, many database drivers return an array of result sets rather than a single result object. Each element in the array represents the results from one of the `SELECT` statements. For example, a query such as `SELECT * FROM users; SELECT * FROM roles;` may return an array where the first entry contains the user records and the second entry contains the role records. This behavior allows the driver to preserve the results from each statement separately, since there is no single result set that can represent multiple independent queries. The exact structure of the returned array depends on the database driver and configuration being used.
kysely and prisma have other issues, causing this same fix not to work completely.