### PR TITLE
Correctly handle manual failures in spies

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -208,12 +208,24 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  #trackJobsFailed<T> (name: string, jobs: types.Job<T>[], err: Error): void {
+  async #trackJobsFailed<T> (name: string, jobs: types.Job<T>[], err: Error): Promise<void> {
     const spy = this.config.__test__enableSpies ? this.#spies.get(name) : undefined
-    if (spy) {
-      for (const job of jobs) {
-        spy.addJob(job.id, name, job.data as object, 'failed', { message: err?.message, stack: err?.stack })
+    if (!spy) return
+
+    // A handler throw routes through fail(), but fail() only lands the job in the terminal
+    // 'failed' state once its retries are exhausted (retry_count >= retry_limit). While retries
+    // remain the job goes back to 'retry' and will run again, so recording 'failed' here would be
+    // wrong — the spy would report a permanent failure for a job that may yet succeed on retry,
+    // and (if the retry does succeed) it would hold contradictory 'failed' + 'completed' entries.
+    // Read the real persisted state and only record 'failed' when the job actually failed for good.
+    // The eventual outcome of a retried job — success, or terminal failure when retries run out —
+    // is recorded by whichever attempt produces it. Mirrors the slow path in #trackJobsCompleted.
+    for (const job of jobs) {
+      const persisted = await this.getJobById<object>(name, job.id)
+      if (persisted?.state === 'failed') {
+        spy.addJob(job.id, name, job.data as object, 'failed', persisted.output ?? { message: err?.message, stack: err?.stack })
       }
+      // 'retry' / 'created' (retries remaining) have no terminal spy state, so they are skipped.
     }
   }
 
@@ -336,7 +348,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     // inside the trackers stay as a safety net.
     if (this.config.__test__enableSpies && this.#spies.has(name)) {
       if (didFail) {
-        this.#trackJobsFailed(name, jobs, failedError)
+        await this.#trackJobsFailed(name, jobs, failedError)
       } else {
         await this.#trackJobsCompleted(name, jobs, completedResult, completedAffected)
       }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -324,11 +324,16 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
 
     // Spy tracking runs after the completion/failure logic so a spy lookup error can never
-    // be mistaken for a handler failure and re-route the job through fail().
-    if (didFail) {
-      this.#trackJobsFailed(name, jobs, failedError)
-    } else {
-      await this.#trackJobsCompleted(name, jobs, completedResult, completedAffected)
+    // be mistaken for a handler failure and re-route the job through fail(). The flag is
+    // gated here, not just inside the trackers, so the production hot path (spies off) never
+    // even calls the async tracker — no promise allocated, no microtask tick. The checks
+    // inside the trackers stay as a safety net.
+    if (this.config.__test__enableSpies && this.#spies.has(name)) {
+      if (didFail) {
+        this.#trackJobsFailed(name, jobs, failedError)
+      } else {
+        await this.#trackJobsCompleted(name, jobs, completedResult, completedAffected)
+      }
     }
   }
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -197,6 +197,12 @@ class Manager extends EventEmitter implements types.EventsMixin {
       const state = persisted?.state
       if (state === 'completed' || state === 'failed' || state === 'active' || state === 'created') {
         spy.addJob(job.id, name, job.data as object, state, persisted?.output)
+      } else if (!persisted) {
+        // The handler deleted the job itself (e.g. boss.deleteJob in the handler), so there is
+        // no persisted row to inspect. The handler still returned normally, so from the spy's
+        // perspective the work succeeded — record 'completed', matching the behavior before
+        // manual-failure tracking was added.
+        spy.addJob(job.id, name, job.data as object, 'completed', undefined)
       }
       // 'retry' / 'cancelled' have no spy-state equivalent, so they are intentionally skipped
     }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -175,13 +175,30 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
-  #trackJobsCompleted<T> (name: string, jobs: types.Job<T>[], result: unknown): void {
+  async #trackJobsCompleted<T> (name: string, jobs: types.Job<T>[], result: unknown, affected: number): Promise<void> {
     const spy = this.config.__test__enableSpies ? this.#spies.get(name) : undefined
-    if (spy) {
+    if (!spy) return
+
+    // Fast path: complete() transitioned every job (it only touches jobs still in the
+    // active state), so the handler's return value is the output for each one.
+    if (affected === jobs.length) {
       const output = jobs.length === 1 ? result as object : undefined
       for (const job of jobs) {
         spy.addJob(job.id, name, job.data as object, 'completed', output)
       }
+      return
+    }
+
+    // Otherwise the handler transitioned one or more jobs itself before returning (e.g. a
+    // validation failure routed through boss.fail()), making complete() a no-op for those.
+    // Reflect each job's real persisted state rather than assuming completion.
+    for (const job of jobs) {
+      const persisted = await this.getJobById<object>(name, job.id)
+      const state = persisted?.state
+      if (state === 'completed' || state === 'failed' || state === 'active' || state === 'created') {
+        spy.addJob(job.id, name, job.data as object, state, persisted?.output)
+      }
+      // 'retry' / 'cancelled' have no spy-state equivalent, so they are intentionally skipped
     }
   }
 
@@ -284,19 +301,34 @@ class Manager extends EventEmitter implements types.EventsMixin {
       }, intervalMs)
     }
 
