### PR TITLE
feat: delete-failed-jobs-flag

### DIFF
--- a/docs/api/constructor.md
+++ b/docs/api/constructor.md
@@ -67,6 +67,10 @@ The following options can be set as properties in an object for additional confi
 
   If this is set to false, flows, maintenance, and monitoring operations will be skipped on this instance. This is an advanced use case, and not something you would want to do under normal circumstances.
 
+* **deleteFailedJobs**, bool, default true
+
+  If this is set to false, the maintenance (retention) pass will never delete jobs in the `failed` state; they remain in the job table until removed manually via `deleteJob()`, `deleteStoredJobs()`, or `deleteAllJobs()`. Completed and cancelled jobs are still deleted per their `deleteAfterSeconds` setting.
+
 * **schedule**, bool, default true
 
   If this is set to false, this instance will not monitor or created scheduled jobs during. This is an advanced use case you may want to do for testing or if the clock of the server is skewed and you would like to disable the skew warnings.

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -421,6 +421,7 @@ function getConfig (value: string | types.ConstructorOptions): types.ResolvedCon
 
   config.schedule = ('schedule' in config) ? config.schedule : true
   config.supervise = ('supervise' in config) ? config.supervise : true
+  config.deleteFailedJobs = ('deleteFailedJobs' in config) ? config.deleteFailedJobs : true
   config.migrate = ('migrate' in config) ? config.migrate : true
   config.createSchema = ('createSchema' in config) ? config.createSchema : true
   config.useListenNotify = ('useListenNotify' in config) ? config.useListenNotify : false
@@ -574,6 +575,9 @@ function applyPollingInterval (config: any) {
 }
 
 function applyOpsConfig (config: any) {
+  assert(typeof config.deleteFailedJobs === 'boolean',
+    'configuration assert: deleteFailedJobs must be a boolean')
+
   assert(!('superviseIntervalSeconds' in config) || config.superviseIntervalSeconds >= 1,
     'configuration assert: superviseIntervalSeconds must be at least every second')
 

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -288,7 +288,7 @@ class Boss extends EventEmitter implements types.EventsMixin {
 
     if (rows.length) {
       const queues = rows.map((q) => q.name)
-      const sql = plans.deletion(this.#config.schema, table, queues, this.#config.noAdvisoryLocks)
+      const sql = plans.deletion(this.#config.schema, table, queues, this.#config.noAdvisoryLocks, this.#config.deleteFailedJobs)
       await this.#executeQuery(sql)
 
       const depSql = plans.cleanupDependencies(this.#config.schema, table, queues, this.#config.noAdvisoryLocks)

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -2222,13 +2222,14 @@ export function redriveJobs (schema: string, table: string): string {
   `
 }
 
-export function deletion (schema: string, table: string, queues: string[], noAdvisoryLocks?: boolean): string {
+export function deletion (schema: string, table: string, queues: string[], noAdvisoryLocks?: boolean, deleteFailedJobs: boolean = true): string {
+  const failedFilter = deleteFailedJobs ? '' : ` AND state < '${JOB_STATES.failed}'`
   const sql = `
     DELETE FROM ${schema}.${table}
     WHERE name = ANY(${serializeArrayParam(queues)})
       AND
       (
-        (deletion_seconds > 0 AND completed_on + deletion_seconds * interval '1s' < now())
+        (deletion_seconds > 0 AND completed_on + deletion_seconds * interval '1s' < now()${failedFilter})
         OR
         (state < '${JOB_STATES.active}' AND keep_until < now())
       )

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export interface MaintenanceOptions {
   warningQueueSize?: number;
   superviseIntervalSeconds?: number;
   maintenanceIntervalSeconds?: number;
+  deleteFailedJobs?: boolean;
   queueCacheIntervalSeconds?: number;
   monitorIntervalSeconds?: number;
   persistWarnings?: boolean;

--- a/test/configTest.ts
+++ b/test/configTest.ts
@@ -40,6 +40,10 @@ describe('config', function () {
     })
   })
 
+  it('rejects a non-boolean deleteFailedJobs', function () {
+    expect(() => Attorney.getConfig({ connectionString: 'postgres://localhost/db', deleteFailedJobs: 'nope' as any })).toThrow('deleteFailedJobs must be a boolean')
+  })
+
   it('should allow a 50 character custom schema name', async function () {
     const config = ctx.bossConfig
 

--- a/test/deleteTest.ts
+++ b/test/deleteTest.ts
@@ -100,6 +100,84 @@ describe('delete', function () {
     expect(job?.state).toBe('completed')
   })
 
+  it('should delete a failed job via maintenance by default', async function () {
+    const config = {
+      ...ctx.bossConfig,
+      maintenanceIntervalSeconds: 1
+    }
+
+    ctx.boss = await helper.start(config)
+
+    const jobId = await ctx.boss.send(ctx.schema, null, { deleteAfterSeconds: 1, retryLimit: 0 })
+
+    expect(jobId).toBeTruthy()
+
+    await ctx.boss.fetch(ctx.schema)
+    assertTruthy(jobId)
+    await ctx.boss.fail(ctx.schema, jobId)
+
+    await delay(1000)
+
+    await ctx.boss.supervise(ctx.schema)
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+
+    expect(job).toBeFalsy()
+  })
+
+  it('should not delete a failed job via maintenance when deleteFailedJobs is false', async function () {
+    const config = {
+      ...ctx.bossConfig,
+      maintenanceIntervalSeconds: 1,
+      deleteFailedJobs: false
+    }
+
+    ctx.boss = await helper.start(config)
+
+    const jobId = await ctx.boss.send(ctx.schema, null, { deleteAfterSeconds: 1, retryLimit: 0 })
+
+    expect(jobId).toBeTruthy()
+
+    await ctx.boss.fetch(ctx.schema)
+    assertTruthy(jobId)
+    await ctx.boss.fail(ctx.schema, jobId)
+
+    await delay(2000)
+
+    await ctx.boss.supervise(ctx.schema)
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+
+    expect(job).toBeTruthy()
+    expect(job?.state).toBe('failed')
+  })
+
+  it('should still delete a completed job via maintenance when deleteFailedJobs is false', async function () {
+    const config = {
+      ...ctx.bossConfig,
+      maintenanceIntervalSeconds: 1,
+      deleteFailedJobs: false
+    }
+
+    ctx.boss = await helper.start(config)
+
+    const jobId = await ctx.boss.send(ctx.schema, null, { deleteAfterSeconds: 1 })
+
+    expect(jobId).toBeTruthy()
+
+    await ctx.boss.fetch(ctx.schema)
+    assertTruthy(jobId)
+    await ctx.boss.complete(ctx.schema, jobId)
+
+    await delay(1000)
+
+    await ctx.boss.supervise(ctx.schema)
+
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+
+    expect(job).toBeFalsy()
+  })
+
   it('should never delete a completed job when deleteAfterSeconds is 0 - cascade config from queue', async function () {
     const config = {
       ...ctx.bossConfig,


### PR DESCRIPTION
Adds a new boolean configuration flag (e.g. deleteFailedJobs) that controls whether failed jobs are included in the supervisor's retention cleanup.

When the flag is true (default), behavior is unchanged — both completed and failed jobs are deleted per the retention policy.

When the flag is false, the supervisor only deletes completed jobs, and failed jobs are kept in the table for debugging, auditing, and manual reprocessing.