### PR TITLE
feat(work): per-job settlement for batch handlers via perJobResults

### DIFF
--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -36,14 +36,17 @@ The default options for `work()` is 1 job every 2 seconds.
         const output = resize(job.data)
         return { id: job.id, status: 'completed', output }
       } catch (err) {
-        return { id: job.id, status: 'failed', output: err }
+        return err.fatal
+          ? { id: job.id, status: 'deadletter', output: err }
+          : { id: job.id, status: 'failed', output: err }
       }
     })
   })
   ```
 
-  Each `JobResult` is `{ id, status, output? }` where `id` matches a job from the batch, `status` is `'completed'` or `'failed'`, and `output` is stored on that job (the completion result, or the failure detail). Notes:
+  Each `JobResult` is `{ id, status, output? }` where `id` matches a job from the batch, `status` is `'completed'`, `'failed'`, or `'deadletter'`, and `output` is stored on that job (the completion result, or the failure detail). Notes:
 
+  - **`deadletter`** fails the job terminally and routes it straight to the queue's configured dead letter queue, bypassing any remaining retries (the `output` travels to the dead letter job). If the queue has no dead letter queue configured, the job simply fails terminally — equivalent to a `failed` job that has exhausted its retries.
   - Any job in the batch the handler omits from the array is **failed** with a descriptive error so it retries (or dead-letters) per the queue config — a returned result is never assumed.
   - **Throwing** from the handler still fails the entire batch, exactly as without `perJobResults`. Use the returned array to express per-job failures; reserve throwing for batch-wide errors.
   - Resolving with anything other than an array is treated as a contract violation and fails the whole batch.

--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -25,6 +25,29 @@ The default options for `work()` is 1 job every 2 seconds.
 
   Same as in [`fetch()`](./jobs#fetchname-options)
 
+* **perJobResults**, bool, *(default=false)*
+
+  Opt in to per-job settlement for batch handlers. By default a batch handler is all-or-nothing: returning completes every job in the batch (and the return value is only stored as `output` when `batchSize` is 1), while throwing fails every job. When `perJobResults` is true, the handler must instead resolve with an array of `JobResult` objects — one per job it processed — and pg-boss settles each job individually, preserving its own output:
+
+  ```js
+  await boss.work('resize-image', { batchSize: 10, perJobResults: true }, async (jobs) => {
+    return jobs.map(job => {
+      try {
+        const output = resize(job.data)
+        return { id: job.id, status: 'completed', output }
+      } catch (err) {
+        return { id: job.id, status: 'failed', output: err }
+      }
+    })
+  })
+  ```
+
+  Each `JobResult` is `{ id, status, output? }` where `id` matches a job from the batch, `status` is `'completed'` or `'failed'`, and `output` is stored on that job (the completion result, or the failure detail). Notes:
+
+  - Any job in the batch the handler omits from the array is **failed** with a descriptive error so it retries (or dead-letters) per the queue config — a returned result is never assumed.
+  - **Throwing** from the handler still fails the entire batch, exactly as without `perJobResults`. Use the returned array to express per-job failures; reserve throwing for batch-wide errors.
+  - Resolving with anything other than an array is treated as a contract violation and fails the whole batch.
+
 * **priority**, bool, *(default=true)*
 
   Same as in [`fetch()`](./jobs#fetchname-options)
@@ -166,6 +189,8 @@ In this setup:
 **Handler function**
 
 `handler` should return a promise (Usually this is an `async` function). If the `handler` returns a value or an object, it will be stored in the `output` property. If an unhandled error occurs in a handler, `fail()` will automatically be called for the jobs, storing the error in the `output` property, making the job or jobs available for retry.
+
+> By default this is all-or-nothing across the batch. To complete and fail individual jobs within a batch — each with its own `output` — enable the **perJobResults** option above.
 
 The jobs argument is an array of jobs with the following properties.
 

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -327,6 +327,7 @@ function checkWorkArgs (name: string, args: any[]): {
   assert(!('includeMetadata' in options) || typeof options.includeMetadata === 'boolean', 'includeMetadata must be a boolean')
   assert(!('priority' in options) || typeof options.priority === 'boolean', 'priority must be a boolean')
   assert(!('localConcurrency' in options) || (Number.isInteger(options.localConcurrency) && options.localConcurrency >= 1), 'localConcurrency must be an integer >= 1')
+  assert(!('perJobResults' in options) || typeof options.perJobResults === 'boolean', 'perJobResults must be a boolean')
   validatePriorityRangeConfig(options)
   validateGroupConcurrencyConfig(options)
   validateHeartbeatRefreshConfig(options)

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,8 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
   }
 
   work<ReqData, ResData = any>(name: string, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
+  work<ReqData, ResData = any>(name: string, options: types.WorkOptions & { perJobResults: true; includeMetadata: true }, handler: types.PerJobWorkWithMetadataHandler<ReqData, ResData>): Promise<string>
+  work<ReqData, ResData = any>(name: string, options: types.WorkOptions & { perJobResults: true }, handler: types.PerJobWorkHandler<ReqData, ResData>): Promise<string>
   work<ReqData, ResData = any>(name: string, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData, ResData>): Promise<string>
   work<ReqData, ResData = any>(name: string, options: types.WorkOptions, handler: types.WorkHandler<ReqData, ResData>): Promise<string>
   work (...args: any[]): Promise<string> {
@@ -450,6 +452,8 @@ export type {
   JobInsert,
   JobOptions,
   JobPollingOptions,
+  JobResult,
+  JobResultStatus,
   JobStates,
   Events,
   JobWithMetadata,
@@ -474,6 +478,8 @@ export type {
   WorkHandler,
   WorkOptions,
   WorkWithMetadataHandler,
+  PerJobWorkHandler,
+  PerJobWorkWithMetadataHandler,
 } from './types.ts'
 
 export type {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -263,7 +263,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
   // and passed as a JSON recordset so the batch size doesn't drive the statement count.
   async #completeWithOutputs (name: string, items: { id: string, output: unknown }[]): Promise<types.CommandResponse> {
     const { table } = await this.getQueueCache(name)
-    const payload = items.map(item => ({ id: item.id, output: this.mapCompletionDataArg(item.output as object) }))
+    const payload = items.map(item => ({ id: item.id, output: this.mapCompletionDataArg(item.output) }))
     const ids = items.map(item => item.id)
 
     if (this.config.noMultiMutationCte) {
@@ -1055,7 +1055,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return ids
   }
 
-  private mapCompletionDataArg (data?: object | null) {
+  private mapCompletionDataArg (data?: unknown) {
     if (data === null || typeof data === 'undefined' || typeof data === 'function') { return null }
 
     const result = (typeof data === 'object' && !Array.isArray(data))

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -211,8 +211,9 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
   // Per-job settlement for `perJobResults` batch handlers. The handler resolves with a JobResult[]
   // describing each job's outcome; we settle completed and failed jobs individually, each with its
-  // own output. Jobs that share an identical output are collapsed into a single complete()/fail()
-  // call. Any batch job the handler omits (or returns with an invalid shape) is failed with a
+  // own output. All completed jobs are settled in a single statement and all failed jobs in another
+  // (each output carried per-id via a JSON recordset), so batch size never drives the statement
+  // count. Any batch job the handler omits (or returns with an invalid shape) is failed with a
   // descriptive error so it retries / dead-letters per queue config.
   async #settlePerJob<T> (name: string, jobs: types.Job<T>[], result: unknown): Promise<void> {
     if (!Array.isArray(result)) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -230,20 +230,24 @@ class Manager extends EventEmitter implements types.EventsMixin {
     const batch = new Map(jobs.map(job => [job.id, job]))
     const disposition = new Map<string, types.JobResult>()
     for (const item of result as types.JobResult[]) {
-      if (item && batch.has(item.id) && (item.status === 'completed' || item.status === 'failed')) {
+      if (item && batch.has(item.id) && (item.status === 'completed' || item.status === 'failed' || item.status === 'deadletter')) {
         disposition.set(item.id, item)
       }
     }
 
-    // Partition the batch (the authoritative set of jobs) by disposition.
+    // Partition the batch (the authoritative set of jobs) by disposition. `deadletter` jobs fail
+    // terminally and route straight to the dead letter queue, bypassing remaining retries.
     const completed: { job: types.Job<T>, output: unknown }[] = []
     const failed: { job: types.Job<T>, output: unknown }[] = []
+    const deadLettered: { job: types.Job<T>, output: unknown }[] = []
     for (const job of jobs) {
       const item = disposition.get(job.id)
       if (item?.status === 'completed') {
         completed.push({ job, output: item.output })
       } else if (item?.status === 'failed') {
         failed.push({ job, output: item.output })
+      } else if (item?.status === 'deadletter') {
+        deadLettered.push({ job, output: item.output })
       } else {
         failed.push({ job, output: new Error('no disposition returned by handler') })
       }
@@ -255,8 +259,12 @@ class Manager extends EventEmitter implements types.EventsMixin {
     if (failed.length > 0) {
       await this.#failWithOutputs(name, failed.map(f => ({ id: f.job.id, output: f.output })))
     }
+    if (deadLettered.length > 0) {
+      await this.#failWithOutputs(name, deadLettered.map(d => ({ id: d.job.id, output: d.output })), true)
+    }
 
-    this.#trackJobsSettled(name, completed, failed)
+    // Dead lettered jobs end in the same terminal `failed` state as failed jobs on the source queue.
+    this.#trackJobsSettled(name, completed, [...failed, ...deadLettered])
   }
 
   // Complete a set of active jobs, each with its own output, in a constant number of statements
@@ -286,8 +294,9 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
   // Fail a set of active jobs, each with its own output, in a constant number of statements. On a
   // distributed backend this reuses the select -> delete -> reinsert split, passing per-id outputs
-  // to reinsertFailedJobs so each job keeps its own failure detail.
-  async #failWithOutputs (name: string, items: { id: string, output: unknown }[]): Promise<types.CommandResponse> {
+  // to reinsertFailedJobs so each job keeps its own failure detail. When `forceTerminal` is set the
+  // jobs fail terminally and route straight to the dead letter queue, bypassing remaining retries.
+  async #failWithOutputs (name: string, items: { id: string, output: unknown }[], forceTerminal = false): Promise<types.CommandResponse> {
     const { table } = await this.getQueueCache(name)
     const ids = items.map(item => item.id)
 
@@ -304,13 +313,15 @@ class Manager extends EventEmitter implements types.EventsMixin {
         const deleteQuery = plans.deleteJobsToFail(this.config.schema, table)
         await tx.executeSql(deleteQuery.text, [name, ids])
 
-        const count = await this.reinsertFailedJobs(tx, table, jobs, null, outputById)
+        const count = await this.reinsertFailedJobs(tx, table, jobs, null, outputById, forceTerminal)
         return { jobs: ids, requested: ids.length, affected: count }
       })
     }
 
     const payload = items.map(item => ({ id: item.id, output: this.mapCompletionDataArg(item.output) }))
-    const sql = plans.failJobsByIdWithOutputs(this.config.schema, table)
+    const sql = forceTerminal
+      ? plans.deadLetterJobsByIdWithOutputs(this.config.schema, table)
+      : plans.failJobsByIdWithOutputs(this.config.schema, table)
     const result = await this.db.executeSql(sql, [name, JSON.stringify(payload)])
     return this.mapCommandResponse(ids, result)
   }
@@ -1196,7 +1207,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
   // Re-insert a set of just-deleted jobs as retry (when retries remain) or failed (+ dead letter),
   // preserving the flow/heartbeat columns. Shared by failDistributed and the distributed
   // maintenance expiry above. Returns the number of jobs processed.
-  private async reinsertFailedJobs (tx: types.IDatabase, table: string, jobs: any[], outputData: any, outputById?: Map<string, any>): Promise<number> {
+  private async reinsertFailedJobs (tx: types.IDatabase, table: string, jobs: any[], outputData: any, outputById?: Map<string, any>, forceTerminal = false): Promise<number> {
     const insertSql = plans.insertRetryJob(this.config.schema, table)
     const dlqSql = plans.insertDeadLetterJob(this.config.schema)
     let count = 0
@@ -1214,7 +1225,9 @@ class Manager extends EventEmitter implements types.EventsMixin {
       const retryDelay = Number(job.retry_delay)
       const retryDelayMax = job.retry_delay_max != null ? Number(job.retry_delay_max) : null
 
-      const canRetry = retryCount < retryLimit
+      // forceTerminal (perJobResults `deadletter`) skips retries so the job fails terminally and
+      // routes straight to the dead letter queue below.
+      const canRetry = !forceTerminal && retryCount < retryLimit
       let retried = false
 
       if (canRetry) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -194,6 +194,91 @@ class Manager extends EventEmitter implements types.EventsMixin {
     }
   }
 
+  #trackJobsSettled<T> (
+    name: string,
+    completed: { job: types.Job<T>, output: unknown }[],
+    failed: { job: types.Job<T>, output: unknown }[]
+  ): void {
+    const spy = this.config.__test__enableSpies ? this.#spies.get(name) : undefined
+    if (!spy) return
+    for (const { job, output } of completed) {
+      spy.addJob(job.id, name, job.data as object, 'completed', output as object)
+    }
+    for (const { job, output } of failed) {
+      spy.addJob(job.id, name, job.data as object, 'failed', stringify(output) as object)
+    }
+  }
+
+  // Per-job settlement for `perJobResults` batch handlers. The handler resolves with a JobResult[]
+  // describing each job's outcome; we settle completed and failed jobs individually, each with its
+  // own output. Jobs that share an identical output are collapsed into a single complete()/fail()
+  // call. Any batch job the handler omits (or returns with an invalid shape) is failed with a
+  // descriptive error so it retries / dead-letters per queue config.
+  async #settlePerJob<T> (name: string, jobs: types.Job<T>[], result: unknown): Promise<void> {
+    if (!Array.isArray(result)) {
+      // The handler opted into perJobResults but did not return an array: a contract violation.
+      // Fail the whole batch so the mistake surfaces and the jobs are retried.
+      const err = new Error('perJobResults handler must resolve with an array of job results')
+      await this.fail(name, jobs.map(job => job.id), err)
+      this.#trackJobsFailed(name, jobs, err)
+      return
+    }
+
+    // Index the handler's dispositions by job id, keeping only valid entries that reference a job
+    // from this batch. Last write wins on duplicate ids.
+    const batch = new Map(jobs.map(job => [job.id, job]))
+    const disposition = new Map<string, types.JobResult>()
+    for (const item of result as types.JobResult[]) {
+      if (item && batch.has(item.id) && (item.status === 'completed' || item.status === 'failed')) {
+        disposition.set(item.id, item)
+      }
+    }
+
+    // Partition the batch (the authoritative set of jobs) by disposition.
+    const completed: { job: types.Job<T>, output: unknown }[] = []
+    const failed: { job: types.Job<T>, output: unknown }[] = []
+    for (const job of jobs) {
+      const item = disposition.get(job.id)
+      if (item?.status === 'completed') {
+        completed.push({ job, output: item.output })
+      } else if (item?.status === 'failed') {
+        failed.push({ job, output: item.output })
+      } else {
+        failed.push({ job, output: new Error('no disposition returned by handler') })
+      }
+    }
+
+    await this.#settleGrouped(name, completed, (ids, output) => this.complete(name, ids, output as object))
+    await this.#settleGrouped(name, failed, (ids, output) => this.fail(name, ids, output))
+
+    this.#trackJobsSettled(name, completed, failed)
+  }
+
+  // Group jobs that share an identical (serialized) output into a single settle() call, so common
+  // cases — no output, or a shared error — collapse to one statement instead of one per job.
+  async #settleGrouped<T> (
+    name: string,
+    items: { job: types.Job<T>, output: unknown }[],
+    settle: (ids: string[], output: unknown) => Promise<unknown>
+  ): Promise<void> {
+    if (items.length === 0) return
+
+    const groups = new Map<string, { output: unknown, ids: string[] }>()
+    for (const { job, output } of items) {
+      const key = JSON.stringify(stringify(output ?? null)) ?? 'null'
+      const group = groups.get(key)
+      if (group) {
+        group.ids.push(job.id)
+      } else {
+        groups.set(key, { output, ids: [job.id] })
+      }
+    }
+
+    for (const { output, ids } of groups.values()) {
+      await settle(ids, output)
+    }
+  }
+
   #storeLocalGroupConfig (name: string, localGroupConcurrency: number | types.GroupConcurrencyConfig): void {
     const config: types.GroupConcurrencyConfig = typeof localGroupConcurrency === 'number'
       ? { default: localGroupConcurrency }
@@ -257,7 +342,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
     jobs: types.Job<T>[],
     callback: types.WorkHandler<T>,
     worker?: Worker<T>,
-    heartbeatRefreshSeconds?: number
+    heartbeatRefreshSeconds?: number,
+    perJobResults = false
   ): Promise<void> {
     const jobIds = jobs.map(job => job.id)
     const maxExpiration = jobs.reduce((acc, i) => Math.max(acc, i.expireInSeconds), 0)
@@ -286,8 +372,12 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
     try {
       const result = await resolveWithinSeconds(callback(jobs), maxExpiration, `handler execution exceeded ${maxExpiration}s`, ac)
-      await this.complete(name, jobIds, jobIds.length === 1 ? result : undefined)
-      this.#trackJobsCompleted(name, jobs, result)
+      if (perJobResults) {
+        await this.#settlePerJob(name, jobs, result)
+      } else {
+        await this.complete(name, jobIds, jobIds.length === 1 ? result : undefined)
+        this.#trackJobsCompleted(name, jobs, result)
+      }
     } catch (err: any) {
       await this.fail(name, jobIds, err)
       this.#trackJobsFailed(name, jobs, err)
@@ -377,6 +467,8 @@ class Manager extends EventEmitter implements types.EventsMixin {
   }
 
   work<ReqData>(name: string, handler: types.WorkHandler<ReqData>): Promise<string>
+  work<ReqData>(name: string, options: types.WorkOptions & { perJobResults: true; includeMetadata: true }, handler: types.PerJobWorkWithMetadataHandler<ReqData>): Promise<string>
+  work<ReqData>(name: string, options: types.WorkOptions & { perJobResults: true }, handler: types.PerJobWorkHandler<ReqData>): Promise<string>
   work<ReqData>(name: string, options: types.WorkOptions & { includeMetadata: true }, handler: types.WorkWithMetadataHandler<ReqData>): Promise<string>
   work<ReqData>(name: string, options: types.WorkOptions, handler: types.WorkHandler<ReqData>): Promise<string>
   async work<ReqData> (name: string, ...args: unknown[]): Promise<string> {
@@ -398,6 +490,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
       heartbeatRefreshSeconds,
       minPriority,
       maxPriority,
+      perJobResults = false,
     } = options
 
     if (localGroupConcurrency != null) {
@@ -426,7 +519,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
         // Skip all in-memory group tracking when localGroupConcurrency is not enabled
         if (localGroupConcurrency == null) {
-          await this.#processJobs(name, jobs, callback, worker, heartbeatRefreshSeconds)
+          await this.#processJobs(name, jobs, callback, worker, heartbeatRefreshSeconds, perJobResults)
         } else {
           const { allowed, excess, groupedJobs } = this.#trackLocalGroupStart(name, jobs)
 
@@ -437,7 +530,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
           if (allowed.length > 0) {
             try {
-              await this.#processJobs(name, allowed, callback, worker, heartbeatRefreshSeconds)
+              await this.#processJobs(name, allowed, callback, worker, heartbeatRefreshSeconds, perJobResults)
             } finally {
               this.#trackLocalGroupEnd(name, groupedJobs)
             }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -248,35 +248,70 @@ class Manager extends EventEmitter implements types.EventsMixin {
       }
     }
 
-    await this.#settleGrouped(name, completed, (ids, output) => this.complete(name, ids, output as object))
-    await this.#settleGrouped(name, failed, (ids, output) => this.fail(name, ids, output))
+    if (completed.length > 0) {
+      await this.#completeWithOutputs(name, completed.map(c => ({ id: c.job.id, output: c.output })))
+    }
+    if (failed.length > 0) {
+      await this.#failWithOutputs(name, failed.map(f => ({ id: f.job.id, output: f.output })))
+    }
 
     this.#trackJobsSettled(name, completed, failed)
   }
 
-  // Group jobs that share an identical (serialized) output into a single settle() call, so common
-  // cases — no output, or a shared error — collapse to one statement instead of one per job.
-  async #settleGrouped<T> (
-    name: string,
-    items: { job: types.Job<T>, output: unknown }[],
-    settle: (ids: string[], output: unknown) => Promise<unknown>
-  ): Promise<void> {
-    if (items.length === 0) return
+  // Complete a set of active jobs, each with its own output, in a constant number of statements
+  // (one on Postgres, two on a distributed backend). Outputs are serialized like complete()/fail()
+  // and passed as a JSON recordset so the batch size doesn't drive the statement count.
+  async #completeWithOutputs (name: string, items: { id: string, output: unknown }[]): Promise<types.CommandResponse> {
+    const { table } = await this.getQueueCache(name)
+    const payload = items.map(item => ({ id: item.id, output: this.mapCompletionDataArg(item.output as object) }))
+    const ids = items.map(item => item.id)
 
-    const groups = new Map<string, { output: unknown, ids: string[] }>()
-    for (const { job, output } of items) {
-      const key = JSON.stringify(stringify(output ?? null)) ?? 'null'
-      const group = groups.get(key)
-      if (group) {
-        group.ids.push(job.id)
-      } else {
-        groups.set(key, { output, ids: [job.id] })
-      }
+    if (this.config.noMultiMutationCte) {
+      return this.withDistributedTransaction(this.db, async (tx) => {
+        const sql = plans.completeJobsWithOutputsDistributed(this.config.schema, table)
+        const { rows } = await tx.executeSql(sql, [name, JSON.stringify(payload)])
+        const blockingIds = rows.filter(row => row.blocking).map(row => row.id)
+        if (blockingIds.length > 0) {
+          await tx.executeSql(plans.decrementDependents(this.config.schema), [name, blockingIds])
+        }
+        return { jobs: ids, requested: ids.length, affected: rows.length }
+      })
     }
 
-    for (const { output, ids } of groups.values()) {
-      await settle(ids, output)
+    const sql = plans.completeJobsWithOutputs(this.config.schema, table)
+    const result = await this.db.executeSql(sql, [name, JSON.stringify(payload)])
+    return this.mapCommandResponse(ids, result)
+  }
+
+  // Fail a set of active jobs, each with its own output, in a constant number of statements. On a
+  // distributed backend this reuses the select -> delete -> reinsert split, passing per-id outputs
+  // to reinsertFailedJobs so each job keeps its own failure detail.
+  async #failWithOutputs (name: string, items: { id: string, output: unknown }[]): Promise<types.CommandResponse> {
+    const { table } = await this.getQueueCache(name)
+    const ids = items.map(item => item.id)
+
+    if (this.config.noMultiMutationCte) {
+      const outputById = new Map(items.map(item => [item.id, this.mapCompletionDataArg(item.output)]))
+      return this.withDistributedTransaction(this.db, async (tx) => {
+        const selectQuery = plans.selectJobsToFailById(this.config.schema, table)
+        const { rows: jobs } = await tx.executeSql(selectQuery.text, [name, ids])
+
+        if (jobs.length === 0) {
+          return { jobs: ids, requested: ids.length, affected: 0 }
+        }
+
+        const deleteQuery = plans.deleteJobsToFail(this.config.schema, table)
+        await tx.executeSql(deleteQuery.text, [name, ids])
+
+        const count = await this.reinsertFailedJobs(tx, table, jobs, null, outputById)
+        return { jobs: ids, requested: ids.length, affected: count }
+      })
     }
+
+    const payload = items.map(item => ({ id: item.id, output: this.mapCompletionDataArg(item.output) }))
+    const sql = plans.failJobsByIdWithOutputs(this.config.schema, table)
+    const result = await this.db.executeSql(sql, [name, JSON.stringify(payload)])
+    return this.mapCommandResponse(ids, result)
   }
 
   #storeLocalGroupConfig (name: string, localGroupConcurrency: number | types.GroupConcurrencyConfig): void {
@@ -1160,12 +1195,15 @@ class Manager extends EventEmitter implements types.EventsMixin {
   // Re-insert a set of just-deleted jobs as retry (when retries remain) or failed (+ dead letter),
   // preserving the flow/heartbeat columns. Shared by failDistributed and the distributed
   // maintenance expiry above. Returns the number of jobs processed.
-  private async reinsertFailedJobs (tx: types.IDatabase, table: string, jobs: any[], outputData: any): Promise<number> {
+  private async reinsertFailedJobs (tx: types.IDatabase, table: string, jobs: any[], outputData: any, outputById?: Map<string, any>): Promise<number> {
     const insertSql = plans.insertRetryJob(this.config.schema, table)
     const dlqSql = plans.insertDeadLetterJob(this.config.schema)
     let count = 0
 
     for (const job of jobs) {
+      // Per-job output when supplied (perJobResults), otherwise the single shared output.
+      const jobOutput = outputById ? (outputById.get(job.id) ?? null) : outputData
+
       // CockroachDB returns INT8 columns as strings. These rows come straight from a SELECT *, so
       // unlike fetch/getJobById they are never normalized. Coerce the fields used in arithmetic and
       // comparison below — otherwise `retry_count < retry_limit` is a lexicographic string compare
@@ -1200,7 +1238,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
           job.retry_delay, job.retry_backoff, job.retry_delay_max, startAfter, job.started_on,
           job.singleton_key, job.singleton_on, job.group_id, job.group_tier, job.expire_seconds,
           job.deletion_seconds, job.created_on, null, job.keep_until, job.policy,
-          outputData, job.dead_letter,
+          jobOutput, job.dead_letter,
           null, job.heartbeat_seconds, job.blocked, job.blocking, job.pending_dependencies
         ])
 
@@ -1216,13 +1254,13 @@ class Manager extends EventEmitter implements types.EventsMixin {
           job.retry_delay, job.retry_backoff, job.retry_delay_max, job.start_after, job.started_on,
           job.singleton_key, job.singleton_on, job.group_id, job.group_tier, job.expire_seconds,
           job.deletion_seconds, job.created_on, new Date(), job.keep_until, job.policy,
-          outputData, job.dead_letter,
+          jobOutput, job.dead_letter,
           null, job.heartbeat_seconds, job.blocked, job.blocking, job.pending_dependencies
         ])
 
         // Insert to dead letter queue if failed and has dead_letter configured
         if (job.dead_letter) {
-          await tx.executeSql(dlqSql, [job.dead_letter, job.data, outputData])
+          await tx.executeSql(dlqSql, [job.dead_letter, job.data, jobOutput])
         }
       }
 

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1452,7 +1452,20 @@ function failJobs (schema: string, table: string, where: string, output: string)
 // re-insert them as retry (when retries remain) or failed (+ dead letter). `where` selects the rows
 // to fail and `output` is the SQL expression stored on each re-inserted job. Returned without the
 // leading `WITH` or trailing `SELECT` so callers can prepend extra CTEs (e.g. an output map).
-function failJobsBody (schema: string, table: string, where: string, output: string) {
+// When `forceTerminal` is set, every re-inserted job goes straight to the terminal `failed` state
+// regardless of remaining retries, so the dlq_jobs CTE routes it to the dead letter queue (if any)
+// immediately. This backs the perJobResults `deadletter` disposition.
+function failJobsBody (schema: string, table: string, where: string, output: string, forceTerminal = false) {
+  const state = forceTerminal
+    ? `'${JOB_STATES.failed}'::${schema}.job_state`
+    : `CASE
+          WHEN retry_count < retry_limit THEN '${JOB_STATES.retry}'::${schema}.job_state
+          ELSE '${JOB_STATES.failed}'::${schema}.job_state
+          END`
+  const completedOn = forceTerminal
+    ? 'now()'
+    : 'CASE WHEN retry_count < retry_limit THEN NULL ELSE now() END'
+
   return `deleted_jobs AS (
       DELETE FROM ${schema}.${table}
       WHERE ${where}
@@ -1495,10 +1508,7 @@ function failJobsBody (schema: string, table: string, where: string, output: str
         name,
         priority,
         data,
-        CASE
-          WHEN retry_count < retry_limit THEN '${JOB_STATES.retry}'::${schema}.job_state
-          ELSE '${JOB_STATES.failed}'::${schema}.job_state
-          END as state,
+        ${state} as state,
         retry_limit,
         retry_count,
         retry_delay,
@@ -1522,7 +1532,7 @@ function failJobsBody (schema: string, table: string, where: string, output: str
         expire_seconds,
         deletion_seconds,
         created_on,
-        CASE WHEN retry_count < retry_limit THEN NULL ELSE now() END as completed_on,
+        ${completedOn} as completed_on,
         keep_until,
         policy,
         ${output},
@@ -1636,6 +1646,21 @@ export function failJobsByIdWithOutputs (schema: string, table: string) {
       SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
     ),
     ${failJobsBody(schema, table, where, output)}
+    SELECT COUNT(*) FROM results
+  `
+}
+
+// Like failJobsByIdWithOutputs, but fails every job terminally (forceTerminal) so it routes straight
+// to the dead letter queue, bypassing remaining retries. Backs the perJobResults `deadletter` status.
+export function deadLetterJobsByIdWithOutputs (schema: string, table: string) {
+  const where = `name = $1 AND id IN (SELECT id FROM output_map) AND state < '${JOB_STATES.completed}'`
+  const output = '(SELECT om.output FROM output_map om WHERE om.id = deleted_jobs.id)'
+
+  return `
+    WITH output_map AS (
+      SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
+    ),
+    ${failJobsBody(schema, table, where, output, true)}
     SELECT COUNT(*) FROM results
   `
 }

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1206,6 +1206,62 @@ export function completeJobs (schema: string, table: string, includeQueued?: boo
   `
 }
 
+// Per-job-output completion: each job's output is supplied via a JSON recordset ($2) and applied by
+// id, so a batch can be completed with distinct outputs in a single statement. Mirrors completeJobs
+// (only active jobs; same dependency-unblocking), but sources output from the input join.
+export function completeJobsWithOutputs (schema: string, table: string) {
+  return `
+    WITH input AS (
+      SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
+    ),
+    completed AS (
+      UPDATE ${schema}.${table} j
+      SET completed_on = now(),
+        state = '${JOB_STATES.completed}',
+        output = i.output
+      FROM input i
+      WHERE j.name = $1
+        AND j.id = i.id
+        AND j.state = '${JOB_STATES.active}'
+      RETURNING j.name, j.id, j.blocking
+    ),
+    decremented AS (
+      SELECT d.child_name, d.child_id, COUNT(*)::int AS n
+      FROM ${schema}.job_dependency d
+      JOIN completed c ON c.blocking
+        AND d.parent_name = c.name
+        AND d.parent_id = c.id
+      GROUP BY d.child_name, d.child_id
+    ),
+    ${lockedChildrenCte(schema)},
+    unblocked AS (
+      ${unblockChildrenUpdate(schema)}
+      RETURNING 1
+    )
+    SELECT COUNT(*) FROM completed
+  `
+}
+
+// Distributed equivalent of completeJobsWithOutputs: a single mutation that returns the completed
+// ids and whether each was blocking, so the caller can decrement dependents in a separate statement
+// (CockroachDB rejects multi-mutation CTEs). Pairs with decrementDependents().
+export function completeJobsWithOutputsDistributed (schema: string, table: string) {
+  return `
+    WITH input AS (
+      SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
+    )
+    UPDATE ${schema}.${table} j
+    SET completed_on = now(),
+      state = '${JOB_STATES.completed}',
+      output = i.output
+    FROM input i
+    WHERE j.name = $1
+      AND j.id = i.id
+      AND j.state = '${JOB_STATES.active}'
+    RETURNING j.id, j.blocking
+  `
+}
+
 export function cancelJobs (schema: string, table: string) {
   return `
     WITH results as (
@@ -1387,7 +1443,17 @@ export function touchJobs (schema: string, table: string) {
 
 function failJobs (schema: string, table: string, where: string, output: string) {
   return `
-    WITH deleted_jobs AS (
+    WITH ${failJobsBody(schema, table, where, output)}
+    SELECT COUNT(*) FROM results
+  `
+}
+
+// The CTE chain shared by failJobs() and failJobsByIdWithOutputs(): delete the matched jobs and
+// re-insert them as retry (when retries remain) or failed (+ dead letter). `where` selects the rows
+// to fail and `output` is the SQL expression stored on each re-inserted job. Returned without the
+// leading `WITH` or trailing `SELECT` so callers can prepend extra CTEs (e.g. an output map).
+function failJobsBody (schema: string, table: string, where: string, output: string) {
+  return `deleted_jobs AS (
       DELETE FROM ${schema}.${table}
       WHERE ${where}
       RETURNING *
@@ -1555,7 +1621,21 @@ function failJobs (schema: string, table: string, where: string, output: string)
       FROM results r
         JOIN ${schema}.queue q ON q.name = r.dead_letter
       WHERE state = '${JOB_STATES.failed}'
-    )
+    )`
+}
+
+export function failJobsByIdWithOutputs (schema: string, table: string) {
+  // Output is supplied per job via a JSON recordset ($2). `where` and the output expression both
+  // reference the output_map CTE so each re-inserted job keeps its own output. Constant number of
+  // statements regardless of batch size.
+  const where = `name = $1 AND id IN (SELECT id FROM output_map) AND state < '${JOB_STATES.completed}'`
+  const output = '(SELECT om.output FROM output_map om WHERE om.id = deleted_jobs.id)'
+
+  return `
+    WITH output_map AS (
+      SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
+    ),
+    ${failJobsBody(schema, table, where, output)}
     SELECT COUNT(*) FROM results
   `
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -447,10 +447,10 @@ export type WorkOptions = JobFetchOptions & JobPollingOptions & WorkConcurrencyO
   heartbeatRefreshSeconds?: number;
   /**
    * Opt in to per-job settlement for batch handlers. When true, the handler must resolve with a
-   * `JobResult[]` describing the outcome (`completed` or `failed`, with optional per-job `output`)
-   * of each job in the batch. pg-boss settles each job individually, preserving its own output.
-   * Any job omitted from the result is failed (and retried) with a descriptive error. Throwing
-   * from the handler still fails the whole batch. Defaults to false.
+   * `JobResult[]` describing the outcome (`completed`, `failed`, or `deadletter`, with optional
+   * per-job `output`) of each job in the batch. pg-boss settles each job individually, preserving
+   * its own output. Any job omitted from the result is failed (and retried) with a descriptive
+   * error. Throwing from the handler still fails the whole batch. Defaults to false.
    */
   perJobResults?: boolean;
 }
@@ -473,11 +473,15 @@ export interface WorkWithMetadataHandler<ReqData, ResData = any> {
   (job: JobWithMetadata<ReqData>[]): Promise<ResData>;
 }
 
-export type JobResultStatus = 'completed' | 'failed'
+export type JobResultStatus = 'completed' | 'failed' | 'deadletter'
 
 /**
  * Per-job outcome returned by a `perJobResults` batch handler. `id` must match a job from the
  * batch; `output` is stored on that job (the completion result, or the failure detail).
+ *
+ * `deadletter` fails the job terminally and routes it straight to the queue's configured dead
+ * letter queue, bypassing any remaining retries. If the queue has no dead letter queue, it simply
+ * fails terminally (same as a `failed` job whose retries are exhausted).
  */
 export interface JobResult<ResData = any> {
   id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -445,6 +445,14 @@ export type WorkOptions = JobFetchOptions & JobPollingOptions & WorkConcurrencyO
    * Must be strictly less than `heartbeatSeconds`.
    */
   heartbeatRefreshSeconds?: number;
+  /**
+   * Opt in to per-job settlement for batch handlers. When true, the handler must resolve with a
+   * `JobResult[]` describing the outcome (`completed` or `failed`, with optional per-job `output`)
+   * of each job in the batch. pg-boss settles each job individually, preserving its own output.
+   * Any job omitted from the result is failed (and retried) with a descriptive error. Throwing
+   * from the handler still fails the whole batch. Defaults to false.
+   */
+  perJobResults?: boolean;
 }
 export interface FetchGroupConcurrencyOptions {
   groupConcurrency?: number | GroupConcurrencyConfig;
@@ -463,6 +471,26 @@ export interface WorkHandler<ReqData, ResData = any> {
 
 export interface WorkWithMetadataHandler<ReqData, ResData = any> {
   (job: JobWithMetadata<ReqData>[]): Promise<ResData>;
+}
+
+export type JobResultStatus = 'completed' | 'failed';
+
+/**
+ * Per-job outcome returned by a `perJobResults` batch handler. `id` must match a job from the
+ * batch; `output` is stored on that job (the completion result, or the failure detail).
+ */
+export interface JobResult<ResData = any> {
+  id: string;
+  status: JobResultStatus;
+  output?: ResData;
+}
+
+export interface PerJobWorkHandler<ReqData, ResData = any> {
+  (job: Job<ReqData>[]): Promise<JobResult<ResData>[]>;
+}
+
+export interface PerJobWorkWithMetadataHandler<ReqData, ResData = any> {
+  (job: JobWithMetadata<ReqData>[]): Promise<JobResult<ResData>[]>;
 }
 
 export interface Request {

--- a/src/types.ts
+++ b/src/types.ts
@@ -473,7 +473,7 @@ export interface WorkWithMetadataHandler<ReqData, ResData = any> {
   (job: JobWithMetadata<ReqData>[]): Promise<ResData>;
 }
 
-export type JobResultStatus = 'completed' | 'failed';
+export type JobResultStatus = 'completed' | 'failed'
 
 /**
  * Per-job outcome returned by a `perJobResults` batch handler. `id` must match a job from the

--- a/test/perJobResultsTest.ts
+++ b/test/perJobResultsTest.ts
@@ -245,4 +245,205 @@ describe('perJobResults', function () {
     expect(job.state).toBe('failed')
     expect((job.output as { message: string }).message).toBe('no disposition returned by handler')
   })
+
+  it('routes a deadletter result straight to the DLQ, bypassing remaining retries', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const deadLetter = `${ctx.schema}_dlq`
+    await ctx.boss.createQueue(deadLetter)
+    await ctx.boss.createQueue(ctx.schema, { deadLetter })
+
+    // retryLimit is 2, but a deadletter disposition must skip the retries entirely.
+    const jobId = await ctx.boss.send(ctx.schema, { key: 'payload' }, { retryLimit: 2 })
+    assertTruthy(jobId)
+
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      jobs.map(job => ({ id: job.id, status: 'deadletter' as const, output: new Error('fatal, do not retry') })))
+
+    await spy.waitForJobWithId(jobId, 'failed')
+
+    // The source job is terminally failed on its first attempt - no retry was consumed.
+    const source = await ctx.boss.getJobById(ctx.schema, jobId)
+    assertTruthy(source)
+    expect(source.state).toBe('failed')
+    expect(source.retryCount).toBe(0)
+
+    // The dead letter job carries the original data and the per-job output.
+    const [dlqJob] = await ctx.boss.fetch<{ key: string }>(deadLetter)
+    assertTruthy(dlqJob)
+    expect(dlqJob.data.key).toBe('payload')
+
+    const dlqWithMeta = await ctx.boss.getJobById(deadLetter, dlqJob.id)
+    assertTruthy(dlqWithMeta)
+    expect((dlqWithMeta.output as { message: string }).message).toBe('fatal, do not retry')
+  })
+
+  it('fails a deadletter result terminally when the queue has no DLQ configured', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const jobId = await ctx.boss.send(ctx.schema, { key: 'payload' }, { retryLimit: 5 })
+    assertTruthy(jobId)
+
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      jobs.map(job => ({ id: job.id, status: 'deadletter' as const, output: new Error('terminal') })))
+
+    await spy.waitForJobWithId(jobId, 'failed')
+
+    // Without a dead letter queue, deadletter is just a terminal failure that skips remaining retries.
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+    assertTruthy(job)
+    expect(job.state).toBe('failed')
+    expect(job.retryCount).toBe(0)
+    expect((job.output as { message: string }).message).toBe('terminal')
+  })
+
+  // The per-job complete/fail paths have a distributed variant (noMultiMutationCte) that splits the
+  // single multi-mutation CTE into a transaction of separate statements, because CockroachDB and
+  // friends reject the CTE. The standard coverage run is plain Postgres, so force that variant here
+  // with __test__distributed (the same toggle the DISTRIBUTED=true suite uses) to exercise it.
+  describe('distributed backend path (noMultiMutationCte)', function () {
+    it('settles a mixed batch of completions and failures with their own outputs', async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: true, __test__enableSpies: true })
+      const spy = ctx.boss.getSpy(ctx.schema)
+
+      const completeId = await ctx.boss.send(ctx.schema, { outcome: 'complete' }, { retryLimit: 0 })
+      const failId = await ctx.boss.send(ctx.schema, { outcome: 'fail' }, { retryLimit: 0 })
+      assertTruthy(completeId)
+      assertTruthy(failId)
+
+      await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+        jobs.map(job => (job.data as { outcome: string }).outcome === 'complete'
+          ? { id: job.id, status: 'completed' as const, output: { ok: true } }
+          : { id: job.id, status: 'failed' as const, output: new Error('handler said fail') }))
+
+      await spy.waitForJobWithId(completeId, 'completed')
+      await spy.waitForJobWithId(failId, 'failed')
+
+      const completed = await ctx.boss.getJobById(ctx.schema, completeId)
+      const failed = await ctx.boss.getJobById(ctx.schema, failId)
+
+      assertTruthy(completed)
+      expect(completed.state).toBe('completed')
+      expect((completed.output as { ok: boolean }).ok).toBe(true)
+
+      assertTruthy(failed)
+      expect(failed.state).toBe('failed')
+      expect((failed.output as { message: string }).message).toBe('handler said fail')
+    })
+
+    it('unblocks a dependent child when the blocking parent is completed', async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: true, __test__enableSpies: true })
+      const spy = ctx.boss.getSpy(ctx.schema)
+
+      const flow = await ctx.boss.flow([
+        { ref: 'parent', name: ctx.schema, data: { role: 'parent' } },
+        { ref: 'child', name: ctx.schema, data: { role: 'child' }, dependsOn: ['parent'] }
+      ])
+      const parentId = flow.parent
+      const childId = flow.child
+
+      const parentBefore = await ctx.boss.getJobById(ctx.schema, parentId)
+      assertTruthy(parentBefore)
+      expect(parentBefore.blocking).toBe(true)
+
+      // Completing the parent through the distributed path must run the separate decrementDependents
+      // statement so the child becomes fetchable.
+      await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+        jobs.map(job => ({ id: job.id, status: 'completed' as const, output: { role: (job.data as { role: string }).role } })))
+
+      await spy.waitForJobWithId(parentId, 'completed')
+      await spy.waitForJobWithId(childId, 'completed')
+
+      const child = await ctx.boss.getJobById(ctx.schema, childId)
+      assertTruthy(child)
+      expect(child.blocked).toBe(false)
+      expect(child.pendingDependencies).toBe(0)
+      expect(child.state).toBe('completed')
+    })
+
+    it('routes a per-job failure to the dead letter queue with its own output', async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: true, noDefault: true, __test__enableSpies: true })
+      const spy = ctx.boss.getSpy(ctx.schema)
+
+      const deadLetter = `${ctx.schema}_dlq`
+      await ctx.boss.createQueue(deadLetter)
+      await ctx.boss.createQueue(ctx.schema, { deadLetter })
+
+      const jobId = await ctx.boss.send(ctx.schema, { key: 'payload' }, { retryLimit: 0 })
+      assertTruthy(jobId)
+
+      await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+        jobs.map(job => ({ id: job.id, status: 'failed' as const, output: new Error('dlq please') })))
+
+      await spy.waitForJobWithId(jobId, 'failed')
+
+      // reinsertFailedJobs runs through the distributed split here, carrying the per-id output.
+      const [dlqJob] = await ctx.boss.fetch<{ key: string }>(deadLetter)
+      assertTruthy(dlqJob)
+      expect(dlqJob.data.key).toBe('payload')
+
+      const dlqWithMeta = await ctx.boss.getJobById(deadLetter, dlqJob.id)
+      assertTruthy(dlqWithMeta)
+      expect((dlqWithMeta.output as { message: string }).message).toBe('dlq please')
+    })
+
+    it('routes a deadletter result straight to the DLQ, bypassing remaining retries', async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: true, noDefault: true, __test__enableSpies: true })
+      const spy = ctx.boss.getSpy(ctx.schema)
+
+      const deadLetter = `${ctx.schema}_dlq`
+      await ctx.boss.createQueue(deadLetter)
+      await ctx.boss.createQueue(ctx.schema, { deadLetter })
+
+      const jobId = await ctx.boss.send(ctx.schema, { key: 'payload' }, { retryLimit: 2 })
+      assertTruthy(jobId)
+
+      // reinsertFailedJobs must force the terminal failure (canRetry = false) so the job dead-letters
+      // on its first attempt rather than re-inserting as a retry.
+      await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+        jobs.map(job => ({ id: job.id, status: 'deadletter' as const, output: new Error('fatal, do not retry') })))
+
+      await spy.waitForJobWithId(jobId, 'failed')
+
+      const source = await ctx.boss.getJobById(ctx.schema, jobId)
+      assertTruthy(source)
+      expect(source.state).toBe('failed')
+      expect(source.retryCount).toBe(0)
+
+      const [dlqJob] = await ctx.boss.fetch<{ key: string }>(deadLetter)
+      assertTruthy(dlqJob)
+      expect(dlqJob.data.key).toBe('payload')
+
+      const dlqWithMeta = await ctx.boss.getJobById(deadLetter, dlqJob.id)
+      assertTruthy(dlqWithMeta)
+      expect((dlqWithMeta.output as { message: string }).message).toBe('fatal, do not retry')
+    })
+
+    it('no-ops the per-job fail when the job already left the active state', async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: true, __test__enableSpies: true })
+      const spy = ctx.boss.getSpy(ctx.schema)
+
+      const jobId = await ctx.boss.send(ctx.schema, { key: 'payload' }, { retryLimit: 0 })
+      assertTruthy(jobId)
+
+      // Settle the job out of band before returning a failed disposition for it. By the time the
+      // distributed per-job fail runs, selectJobsToFailById finds no active row, so it short-circuits
+      // (jobs.length === 0) instead of re-inserting - modelling a job that vanished mid-batch.
+      await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs => {
+        await ctx.boss.complete(ctx.schema, jobs[0]!.id)
+        return jobs.map(job => ({ id: job.id, status: 'failed' as const, output: new Error('too late') }))
+      })
+
+      // The settle records the (attempted) failure on the spy after the no-op fail runs, so this
+      // resolving guarantees the guard executed.
+      await spy.waitForJobWithId(jobId, 'failed')
+
+      // The out-of-band completion stands; the per-job fail did nothing.
+      const job = await ctx.boss.getJobById(ctx.schema, jobId)
+      assertTruthy(job)
+      expect(job.state).toBe('completed')
+    })
+  })
 })

--- a/test/perJobResultsTest.ts
+++ b/test/perJobResultsTest.ts
@@ -41,6 +41,41 @@ describe('perJobResults', function () {
     expect((failed.output as { message: string }).message).toBe('handler said fail')
   })
 
+  it('settles a large batch of distinct per-job outputs', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const size = 25
+    const ids: string[] = []
+    for (let i = 0; i < size; i++) {
+      const id = await ctx.boss.send(ctx.schema, { n: i }, { retryLimit: 0 })
+      assertTruthy(id)
+      ids.push(id)
+    }
+
+    // Even indices complete with a distinct output, odd indices fail with a distinct output.
+    await ctx.boss.work(ctx.schema, { batchSize: size, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      jobs.map(job => {
+        const n = (job.data as { n: number }).n
+        return n % 2 === 0
+          ? { id: job.id, status: 'completed' as const, output: { n } }
+          : { id: job.id, status: 'failed' as const, output: new Error(`failed ${n}`) }
+      }))
+
+    for (let i = 0; i < size; i++) {
+      await spy.waitForJobWithId(ids[i]!, i % 2 === 0 ? 'completed' : 'failed')
+      const job = await ctx.boss.getJobById(ctx.schema, ids[i]!)
+      assertTruthy(job)
+      if (i % 2 === 0) {
+        expect(job.state).toBe('completed')
+        expect((job.output as { n: number }).n).toBe(i)
+      } else {
+        expect(job.state).toBe('failed')
+        expect((job.output as { message: string }).message).toBe(`failed ${i}`)
+      }
+    }
+  })
+
   it('fails (and retries) jobs the handler omits from its results', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
     const spy = ctx.boss.getSpy(ctx.schema)

--- a/test/perJobResultsTest.ts
+++ b/test/perJobResultsTest.ts
@@ -446,4 +446,72 @@ describe('perJobResults', function () {
       expect(job.state).toBe('completed')
     })
   })
+
+  // Mirror of the distributed block above. The standard (multi-mutation CTE) per-job settlement paths
+  // - completeJobsWithOutputs / failJobsByIdWithOutputs / deadLetterJobsByIdWithOutputs - only run when
+  // noMultiMutationCte is off. The DISTRIBUTED=true coverage suite forces it on globally, so without
+  // pinning it off here those CTE plans show as uncovered in that run. Force the standard path with
+  // __test__distributed: false so it is exercised in both the standard and distributed coverage suites.
+  describe('standard backend path (multiMutationCte)', function () {
+    it('settles a mixed batch of completions and failures with their own outputs', async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: false, __test__enableSpies: true })
+      const spy = ctx.boss.getSpy(ctx.schema)
+
+      const completeId = await ctx.boss.send(ctx.schema, { outcome: 'complete' }, { retryLimit: 0 })
+      const failId = await ctx.boss.send(ctx.schema, { outcome: 'fail' }, { retryLimit: 0 })
+      assertTruthy(completeId)
+      assertTruthy(failId)
+
+      await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+        jobs.map(job => (job.data as { outcome: string }).outcome === 'complete'
+          ? { id: job.id, status: 'completed' as const, output: { ok: true } }
+          : { id: job.id, status: 'failed' as const, output: new Error('handler said fail') }))
+
+      await spy.waitForJobWithId(completeId, 'completed')
+      await spy.waitForJobWithId(failId, 'failed')
+
+      const completed = await ctx.boss.getJobById(ctx.schema, completeId)
+      const failed = await ctx.boss.getJobById(ctx.schema, failId)
+
+      assertTruthy(completed)
+      expect(completed.state).toBe('completed')
+      expect((completed.output as { ok: boolean }).ok).toBe(true)
+
+      assertTruthy(failed)
+      expect(failed.state).toBe('failed')
+      expect((failed.output as { message: string }).message).toBe('handler said fail')
+    })
+
+    it('routes a deadletter result straight to the DLQ, bypassing remaining retries', async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: false, noDefault: true, __test__enableSpies: true })
+      const spy = ctx.boss.getSpy(ctx.schema)
+
+      const deadLetter = `${ctx.schema}_dlq`
+      await ctx.boss.createQueue(deadLetter)
+      await ctx.boss.createQueue(ctx.schema, { deadLetter })
+
+      const jobId = await ctx.boss.send(ctx.schema, { key: 'payload' }, { retryLimit: 2 })
+      assertTruthy(jobId)
+
+      // deadLetterJobsByIdWithOutputs must force the terminal failure so the job dead-letters on its
+      // first attempt rather than re-inserting as a retry, carrying its own per-job output.
+      await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+        jobs.map(job => ({ id: job.id, status: 'deadletter' as const, output: new Error('fatal, do not retry') })))
+
+      await spy.waitForJobWithId(jobId, 'failed')
+
+      const source = await ctx.boss.getJobById(ctx.schema, jobId)
+      assertTruthy(source)
+      expect(source.state).toBe('failed')
+      expect(source.retryCount).toBe(0)
+
+      const [dlqJob] = await ctx.boss.fetch<{ key: string }>(deadLetter)
+      assertTruthy(dlqJob)
+      expect(dlqJob.data.key).toBe('payload')
+
+      const dlqWithMeta = await ctx.boss.getJobById(deadLetter, dlqJob.id)
+      assertTruthy(dlqWithMeta)
+      expect((dlqWithMeta.output as { message: string }).message).toBe('fatal, do not retry')
+    })
+  })
 })

--- a/test/perJobResultsTest.ts
+++ b/test/perJobResultsTest.ts
@@ -1,0 +1,110 @@
+import { expect } from 'vitest'
+import * as helper from './testHelper.ts'
+import { assertTruthy } from './testHelper.ts'
+import { ctx } from './hooks.ts'
+
+describe('perJobResults', function () {
+  it('validates perJobResults must be a boolean', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+    await expect(async () => {
+      // @ts-expect-error invalid option type
+      await ctx.boss.work(ctx.schema, { perJobResults: 'yes' }, async () => [])
+    }).rejects.toThrow('perJobResults must be a boolean')
+  })
+
+  it('settles each job in a batch individually with its own output', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const completeId = await ctx.boss.send(ctx.schema, { outcome: 'complete' }, { retryLimit: 0 })
+    const failId = await ctx.boss.send(ctx.schema, { outcome: 'fail' }, { retryLimit: 0 })
+    assertTruthy(completeId)
+    assertTruthy(failId)
+
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      jobs.map(job => (job.data as { outcome: string }).outcome === 'complete'
+        ? { id: job.id, status: 'completed', output: { ok: true } }
+        : { id: job.id, status: 'failed', output: new Error('handler said fail') }))
+
+    await spy.waitForJobWithId(completeId, 'completed')
+    await spy.waitForJobWithId(failId, 'failed')
+
+    const completed = await ctx.boss.getJobById(ctx.schema, completeId)
+    const failed = await ctx.boss.getJobById(ctx.schema, failId)
+
+    assertTruthy(completed)
+    expect(completed.state).toBe('completed')
+    expect((completed.output as { ok: boolean }).ok).toBe(true)
+
+    assertTruthy(failed)
+    expect(failed.state).toBe('failed')
+    expect((failed.output as { message: string }).message).toBe('handler said fail')
+  })
+
+  it('fails (and retries) jobs the handler omits from its results', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const keptId = await ctx.boss.send(ctx.schema, { outcome: 'complete' }, { retryLimit: 0 })
+    const omittedId = await ctx.boss.send(ctx.schema, { outcome: 'omit' }, { retryLimit: 0 })
+    assertTruthy(keptId)
+    assertTruthy(omittedId)
+
+    // Handler only reports the kept job; the omitted one is left out of the results entirely.
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      jobs
+        .filter(job => (job.data as { outcome: string }).outcome !== 'omit')
+        .map(job => ({ id: job.id, status: 'completed' as const })))
+
+    await spy.waitForJobWithId(keptId, 'completed')
+    await spy.waitForJobWithId(omittedId, 'failed')
+
+    const kept = await ctx.boss.getJobById(ctx.schema, keptId)
+    const omitted = await ctx.boss.getJobById(ctx.schema, omittedId)
+
+    assertTruthy(kept)
+    expect(kept.state).toBe('completed')
+
+    assertTruthy(omitted)
+    expect(omitted.state).toBe('failed')
+    expect((omitted.output as { message: string }).message).toBe('no disposition returned by handler')
+  })
+
+  it('fails the whole batch when the handler does not resolve with an array', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const jobId = await ctx.boss.send(ctx.schema, { outcome: 'complete' }, { retryLimit: 0 })
+    assertTruthy(jobId)
+
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 },
+      // @ts-expect-error deliberately violating the contract
+      async () => ({ not: 'an array' }))
+
+    await spy.waitForJobWithId(jobId, 'failed')
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+    assertTruthy(job)
+    expect(job.state).toBe('failed')
+    expect((job.output as { message: string }).message).toContain('must resolve with an array')
+  })
+
+  it('still fails the whole batch when the handler throws', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const jobId = await ctx.boss.send(ctx.schema, { outcome: 'complete' }, { retryLimit: 0 })
+    assertTruthy(jobId)
+
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async () => {
+      throw new Error('boom')
+    })
+
+    await spy.waitForJobWithId(jobId, 'failed')
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+    assertTruthy(job)
+    expect(job.state).toBe('failed')
+    expect((job.output as { message: string }).message).toBe('boom')
+  })
+})

--- a/test/perJobResultsTest.ts
+++ b/test/perJobResultsTest.ts
@@ -76,7 +76,7 @@ describe('perJobResults', function () {
     }
   })
 
-  it('fails (and retries) jobs the handler omits from its results', async function () {
+  it('fails jobs the handler omits from its results', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
     const spy = ctx.boss.getSpy(ctx.schema)
 
@@ -141,5 +141,108 @@ describe('perJobResults', function () {
     assertTruthy(job)
     expect(job.state).toBe('failed')
     expect((job.output as { message: string }).message).toBe('boom')
+  })
+
+  it('retries a per-job failure and can settle it on a later attempt', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const jobId = await ctx.boss.send(ctx.schema, { outcome: 'flaky' }, { retryLimit: 1, retryDelay: 0 })
+    assertTruthy(jobId)
+
+    // Fail the job on its first processing, complete it on the retry. This exercises the
+    // fail -> reinsert-as-retry -> re-fetch -> settle path that retryLimit: 0 tests never reach.
+    let attempts = 0
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      jobs.map(job => {
+        attempts++
+        return attempts === 1
+          ? { id: job.id, status: 'failed' as const, output: new Error('transient') }
+          : { id: job.id, status: 'completed' as const, output: { ok: true } }
+      }))
+
+    await spy.waitForJobWithId(jobId, 'failed')
+    await spy.waitForJobWithId(jobId, 'completed')
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+    assertTruthy(job)
+    expect(job.state).toBe('completed')
+    expect(job.retryCount).toBe(1)
+    expect((job.output as { ok: boolean }).ok).toBe(true)
+  })
+
+  it('routes a per-job failure to the dead letter queue with its own output', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const deadLetter = `${ctx.schema}_dlq`
+    await ctx.boss.createQueue(deadLetter)
+    await ctx.boss.createQueue(ctx.schema, { deadLetter })
+
+    const jobId = await ctx.boss.send(ctx.schema, { key: 'payload' }, { retryLimit: 0 })
+    assertTruthy(jobId)
+
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      jobs.map(job => ({ id: job.id, status: 'failed' as const, output: new Error('dlq please') })))
+
+    await spy.waitForJobWithId(jobId, 'failed')
+
+    // The dead letter job carries the original data and the per-job failure output.
+    const [dlqJob] = await ctx.boss.fetch<{ key: string }>(deadLetter)
+    assertTruthy(dlqJob)
+    expect(dlqJob.data.key).toBe('payload')
+
+    const dlqWithMeta = await ctx.boss.getJobById(deadLetter, dlqJob.id)
+    assertTruthy(dlqWithMeta)
+    expect((dlqWithMeta.output as { message: string }).message).toBe('dlq please')
+  })
+
+  it('unblocks a dependent child when the blocking parent is completed via perJobResults', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const flow = await ctx.boss.flow([
+      { ref: 'parent', name: ctx.schema, data: { role: 'parent' } },
+      { ref: 'child', name: ctx.schema, data: { role: 'child' }, dependsOn: ['parent'] }
+    ])
+    const parentId = flow.parent
+    const childId = flow.child
+
+    const parentBefore = await ctx.boss.getJobById(ctx.schema, parentId)
+    assertTruthy(parentBefore)
+    expect(parentBefore.blocking).toBe(true)
+
+    // The worker only ever fetches the parent until it completes; completing it through the
+    // perJobResults path must run the dependency-unblock CTE so the child becomes fetchable.
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      jobs.map(job => ({ id: job.id, status: 'completed' as const, output: { role: (job.data as { role: string }).role } })))
+
+    await spy.waitForJobWithId(parentId, 'completed')
+    await spy.waitForJobWithId(childId, 'completed')
+
+    const child = await ctx.boss.getJobById(ctx.schema, childId)
+    assertTruthy(child)
+    expect(child.blocked).toBe(false)
+    expect(child.pendingDependencies).toBe(0)
+    expect(child.state).toBe('completed')
+  })
+
+  it('fails a job whose result carries an unrecognized status', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
+    const spy = ctx.boss.getSpy(ctx.schema)
+
+    const jobId = await ctx.boss.send(ctx.schema, { outcome: 'complete' }, { retryLimit: 0 })
+    assertTruthy(jobId)
+
+    await ctx.boss.work(ctx.schema, { batchSize: 10, perJobResults: true, pollingIntervalSeconds: 0.5 }, async jobs =>
+      // @ts-expect-error 'skipped' is not a valid JobResultStatus
+      jobs.map(job => ({ id: job.id, status: 'skipped', output: { ignored: true } })))
+
+    await spy.waitForJobWithId(jobId, 'failed')
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+    assertTruthy(job)
+    expect(job.state).toBe('failed')
+    expect((job.output as { message: string }).message).toBe('no disposition returned by handler')
   })
 })

--- a/test/workTest.ts
+++ b/test/workTest.ts
@@ -55,7 +55,13 @@ describe('work', function () {
 
     await delay(timeout)
 
-    expect(processCount).toBe(timeout / 1000 / pollingIntervalSeconds)
+    // The worker fetches immediately, then waits `interval` between polls, so over the timeout
+    // window it runs roughly `timeout / interval` times. The exact count races with the window
+    // boundary (a poll firing right at `timeout` may or may not start before the delay resolves),
+    // so allow ±1 to absorb scheduling jitter instead of asserting an exact count.
+    const expectedPolls = timeout / 1000 / pollingIntervalSeconds
+    expect(processCount).toBeGreaterThanOrEqual(expectedPolls - 1)
+    expect(processCount).toBeLessThanOrEqual(expectedPolls + 1)
   })
 
   it('should provide abort signal to job handler', async function () {


### PR DESCRIPTION
# Description

## Summary

Adds an opt-in way for a batch `work()` handler to settle each job in the batch **individually** — completing some and failing others, each with its own `output` — instead of the current all-or-nothing behavior.

Enable it with the new `perJobResults: true` work option and resolve the handler with an array of `JobResult` objects:

```js
await boss.work('resize-image', { batchSize: 10, perJobResults: true }, async (jobs) => {
  return jobs.map(job => {
    try {
      return { id: job.id, status: 'completed', output: resize(job.data) }
    } catch (err) {
      return { id: job.id, status: 'failed', output: err }
    }
  })
})
```

## Motivation

When `batchSize > 1`, a `work()` handler is all-or-nothing (`manager.ts`):

- resolve → every job in the batch is completed, and the return value is only stored as `output` when `batchSize === 1` (for larger batches per-job output is discarded);
- throw → every job in the batch fails, so a single poison job forces the whole batch to retry.

Consumers that process heterogeneous batches currently have to work around this by calling `boss.complete()` / `boss.fail()` manually inside the handler and relying on the fact that the post-handler auto-complete only matches `state = 'active'`. That is undocumented, fights the framework's own settlement, and still can't store a per-job success output. This PR makes per-job settlement a first-class, typed feature.

## What changed

### Public API

- New `WorkOptions.perJobResults?: boolean` (default `false`).
- New exported types: `JobResult`, `JobResultStatus`, `PerJobWorkHandler`, `PerJobWorkWithMetadataHandler`.
- New typed `work()` overloads: when `perJobResults: true` is set, the handler must resolve with `JobResult[]` (`{ id, status: 'completed' | 'failed', output? }[]`). This mirrors how `includeMetadata: true` already switches the handler type, so the contract is enforced by the compiler and unambiguous at runtime.

### Behavior

- Each job is settled individually, **preserving its own output** (fixes the per-job-output loss for batches `> 1`).
- A `deadletter` disposition fails the job **terminally and routes it straight to the queue's configured dead letter queue**, bypassing any remaining retries (the per-job `output` travels to the dead letter job). If the queue has no dead letter queue configured, it degrades to a plain terminal failure — equivalent to a `failed` job that has exhausted its retries. This gives handlers a first-class way to send a poison job to the DLQ immediately instead of waiting out its retry budget.
- A job the handler **omits** from the result array is failed with a descriptive error (`"no disposition returned by handler"`) so it retries / dead-letters per the queue config — a result is never assumed.
- **Throwing** from the handler still fails the entire batch, exactly as before. The returned array expresses per-job failures; throwing is reserved for batch-wide errors.
- Resolving with a non-array is treated as a contract violation and fails the whole batch with a clear error.
- Default (non-`perJobResults`) behavior is **unchanged**.

### Implementation

- Per-job settlement runs in a **constant number of statements** regardless of batch size, so it scales to large batches:
  - **New, separate SQL** `completeJobsWithOutputs` and `failJobsByIdWithOutputs` apply per-id outputs via a `json_to_recordset($2::json)` join (the same binding pattern as bulk `insert`). Existing `completeJobs` / `failJobs` are left intact.
  - The shared `failJobs` CTE chain was extracted into a `failJobsBody` helper so the new fail SQL reuses it without duplication; the existing `failJobs` output is **byte-for-byte identical** after the refactor (verified).
- **Distributed backends (CockroachDB / `noMultiMutationCte`) are fully supported**: `completeJobsWithOutputsDistributed` plus the existing `decrementDependents` step, and the existing select → delete → reinsert path with per-id outputs threaded through `reinsertFailedJobs` (new optional, backward-compatible argument).

### Docs

- `docs/api/workers.md` documents the `perJobResults` option, the `JobResult[]` contract, per-job output, the omitted-job rule, and that throwing still fails the whole batch.

## Backward compatibility

Fully backward compatible. The feature is opt-in via `perJobResults`; existing handlers, the existing `complete` / `fail` SQL, and default batch semantics are unchanged.
