### PR TITLE
docs: clarify retryBackoff requires a non-zero retryDelay

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -36,11 +36,11 @@ Creates a new job and returns the job id.
 
 * **retryDelay**, int
 
-  Default: 0. Delay between retries of failed jobs, in seconds.
+  Default: 0. Delay between retries of failed jobs, in seconds. When `retryBackoff` is enabled, this is the base delay that the exponential backoff multiplies, so it must be non-zero for backoff to have any effect.
 
 * **retryBackoff**, bool
 
-  Default: false. Enables exponential backoff retries based on retryDelay instead of a fixed delay. Sets initial retryDelay to 1 if not set. A simplified function to get the delay between runs is: `retryDelay * 2 ^ retryCount` with some jitter. The full function to determine the backoff delay is `Math.min(retryDelayMax, retryDelay * (2 ** Math.Min(16, retryCount) / 2 + 2 ** Math.Min(16, retryCount) / 2 * Math.random()))`
+  Default: false. Enables exponential backoff retries based on `retryDelay` instead of a fixed delay. The backoff delay is a multiple of `retryDelay`, so `retryDelay` must be set to a non-zero value for backoff to take effect. With the default `retryDelay` of 0 the computed delay is always 0 and retries fire immediately. A simplified function to get the delay between runs is: `retryDelay * 2 ^ retryCount` with some jitter. The full function to determine the backoff delay is `Math.min(retryDelayMax, retryDelay * (2 ** Math.min(16, retryCount + 1) / 2 + 2 ** Math.min(16, retryCount + 1) / 2 * Math.random()))`
 
 * **retryDelayMax**, int
 

--- a/docs/api/queues.md
+++ b/docs/api/queues.md
@@ -77,11 +77,11 @@ Allowed policy values:
 
 * **retryDelay**, int
 
-  Default: 0. Delay between retries of failed jobs, in seconds.
+  Default: 0. Delay between retries of failed jobs, in seconds. When `retryBackoff` is enabled, this is the base delay that the exponential backoff multiplies, so it must be non-zero for backoff to have any effect.
 
 * **retryBackoff**, bool
 
-  Default: false. Enables exponential backoff retries based on retryDelay instead of a fixed delay. Sets initial retryDelay to 1 if not set. A simplified function to get the delay between runs is: `retryDelay * 2 ^ retryCount` with some jitter. The full function to determine the backoff delay is `Math.min(retryDelayMax, retryDelay * (2 ** Math.Min(16, retryCount) / 2 + 2 ** Math.Min(16, retryCount) / 2 * Math.random()))`
+  Default: false. Enables exponential backoff retries based on `retryDelay` instead of a fixed delay. The backoff delay is a multiple of `retryDelay`, so `retryDelay` must be set to a non-zero value for backoff to take effect. With the default `retryDelay` of 0 the computed delay is always 0 and retries fire immediately. A simplified function to get the delay between runs is: `retryDelay * 2 ^ retryCount` with some jitter. The full function to determine the backoff delay is `Math.min(retryDelayMax, retryDelay * (2 ** Math.min(16, retryCount + 1) / 2 + 2 ** Math.min(16, retryCount + 1) / 2 * Math.random()))`
 
 * **retryDelayMax**, int
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,20 +315,24 @@ export interface QueueOptions {
    */
   retryLimit?: number;
   /**
-   * Delay between retries of failed jobs, in seconds.
+   * Delay between retries of failed jobs, in seconds. When `retryBackoff` is
+   * enabled, this is the base delay that the exponential backoff multiplies, so
+   * it must be non-zero for backoff to have any effect.
    * @default 0
    */
   retryDelay?: number;
   /**
    * Enables exponential backoff retries based on `retryDelay` instead of a
-   * fixed delay. Sets initial `retryDelay` to 1 if not set.
+   * fixed delay. The backoff delay is a multiple of `retryDelay`, so `retryDelay`
+   * must be set to a non-zero value for backoff to take effect. With the default
+   * `retryDelay` of 0 the computed delay is always 0 and retries fire immediately.
    *
    * A simplified function to get the delay between runs is: `retryDelay * 2 ^ retryCount`
    * with some jitter.
    *
    * The function used to determine the backoff delay is:
    * ```js
-   * Math.min(retryDelayMax, retryDelay * (2 ** Math.Min(16, retryCount) / 2 + 2 Math.Min(16, retryCount) / 2 * Math.random()))
+   * Math.min(retryDelayMax, retryDelay * (2 ** Math.min(16, retryCount + 1) / 2 + 2 ** Math.min(16, retryCount + 1) / 2 * Math.random()))
    * ```
    * @default false
    */


### PR DESCRIPTION
## Description

Fixes #839.

With `retryBackoff` enabled and `retryDelay` left at its default,
every computed delay is `0 * 2^retryCount = 0`, so retries fire immediately
instead of backing off.

This updates the documentation to match actual behavior: `retryDelay` must be
set to a non-zero value for backoff to have any effect. It also corrects typos
in the backoff formula shown in the docs and JSDoc.

## Code Changes

- `docs/api/jobs.md`: removed the incorrect "Sets initial retryDelay to 1 if not
  set" claim, noted that `retryDelay` must be non-zero for backoff to take
  effect, and fixed the backoff formula (`Math.Min` to `Math.min`, added the
  missing `**` and the `retryCount + 1` used by the code).
- `docs/api/queues.md`: same changes as `jobs.md`.
- `src/types.ts`: updated the `retryDelay` and `retryBackoff` JSDoc to match, and
  corrected the same formula typos shown in editor tooltips.