### PR TITLE
fix: scope warning thresholds to each instance

### DIFF
--- a/docs/api/constructor.md
+++ b/docs/api/constructor.md
@@ -107,6 +107,14 @@ The following configuration options should not normally need to be changed, but 
 
   How often the background flow resolver runs to unblock dependent jobs (created via [`flow()`](./jobs.md#flowjobs-options)) whose parents have completed. Completing a job no longer unblocks its dependents inline; this resolver handles it shortly after, off the completion hot path. Only runs when `supervise` is enabled.
 
+* **warningSlowQuerySeconds**, int, default 30
+
+  The threshold, in seconds, above which a monitoring or maintenance query emits a `slow_query` [`warning`](./events.md#warning) event. Applies per instance and must be at least 1.
+
+* **warningQueueSize**, int, default 10000
+
+  The default number of jobs in the created or retry state a queue may hold before emitting a `queue_backlog` [`warning`](./events.md#warning) event. Applies per instance and must be at least 1. Individual queues can override this with their own [`warningQueueSize`](./queues.md#createqueue-name-queue) on `createQueue`.
+
 * **persistWarnings**, bool, default false
 
   If set to true, warnings emitted during monitoring and maintenance (slow queries, queue backlogs, clock skew) will be persisted to the `warning` table in addition to being emitted as events. This enables historical tracking of warnings for debugging and monitoring purposes. See [Events](./events.md#warning) for more details on warning types.

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -10,6 +10,7 @@ const events = {
   warning: 'warning'
 }
 
+// Default thresholds and warning messages
 const WARNINGS = {
   SLOW_QUERY: { seconds: 30, message: 'Warning: slow query. Your queues and/or database server should be reviewed' },
   LARGE_QUEUE: { size: 10_000, message: 'Warning: large queue backlog. Your queue should be reviewed' }
@@ -28,6 +29,8 @@ class Boss extends EventEmitter implements types.EventsMixin {
   #db: types.IDatabase
   #config: types.ResolvedConstructorOptions
   #manager: Manager
+  #slowQuerySeconds: number
+  #largeQueueSize: number
 
   events = events
 
@@ -43,14 +46,8 @@ class Boss extends EventEmitter implements types.EventsMixin {
     this.#manager = manager
     this.#stopped = true
     this.#stopping = false
-
-    if (config.warningSlowQuerySeconds) {
-      WARNINGS.SLOW_QUERY.seconds = config.warningSlowQuerySeconds
-    }
-
-    if (config.warningQueueSize) {
-      WARNINGS.LARGE_QUEUE.size = config.warningQueueSize
-    }
+    this.#slowQuerySeconds = config.warningSlowQuerySeconds || WARNINGS.SLOW_QUERY.seconds
+    this.#largeQueueSize = config.warningQueueSize || WARNINGS.LARGE_QUEUE.size
   }
 
   get maintaining (): boolean {
@@ -102,7 +99,7 @@ class Boss extends EventEmitter implements types.EventsMixin {
     const elapsed = (Date.now() - started) / 1000
 
     if (
-      elapsed > WARNINGS.SLOW_QUERY.seconds ||
+      elapsed > this.#slowQuerySeconds ||
       this.#config.__test__warn_slow_query
     ) {
       await emitAndPersistWarning(this.#warningContext,
@@ -243,7 +240,7 @@ class Boss extends EventEmitter implements types.EventsMixin {
       // Coerce with Number(): CockroachDB returns these integer columns as strings, so a bare `>`
       // would compare lexicographically ("100" > "9" === false) and silently miss the backlog. On
       // standard Postgres these are already numbers, so Number() is a no-op.
-      const warnings = rowsCacheStats.filter(i => Number(i.queuedCount) > (Number(i.warningQueueSize) || WARNINGS.LARGE_QUEUE.size))
+      const warnings = rowsCacheStats.filter(i => Number(i.queuedCount) > (Number(i.warningQueueSize) || this.#largeQueueSize))
 
       for (const warning of warnings) {
         await emitAndPersistWarning(this.#warningContext,

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -29,8 +29,8 @@ class Boss extends EventEmitter implements types.EventsMixin {
   #db: types.IDatabase
   #config: types.ResolvedConstructorOptions
   #manager: Manager
-  #slowQuerySeconds: number
-  #largeQueueSize: number
+  readonly #slowQuerySeconds: number
+  readonly #largeQueueSize: number
 
   events = events
 

--- a/test/monitoringTest.ts
+++ b/test/monitoringTest.ts
@@ -108,7 +108,8 @@ describe('monitoring', function () {
   })
 
   it('should not leak warningQueueSize to other instances', async function () {
-   new PgBoss({ ...ctx.bossConfig, warningQueueSize: 1 })
+    // eslint-disable-next-line no-new
+    new PgBoss({ ...ctx.bossConfig, warningQueueSize: 1 })
 
     const boss = ctx.boss = await helper.start(ctx.bossConfig)
     await boss.send(ctx.schema)

--- a/test/monitoringTest.ts
+++ b/test/monitoringTest.ts
@@ -108,8 +108,7 @@ describe('monitoring', function () {
   })
 
   it('should not leak warningQueueSize to other instances', async function () {
-    const other = new PgBoss({ ...ctx.bossConfig, warningQueueSize: 1 })
-    expect(other).toBeTruthy()
+   new PgBoss({ ...ctx.bossConfig, warningQueueSize: 1 })
 
     const boss = ctx.boss = await helper.start(ctx.bossConfig)
     await boss.send(ctx.schema)

--- a/test/monitoringTest.ts
+++ b/test/monitoringTest.ts
@@ -2,6 +2,7 @@ import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
 import { delay } from '../src/tools.ts'
 import { ctx } from './hooks.ts'
+import { PgBoss } from '../src/index.ts'
 import * as plans from '../src/plans.ts'
 
 describe('monitoring', function () {
@@ -104,6 +105,22 @@ describe('monitoring', function () {
     await delay(1000)
 
     expect(eventCount > 0).toBeTruthy()
+  })
+
+  it('should not leak warningQueueSize to other instances', async function () {
+    const other = new PgBoss({ ...ctx.bossConfig, warningQueueSize: 1 })
+    expect(other).toBeTruthy()
+
+    const boss = ctx.boss = await helper.start(ctx.bossConfig)
+    await boss.send(ctx.schema)
+    await boss.send(ctx.schema)
+
+    let leaked = false
+    boss.on('warning', (event) => { if (event.message.includes('queue')) leaked = true })
+
+    await boss.supervise(ctx.schema)
+
+    expect(leaked).toBe(false)
   })
 
   it('large queue should emit warning via queue config', async function () {


### PR DESCRIPTION
### Description

Warning thresholds were stored on a module-level `WARNINGS` constant and mutated in the `Boss` constructor. Because the object is shared across every `PgBoss` instance in a process, constructing one instance with a custom `warningSlowQuerySeconds` or `warningQueueSize` changed the thresholds for all other instances.

This scopes the resolved thresholds to per-instance private fields so each `Boss` uses its own config and the module-level defaults stay immutable.

### Code Changes

- Add `#slowQuerySeconds` and `#largeQueueSize` private fields to `Boss`, resolved from config in the constructor with a fallback to the `WARNINGS` defaults.
- Stop mutating `WARNINGS.SLOW_QUERY.seconds` and `WARNINGS.LARGE_QUEUE.size` in the constructor.
- Read the instance fields in the slow-query and large-queue checks instead of the shared constant.
- Add a test asserting that constructing one instance with `warningQueueSize: 1` does not cause another instance to emit a queue warning.

### Developer Notes

The `WARNINGS` constant is now used only for default values and the warning message strings, so it is left as a shared module-level object.
