### PR TITLE
Evict queue metadata cache on create, update, and delete

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -543,6 +543,10 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return queue
   }
 
+  #evictQueueCache (name: string) {
+    if (this.queues) delete this.queues[name]
+  }
+
   async stop () {
     this.stopped = true
 
@@ -1515,6 +1519,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
     const sql = plans.createQueue(this.config.schema, name, { ...options, policy }, this.config.noAdvisoryLocks)
     await this.db.executeSql(sql)
+    this.#evictQueueCache(name)
   }
 
   async getBlockedKeys (name: string): Promise<string[]> {
@@ -1579,6 +1584,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
     const sql = plans.updateQueue(this.config.schema, { deadLetter })
     await this.db.executeSql(sql, [name, options])
+    this.#evictQueueCache(name)
   }
 
   async getQueue (name: string) {
@@ -1594,6 +1600,7 @@ class Manager extends EventEmitter implements types.EventsMixin {
       await this.getQueueCache(name)
       const sql = plans.deleteQueue(this.config.schema, name, this.config.noAdvisoryLocks)
       await this.db.executeSql(sql)
+      this.#evictQueueCache(name)
     } catch { }
   }
 

--- a/test/queueTest.ts
+++ b/test/queueTest.ts
@@ -66,6 +66,26 @@ describe('queues', function () {
     await ctx.boss.createQueue(ctx.schema)
   })
 
+  helper.itPostgresOnly('should not use a stale cached table after delete and recreate with a different partition setting', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+    const queue = ctx.schema
+
+    await ctx.boss.createQueue(queue, { partition: true })
+    await ctx.boss.send(queue)
+
+    await ctx.boss.deleteQueue(queue)
+    await ctx.boss.createQueue(queue, { partition: false })
+
+    const jobId = await ctx.boss.send(queue)
+
+    assertTruthy(jobId)
+    const jobs = await ctx.boss.findJobs(queue, { id: jobId })
+    const job = jobs[0]
+    expect(job).toBeTruthy()
+    expect(job!.id).toBe(jobId)
+  })
+
   it('should delete an empty queue', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
 


### PR DESCRIPTION
### Description

The manager keeps an in-memory cache of per-queue metadata and only refreshes it in full on a timer. The `createQueue`, `updateQueue`, and `deleteQueue` functions did not evict the cached entry. After a queue is used, deleting it and recreating it with a different partition setting leaves the cached table name stale.

### Code Changes

- Add `#evictQueueCache(name`) and call it after the database write
  in `createQueue`, `updateQueue`, and `deleteQueue`.
- Create a Postgres-only regression test 

### Developer Notes
- `updateQueue` is included because it can change the cached notify flag.
