### PR TITLE
Fix `getQueues()` ignoring its names filter

### DIFF
--- a/docs/api/queues.md
+++ b/docs/api/queues.md
@@ -136,9 +136,9 @@ Updates options on an existing queue, with the exception of the `policy` and `pa
 
 Deletes a queue and all jobs.
 
-### `getQueues()`
+### `getQueues(names?)`
 
-Returns all queues
+Returns all queues, or only the named queues when an array of names is provided.
 
 ### `getQueue(name)`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,7 +352,7 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
   }
 
   getQueues (names?: string[]): Promise<types.QueueResult[]> {
-    return this.#manager.getQueues()
+    return this.#manager.getQueues(names)
   }
 
   getQueue (name: string): Promise<types.QueueResult | null> {

--- a/test/queueTest.ts
+++ b/test/queueTest.ts
@@ -189,6 +189,24 @@ describe('queues', function () {
     expect(queues.some(q => q.name === queue2)).toBeTruthy()
   })
 
+  it('getQueues(names) filters to the requested queues', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+    const queue1 = `${ctx.bossConfig.schema}_1`
+    const queue2 = `${ctx.bossConfig.schema}_2`
+    const queue3 = `${ctx.bossConfig.schema}_3`
+
+    await ctx.boss.createQueue(queue1)
+    await ctx.boss.createQueue(queue2)
+    await ctx.boss.createQueue(queue3)
+
+    const queues = await ctx.boss.getQueues([queue1, queue2])
+
+    expect(queues.length).toBe(2)
+    expect(queues.some(q => q.name === queue1)).toBeTruthy()
+    expect(queues.some(q => q.name === queue2)).toBeTruthy()
+    expect(queues.some(q => q.name === queue3)).toBeFalsy()
+  })
+
   it('should update queue properties', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
 


### PR DESCRIPTION
### Description:
`getQueues(names)` takes an optional list of queue names, but does not pass them through to `this.#manager.getQueues()`. The filter is silently ignored and every call returns all queues.

### Code Changes:
- Forward `names` to `manager.getQueues(names)`
- Add a test covering the filter
- Document the `names` parameter in the queues API docs