### PR TITLE
Allow all schedules to be queried

### DIFF
--- a/src/plans.ts
+++ b/src/plans.ts
@@ -825,6 +825,10 @@ export function getSchedules (schema: string) {
 }
 
 export function getSchedulesByQueue (schema: string) {
+  return `SELECT * FROM ${schema}.schedule WHERE name = $1 ORDER BY key`
+}
+
+export function getSchedulesByQueueAndKey (schema: string) {
   return `SELECT * FROM ${schema}.schedule WHERE name = $1 AND COALESCE(key, '') = $2`
 }
 

--- a/src/timekeeper.ts
+++ b/src/timekeeper.ts
@@ -202,13 +202,16 @@ class Timekeeper extends EventEmitter implements types.EventsMixin {
     await Promise.allSettled(jobs.map(({ data }) => this.manager.send(data)))
   }
 
-  async getSchedules (name?: string, key = '') : Promise<types.Schedule[]> {
+  async getSchedules (name?: string, key?: string): Promise<types.Schedule[]> {
     let sql = plans.getSchedules(this.config.schema)
     let params: unknown[] = []
 
-    if (name) {
-      sql = plans.getSchedulesByQueue(this.config.schema)
+    if (name && key !== undefined) {
+      sql = plans.getSchedulesByQueueAndKey(this.config.schema)
       params = [name, key]
+    } else if (name) {
+      sql = plans.getSchedulesByQueue(this.config.schema)
+      params = [name]
     }
 
     const { rows } = await this.db.executeSql(sql, params)

--- a/test/scheduleTest.ts
+++ b/test/scheduleTest.ts
@@ -389,4 +389,43 @@ describe('schedule', function () {
     expect(schedules.length).toBe(1)
     expect(schedules[0].cron).toBe('0 1 * * *')
   })
+
+  it('should get all schedules for a queue regardless of key when no key is given', async function () {
+    const config = {
+      ...ctx.bossConfig
+    }
+
+    ctx.boss = await helper.start(config)
+
+    const queue2 = ctx.bossConfig.schema + '2'
+
+    await ctx.boss.createQueue(queue2)
+
+    await ctx.boss.schedule(ctx.schema, '* * * * *', null, { key: 'a' })
+    await ctx.boss.schedule(ctx.schema, '0 1 * * *', null, { key: 'b' })
+    await ctx.boss.schedule(queue2, '0 2 * * *')
+
+    const schedules = await ctx.boss.getSchedules(ctx.schema)
+
+    expect(schedules.length).toBe(2)
+    expect(schedules.every(s => s.name === ctx.schema)).toBeTruthy()
+    expect(schedules.some(s => s.key === 'a')).toBeTruthy()
+    expect(schedules.some(s => s.key === 'b')).toBeTruthy()
+  })
+
+  it('should get only the default-key schedule when key is explicitly empty', async function () {
+    const config = {
+      ...ctx.bossConfig
+    }
+
+    ctx.boss = await helper.start(config)
+
+    await ctx.boss.schedule(ctx.schema, '* * * * *')
+    await ctx.boss.schedule(ctx.schema, '0 1 * * *', null, { key: 'a' })
+
+    const schedules = await ctx.boss.getSchedules(ctx.schema, '')
+
+    expect(schedules.length).toBe(1)
+    expect(schedules[0].cron).toBe('* * * * *')
+  })
 })


### PR DESCRIPTION
### Description:

`getSchedules(name)` only returns schedules with the default empty key, so any schedule created with a custom key is unqueryable without the key. Now a name-only call returns every schedule for that queue, regardless of key.

### Code Changes:

- Split the old `getSchedulesByQueue` query into two: `getSchedulesByQueue` and `getSchedulesByQueueAndKey`
- Updated `Timekeeper.getSchedules` to branch on whether a key was actually passed. `key` is now `undefined` by default instead of `''`.
- Added two tests
### Developer Notes:

This is a behavior change on a public method. Anyone relying on `getSchedules(name)` returning only the default-key schedule will now get all of them. The old runtime behavior already disagreed with the docs and the type signature, so this is bringing those into line rather than inventing new behavior.