+    let completedResult: unknown
+    let completedAffected = 0
+    let failedError: any
+    let didFail = false
+
     try {
       const result = await resolveWithinSeconds(callback(jobs), maxExpiration, `handler execution exceeded ${maxExpiration}s`, ac)
-      await this.complete(name, jobIds, jobIds.length === 1 ? result : undefined)
-      this.#trackJobsCompleted(name, jobs, result)
+      const completion = await this.complete(name, jobIds, jobIds.length === 1 ? result : undefined)
+      completedResult = result
+      completedAffected = completion.affected
     } catch (err: any) {
       await this.fail(name, jobIds, err)
-      this.#trackJobsFailed(name, jobs, err)
+      failedError = err
+      didFail = true
     } finally {
       if (heartbeatTimer) clearInterval(heartbeatTimer)
       if (worker) {
         // Clear between jobs
         worker.abortController = null
       }
+    }
+
+    // Spy tracking runs after the completion/failure logic so a spy lookup error can never
+    // be mistaken for a handler failure and re-route the job through fail().
+    if (didFail) {
+      this.#trackJobsFailed(name, jobs, failedError)
+    } else {
+      await this.#trackJobsCompleted(name, jobs, completedResult, completedAffected)
     }
   }
 

--- a/test/spyTest.ts
+++ b/test/spyTest.ts
@@ -90,6 +90,62 @@ describe('spy', function () {
     expect((persisted as any).state).toBe('failed')
   })
 
+  it('should not record a transient failure as failed when the job later succeeds on retry', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    // retryLimit 1 + no delay: first attempt throws (job → retry), second attempt succeeds.
+    const jobId = await ctx.boss.send(ctx.schema, { value: 'test' }, { retryLimit: 1, retryDelay: 0 })
+    assertTruthy(jobId)
+
+    let attempts = 0
+    await ctx.boss.work(ctx.schema, async () => {
+      attempts++
+      if (attempts === 1) {
+        throw new Error('transient error')
+      }
+      return { result: 'success' }
+    })
+
+    // The job ultimately succeeds, so the spy must report it as completed...
+    const job = await spy.waitForJobWithId(jobId, 'completed')
+    expect(job.id).toBe(jobId)
+    expect(job.state).toBe('completed')
+    expect(job.output).toEqual({ result: 'success' })
+
+    // ...and must never have recorded the transient first-attempt failure as a terminal failure.
+    const failedResult = await Promise.race([
+      spy.waitForJobWithId(jobId, 'failed'),
+      delay(500).then(() => 'timeout')
+    ])
+    expect(failedResult).toBe('timeout')
+  })
+
+  it('should record a failure as failed only once retries are exhausted', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    // retryLimit 1 + no delay: both the initial attempt and its single retry throw.
+    const jobId = await ctx.boss.send(ctx.schema, { value: 'test' }, { retryLimit: 1, retryDelay: 0 })
+    assertTruthy(jobId)
+
+    await ctx.boss.work(ctx.schema, async () => {
+      throw new Error('always fails')
+    })
+
+    const job = await spy.waitForJobWithId(jobId, 'failed')
+    expect(job.id).toBe(jobId)
+    expect(job.state).toBe('failed')
+    expect((job.output as any).message).toBe('always fails')
+
+    // The database agrees the job is terminally failed (retries exhausted).
+    const persisted = await ctx.boss.getJobById(ctx.schema, jobId)
+    expect((persisted as any).state).toBe('failed')
+    expect((persisted as any).retryCount).toBe(1)
+  })
+
   it('should track job as active', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 

--- a/test/spyTest.ts
+++ b/test/spyTest.ts
@@ -57,6 +57,39 @@ describe('spy', function () {
     expect((job.output as any).message).toBe('test error')
   })
 
+  it('should track a manual failure inside the handler as failed, not completed', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    // retryLimit 0 so the manual fail lands in the terminal failed state (not retry)
+    const jobId = await ctx.boss.send(ctx.schema, { value: 'test' }, { retryLimit: 0 })
+    assertTruthy(jobId)
+
+    // Handler manually fails the job (e.g. a validation error) but returns normally
+    await ctx.boss.work(ctx.schema, async ([job]) => {
+      await ctx.boss!.fail(ctx.schema, job.id, new Error('validation failed'))
+    })
+
+    // Spy must reflect the real persisted state, not infer completion from the
+    // handler returning without throwing
+    const job = await spy.waitForJobWithId(jobId, 'failed')
+    expect(job.id).toBe(jobId)
+    expect(job.state).toBe('failed')
+    expect((job.output as any).message).toBe('validation failed')
+
+    // It must never have been recorded as completed
+    const completedResult = await Promise.race([
+      spy.waitForJobWithId(jobId, 'completed'),
+      delay(500).then(() => 'timeout')
+    ])
+    expect(completedResult).toBe('timeout')
+
+    // And the database agrees
+    const persisted = await ctx.boss.getJobById(ctx.schema, jobId)
+    expect((persisted as any).state).toBe('failed')
+  })
+
   it('should track job as active', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 


### PR DESCRIPTION
In manager.ts, the worker loop (#processJobs) inferred the Spy's job state from whether the handler threw, not from what actually happened in the database:

```ts  
const result = await callback(jobs)   // returned normally → assumed "completed"
await this.complete(name, jobIds, …)  // SQL only updates jobs where state = 'active'
this.#trackJobsCompleted(name, jobs, result)  // ← recorded 'completed' unconditionally
```

When a handler manually fails a job (e.g. boss.fail() on a validation error) and then returns normally, the job is no longer active, so complete() is a no-op - the DB correctly stays failed. But #trackJobsCompleted ran anyway, so the Spy reported completed.

