### PR TITLE
Redirect legacy docsify URLs to VitePress

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,17 @@ export default defineConfig({
   description: 'Queueing jobs in Postgres from Node.js like a boss',
   base: '/pg-boss/',
   lastUpdated: true,
+  head: [
+    ['script', {}, `(function(){
+      var hash = window.location.hash;
+      if(hash.startsWith('#/')){
+        var path = hash.slice(2);
+        if(!path) return;
+        if(path === 'sql') path = 'sql/job-table';
+        window.location.replace('/pg-boss/' + path);
+      }
+    })()`]
+  ],
   themeConfig: {
     search: {
       provider: 'local'

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   title: 'pg-boss',
   description: 'Queueing jobs in Postgres from Node.js like a boss',
   base: '/pg-boss/',
+  cleanUrls: true,
   lastUpdated: true,
   head: [
     ['script', {}, `(function(){

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,11 +10,11 @@ export default defineConfig({
   head: [
     ['script', {}, `(function(){
       var hash = window.location.hash;
-      if(hash.startsWith('#/')){
+      if(window.location.pathname === '/pg-boss/' && hash.startsWith('#/')){
         var path = hash.slice(2);
         if(!path) return;
         if(path === 'sql') path = 'sql/job-table';
-        window.location.replace('/pg-boss/' + path);
+        window.location.replace('/pg-boss/' + path.split('?')[0]);
       }
     })()`]
   ],


### PR DESCRIPTION
### Changes
- Set `cleanUrls: true` in the VitePress config 
- Rewrite links from the old docs (#770) via a redirect script in the page `<head>`

### Notes: 
-  `cleanUrls: true` will work with GitHub pages to generate clean internal links that don't have `.html` in the URL
- An IIFE is added in the `<head>` tag of the new docs. If `window.location.hash` starts with docsify's routing convention of `#/`, it strips the hash prefix and redirects to the equivalent VitePress path via `window.location.replace()`
  - A slightly custom redirect is needed for the `SQL` section since one page was broken up into three
  - The `/pg-boss/` prefix prevents open redirect risk in the final URLs
  - There shouldn't be a way to generate a `#/` link via normal navigaiton within VitePress