### PR TITLE
Allow connection timeout to be disabled

### DIFF
--- a/docs/api/constructor.md
+++ b/docs/api/constructor.md
@@ -36,6 +36,10 @@ The following options can be set as properties in an object for additional confi
 
 * **application_name** - string, defaults to "pgboss"
 
+* **connectionTimeoutMillis** - int, defaults to 10000
+
+  Number of milliseconds to wait before timing out when acquiring a new client from the pool. Set to `0` to disable the timeout and wait indefinitely.
+
 * **db** - object
 
     Passing an object named db allows you "bring your own database connection". This option may be beneficial if you'd like to use an existing database service with its own connection pool. Setting this option will bypass the above configuration.

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,7 +14,7 @@ class Db extends EventEmitter implements types.IDatabase, types.EventsMixin {
     super()
 
     config.application_name = config.application_name || 'pgboss'
-    config.connectionTimeoutMillis = config.connectionTimeoutMillis || 10000
+    config.connectionTimeoutMillis ??= 10000
     // config.maxUses = config.maxUses || 1000
 
     this.config = config


### PR DESCRIPTION
### Description
The connection timeout is currently normalized via `config.connectionTimeoutMillis || 10000`. As a result, passing a value of `0` to disable the timeout ([pg.Pool docs](https://node-postgres.com/apis/pool)) is not respected.

Using `??=` only sets the default when the value is missing, so `0` now passes straight through and disables the timeout.

### Code Changes
- Preserve `connectionTimeoutMillis` value of `0`
- Document `connectionTimeoutMillis`
