### PR TITLE
Improve VitePress config and docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy docs
 on:
   push:
     branches: [master]
-    paths: ['docs/**', '.github/workflows/docs.yml']
+    paths: ['docs/**', '.github/workflows/docs.yml', 'package.json']
   workflow_dispatch:
 
 permissions:
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'timgit/pg-boss'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,8 +19,13 @@ export default defineConfig({
     })()`]
   ],
   themeConfig: {
+    outline: [2, 3],
+    externalLinkIcon: true,
     search: {
-      provider: 'local'
+      provider: 'local',
+      options: {
+        detailedView: true
+      }
     },
     nav: [
       { text: 'Get Started', link: '/introduction' },
@@ -41,6 +46,7 @@ export default defineConfig({
       { text: 'Proxy', link: '/proxy' },
       {
         text: 'API',
+        collapsed: false,
         items: [
           { text: 'Constructor', link: '/api/constructor' },
           { text: 'Events', link: '/api/events' },
@@ -57,6 +63,7 @@ export default defineConfig({
       },
       {
         text: 'SQL',
+        collapsed: true,
         items: [
           { text: 'Job Table', link: '/sql/job-table' },
           { text: 'Queue Functions', link: '/sql/queue-functions' },
@@ -66,13 +73,14 @@ export default defineConfig({
     ],
     editLink: {
       pattern: 'https://github.com/timgit/pg-boss/edit/master/docs/:path',
-      text: 'Edit this page on GitHub'
+      text: 'Suggest changes to this page'
     },
     lastUpdated: {
       text: 'Last updated'
     },
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/timgit/pg-boss' }
+      { icon: 'github', link: 'https://github.com/timgit/pg-boss' },
+      { icon: 'npm', link: 'https://www.npmjs.com/package/pg-boss' }
     ]
   }
 })


### PR DESCRIPTION
### VitePress config changes
-  Added `outline: [2, 3]` so the right-hand outline panel shows both `##` and `###` headings
-  Enabled `externalLinkIcon` so links to GitHub, npm, and other external sites show a visual indicator
- Enabled `detailedView` in the local search options. By default search results show only the page title; with this on, results include the matched section heading and a content snippet
- Sidebar: Set the API section to `collapsed: false` and the SQL section to `collapsed: true`
- Changed the edit link label from "Edit this page on GitHub" to "Suggest changes to this page"
- Added an npm icon link alongside the existing GitHub one in the nav bar

### Docs workflow adjustments
-  Added `package.json` to the deploy workflow path filter. The version number in the nav bar is read directly from `package.json` at build time, so bumping the version without touching any doc files leaves the deployed site showing a stale version until something else in `docs/**` changed
- Skip deploy on forks

### Misc 
- Remove `.nojekyll`