### PR TITLE
fix: reset startup state after start errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,28 +99,33 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
 
     this.#starting = true
 
-    if (this.#db._pgbdb && !this.#db.opened) {
-      await this.#db.open()
-    }
+    try {
+      if (this.#db._pgbdb && !this.#db.opened) {
+        await this.#db.open()
+      }
 
-    if (this.#config.migrate) {
-      await this.#contractor.start()
-    } else {
-      await this.#contractor.check()
-    }
+      if (this.#config.migrate) {
+        await this.#contractor.start()
+      } else {
+        await this.#contractor.check()
+      }
 
-    await this.#manager.start()
+      await this.#manager.start()
 
-    if (this.#config.supervise) {
-      await this.#boss.start()
-    }
+      if (this.#config.supervise) {
+        await this.#boss.start()
+      }
 
-    if (this.#config.schedule) {
-      await this.#timekeeper.start()
-    }
+      if (this.#config.schedule) {
+        await this.#timekeeper.start()
+      }
 
-    if (this.#config.migrate) {
-      await this.#bam.start()
+      if (this.#config.migrate) {
+        await this.#bam.start()
+      }
+    } catch (err) {
+      this.#starting = false
+      throw err
     }
 
     this.#starting = false

--- a/test/configTest.ts
+++ b/test/configTest.ts
@@ -55,6 +55,22 @@ describe('config', function () {
     expect(result2).toBeTruthy()
   })
 
+  it('should allow start() retry after a startup error', async function () {
+    let calls = 0
+    const db = {
+      async executeSql () {
+        calls += 1
+        throw new Error('startup failed')
+      }
+    }
+    const boss = new PgBoss({ db, migrate: false, supervise: false, schedule: false })
+
+    await expect(boss.start()).rejects.toThrow('startup failed')
+    await expect(boss.start()).rejects.toThrow('startup failed')
+
+    expect(calls).toBe(2)
+  })
+
   it('isInstalled() should indicate whether db schema is installed', async function () {
     const db = new Db(ctx.bossConfig)
     await db.open()


### PR DESCRIPTION
## Summary
- Reset the internal `#starting` guard when startup fails
- Add regression coverage so a second `start()` attempt is not skipped after a failed startup

Fixes #793

## Test Plan
- `node --import=tsx start-retry-smoke.ts`
- `npx eslint src/index.ts test/configTest.ts`
- `git diff --check`

Note: `npm run tsc` currently reports pre-existing test type errors in unrelated files (for example Prisma test imports and strict-null checks), and the normal Vitest config requires a local Postgres instance for `test/hooks.ts`.
