### PR TITLE
Fix groupConcurrency fetch plan regression

### DIFF
--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1343,30 +1343,42 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
   const hasGroupConcurrency = groupConcurrency != null
   const hasMinPriority = minPriority != null
   const hasMaxPriority = maxPriority != null
+  const groupConcurrencyConfig = hasGroupConcurrency
+    ? (typeof groupConcurrency === 'number' ? { default: groupConcurrency } : groupConcurrency)
+    : null
   const hasTiers = hasGroupConcurrency &&
-    typeof groupConcurrency === 'object' &&
-    groupConcurrency.tiers &&
-    Object.keys(groupConcurrency.tiers).length > 0
+    groupConcurrencyConfig?.tiers &&
+    Object.keys(groupConcurrencyConfig.tiers).length > 0
+  const hasSingleGroupConcurrency = hasGroupConcurrency && !hasTiers && groupConcurrencyConfig?.default === 1
+  const hasActiveGroupCounts = hasGroupConcurrency && !hasSingleGroupConcurrency
 
   const params = buildFetchParams(options)
+  const groupLimit = hasTiers
+    ? `COALESCE((${params.tiersParam} ->> group_tier)::int, ${params.defaultGroupLimitParam})`
+    : params.defaultGroupLimitParam
+  const activeGroupCountExpression = hasActiveGroupCounts
+    ? 'COALESCE(((SELECT counts FROM active_group_count_map) ->> j.group_id)::int, 0)'
+    : ''
 
   const selectCols = [
     'j.id',
     singletonFetch ? 'j.singleton_key' : '',
-    hasGroupConcurrency ? 'j.group_id, j.group_tier' : ''
+    hasGroupConcurrency ? 'j.group_id, j.group_tier' : '',
+    hasActiveGroupCounts ? `${activeGroupCountExpression} as active_cnt` : ''
   ].filter(Boolean).join(', ')
 
-  // MATERIALIZED forces Postgres to compute this aggregation once and cache the
-  // result. Without it, Postgres 12+ may inline the CTE and re-evaluate the
-  // COUNT query at each reference site. active_group_counts is referenced twice:
-  // once in the next CTE join (to pre-filter saturated groups before LIMIT) and
-  // once in group_ranking (to enforce the per-batch concurrency limit).
-  const activeGroupCountsCte = hasGroupConcurrency
-    ? `active_group_counts AS MATERIALIZED (
-        SELECT group_id, COUNT(*)::int as active_cnt
-        FROM ${schema}.${table}
-        WHERE name = '${name}' AND state = '${JOB_STATES.active}' AND group_id IS NOT NULL
-        GROUP BY group_id
+  // For limits above 1, aggregate active counts into a single JSONB value. Each
+  // candidate uses a keyed lookup through an uncorrelated InitPlan, so the planner
+  // cannot turn stale active-group estimates into a per-candidate relation scan.
+  const activeGroupCountMapCte = hasActiveGroupCounts
+    ? `active_group_count_map AS MATERIALIZED (
+        SELECT COALESCE(jsonb_object_agg(group_id, active_cnt), '{}'::jsonb) as counts
+        FROM (
+          SELECT group_id, COUNT(*)::int as active_cnt
+          FROM ${schema}.${table}
+          WHERE name = '${name}' AND state = '${JOB_STATES.active}' AND group_id IS NOT NULL
+          GROUP BY group_id
+        ) active_groups
       ), `
     : ''
 
@@ -1375,8 +1387,22 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
   const lockClause = noSkipLocked ? '' : 'FOR UPDATE OF j SKIP LOCKED'
 
   // Column references are qualified with j. throughout so both the base case and
-  // the groupConcurrency branch (which joins active_group_counts) share one set of
-  // expressions. The join introduces agc.group_id which would otherwise be ambiguous.
+  // the groupConcurrency branches share one set of expressions.
+  const groupConcurrencyFilter = hasGroupConcurrency
+    ? hasSingleGroupConcurrency
+      ? `(j.group_id IS NULL
+            OR NOT EXISTS (
+              SELECT 1
+              FROM ${schema}.${table} active_group_probe
+              WHERE active_group_probe.name = '${name}'
+                AND active_group_probe.state = '${JOB_STATES.active}'
+                AND active_group_probe.group_id IS NOT NULL
+                AND active_group_probe.group_id = j.group_id
+            ))`
+      : `(j.group_id IS NULL
+            OR ${activeGroupCountExpression} < ${groupLimit})`
+    : ''
+
   const whereConditions = [
     `j.name = '${name}'`,
     `j.state < '${JOB_STATES.active}'`,
@@ -1391,20 +1417,13 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
     hasIgnoreGroups ? `(j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : '',
     hasMinPriority ? `j.priority >= ${params.minPriorityParam}` : '',
     hasMaxPriority ? `j.priority <= ${params.maxPriorityParam}` : '',
-    hasGroupConcurrency
-      ? `(j.group_id IS NULL
-            OR agc.active_cnt IS NULL
-            OR agc.active_cnt < ${hasTiers
-              ? `COALESCE((${params.tiersParam} ->> j.group_tier)::int, ${params.defaultGroupLimitParam})`
-              : params.defaultGroupLimitParam})`
-      : ''
+    groupConcurrencyFilter
   ].filter(Boolean).join('\n          AND ')
 
   const nextCte = `
       next AS (
         SELECT ${selectCols}
         FROM ${schema}.${table} j
-        ${hasGroupConcurrency ? 'LEFT JOIN active_group_counts agc ON j.group_id = agc.group_id' : ''}
         WHERE ${whereConditions}
         ORDER BY ${priority ? 'j.priority desc, ' : ''}${orderByCreatedOn ? 'j.created_on, ' : ''}j.id
         LIMIT ${limit}
@@ -1413,7 +1432,7 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
 
   const singletonCte = singletonFetch
     ? `, singleton_ranking AS (
-        SELECT id, ${hasGroupConcurrency ? 'group_id, group_tier, ' : ''}
+        SELECT id, ${hasGroupConcurrency ? 'group_id, group_tier, ' : ''}${hasActiveGroupCounts ? 'active_cnt, ' : ''}
           row_number() OVER (PARTITION BY singleton_key) as singleton_rn
         FROM next
       )`
@@ -1427,25 +1446,30 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
           , t.group_tier
           ${singletonFetch ? ', singleton_rn' : ''}
           , ROW_NUMBER() OVER (PARTITION BY t.group_id ORDER BY t.id) as group_rn
-          , COALESCE(agc.active_cnt, 0) as active_cnt
+          , ${hasActiveGroupCounts ? 't.active_cnt' : '0'} as active_cnt
         FROM ${singletonFetch ? 'singleton_ranking' : 'next'} t
-        LEFT JOIN active_group_counts agc ON t.group_id = agc.group_id
         ${singletonFetch ? 'WHERE singleton_rn = 1' : ''}
       ),
       group_filtered AS (
         SELECT id FROM group_ranking
         WHERE group_id IS NULL
-          OR (active_cnt + group_rn) <= ${hasTiers
-          ? `COALESCE((${params.tiersParam} ->> group_tier)::int, ${params.defaultGroupLimitParam})`
-          : params.defaultGroupLimitParam}
+          OR (active_cnt + group_rn) <= ${groupLimit}
       )`
     : ''
 
-  const finalCte = (hasGroupConcurrency)
+  const finalCte = hasGroupConcurrency
     ? 'group_filtered'
     : (singletonFetch)
         ? 'singleton_ranking'
         : 'next'
+
+  // An uncorrelated array InitPlan makes the selected ids a one-time input to the
+  // UPDATE. Without it, stale estimates can make Postgres put the inlined ranking
+  // query on the inner side of a nested loop and execute it once per job table row.
+  const updateSource = hasGroupConcurrency ? '' : `FROM ${finalCte}`
+  const updateMatch = hasGroupConcurrency
+    ? `j.id = ANY (ARRAY(SELECT id FROM ${finalCte}))`
+    : `j.id = ${finalCte}.id`
 
   // Without SKIP LOCKED, add a state check to prevent duplicate processing
   // when multiple workers try to claim the same jobs concurrently
@@ -1454,7 +1478,7 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
   return {
     text: `
       WITH
-      ${activeGroupCountsCte}
+      ${activeGroupCountMapCte}
       ${nextCte}
       ${singletonCte}
       ${groupConcurrencyCtes}
@@ -1463,8 +1487,8 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
         started_on = now(),
         heartbeat_on = now(),
         retry_count = CASE WHEN started_on IS NOT NULL THEN retry_count + 1 ELSE retry_count END
-      FROM ${finalCte}
-      WHERE name = '${name}' AND j.id = ${finalCte}.id
+      ${updateSource}
+      WHERE name = '${name}' AND ${updateMatch}
       ${singletonFetch && !hasGroupConcurrency ? 'AND singleton_rn = 1' : ''}
       ${distributedStateCheck}
       RETURNING j.${includeMetadata ? JOB_COLUMNS_ALL : JOB_COLUMNS_MIN}

--- a/test/concurrencyGroupTest.ts
+++ b/test/concurrencyGroupTest.ts
@@ -190,6 +190,71 @@ describe('groupConcurrency', function () {
     expect(maxByGroup[freeGroup]).toBeGreaterThanOrEqual(1)
   })
 
+  it('should preserve tiered batch capacity when groups are already active', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const schema = ctx.schema
+    const queueName = ctx.schema
+    const db = await helper.getDb()
+
+    try {
+      // vip-full is already at its tier limit, so its pending jobs must be skipped.
+      await db.executeSql(`
+        INSERT INTO ${schema}.job_common (name, data, state, group_id, group_tier, start_after, created_on, started_on)
+        SELECT $1, jsonb_build_object('group', 'vip-full'), 'active'::${schema}.job_state, 'vip-full', 'vip', now() - interval '5 minutes', now() - interval '5 minutes', now() - interval '5 minutes'
+        FROM generate_series(1, 3)
+      `, [queueName])
+
+      // vip has one active job and a tier limit of three, leaving two slots in this fetch batch.
+      await db.executeSql(`
+        INSERT INTO ${schema}.job_common (name, data, state, group_id, group_tier, start_after, created_on, started_on)
+        VALUES ($1, jsonb_build_object('group', 'vip'), 'active'::${schema}.job_state, 'vip', 'vip', now() - interval '5 minutes', now() - interval '5 minutes', now() - interval '5 minutes')
+      `, [queueName])
+
+      await db.executeSql(`
+        INSERT INTO ${schema}.job_common (name, data, state, group_id, group_tier, start_after, created_on)
+        SELECT $1, jsonb_build_object('group', 'vip-full'), 'created'::${schema}.job_state, 'vip-full', 'vip', now() - interval '5 minutes', now() - interval '4 minutes' + (g * interval '1 millisecond')
+        FROM generate_series(1, 3) g
+      `, [queueName])
+
+      await db.executeSql(`
+        INSERT INTO ${schema}.job_common (name, data, state, group_id, group_tier, start_after, created_on)
+        SELECT $1, jsonb_build_object('group', 'vip'), 'created'::${schema}.job_state, 'vip', 'vip', now() - interval '5 minutes', now() - interval '3 minutes' + (g * interval '1 millisecond')
+        FROM generate_series(1, 3) g
+      `, [queueName])
+
+      await db.executeSql(`
+        INSERT INTO ${schema}.job_common (name, data, state, group_id, start_after, created_on)
+        SELECT $1, jsonb_build_object('group', 'default'), 'created'::${schema}.job_state, 'default', now() - interval '5 minutes', now() - interval '2 minutes' + (g * interval '1 millisecond')
+        FROM generate_series(1, 2) g
+      `, [queueName])
+
+      const jobs = await ctx.boss.fetch(queueName, {
+        batchSize: 10,
+        includeMetadata: true,
+        priority: false,
+        orderByCreatedOn: true,
+        groupConcurrency: {
+          default: 1,
+          tiers: { vip: 3 }
+        }
+      })
+
+      const groupCounts = jobs.reduce<Record<string, number>>((counts, job) => {
+        const group = (job.data as { group: string }).group
+        counts[group] = (counts[group] ?? 0) + 1
+        return counts
+      }, {})
+
+      expect(jobs).toHaveLength(3)
+      expect(groupCounts['vip-full'] ?? 0).toBe(0)
+      expect(groupCounts.vip).toBe(2)
+      expect(groupCounts.default).toBe(1)
+    } finally {
+      await db.close()
+    }
+  })
+
   it('should allow jobs without group to bypass group concurrency limits', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__enableSpies: true })
 

--- a/test/groupConcurrencyPlanReproTest.ts
+++ b/test/groupConcurrencyPlanReproTest.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest'
+import * as helper from './testHelper.ts'
+import { ctx } from './hooks.ts'
+import * as plans from '../src/plans.ts'
+
+const describeRepro = describe.skipIf(
+  helper.isCockroachDb ||
+  helper.isYugabyteDb ||
+  helper.isCitus ||
+  helper.isPglite ||
+  helper.isDistributed
+)
+
+interface PlanNode {
+  'Node Type': string
+  'CTE Name'?: string
+  'Actual Rows'?: number
+  'Actual Loops'?: number
+  'Index Name'?: string
+  'Plan Rows'?: number
+  'Relation Name'?: string
+  'Subplan Name'?: string
+  Plans?: PlanNode[]
+}
+
+interface ExplainedPlan {
+  plan: PlanNode
+  nodes: PlanNode[]
+}
+
+const saturatedGroup = 'group-saturated'
+const activeGroupCount = 115
+const saturatedPendingCount = 12_000
+const minimumAvailablePendingCount = 36
+
+function collectPlanNodes (node: PlanNode, nodes: PlanNode[] = []): PlanNode[] {
+  nodes.push(node)
+
+  for (const child of node.Plans ?? []) {
+    collectPlanNodes(child, nodes)
+  }
+
+  return nodes
+}
+
+function extractPlan (rows: any[]): PlanNode {
+  const rawPlan = rows[0]['QUERY PLAN']
+  const parsed = typeof rawPlan === 'string' ? JSON.parse(rawPlan) : rawPlan
+  return parsed[0].Plan
+}
+
+function planSummary (nodes: PlanNode[]): string {
+  return nodes
+    .filter(node =>
+      node['Node Type'] === 'Aggregate' ||
+      node['Node Type'] === 'CTE Scan' ||
+      node['Node Type'] === 'Hash Join' ||
+      node['Node Type'] === 'Index Only Scan' ||
+      node['Node Type'] === 'Index Scan' ||
+      node['Node Type'] === 'Nested Loop' ||
+      node['Node Type'] === 'Subquery Scan' ||
+      node['Node Type'] === 'WindowAgg'
+    )
+    .map(node => {
+      const type = node['Node Type']
+      const planRows = node['Plan Rows'] ?? '?'
+      const actualRows = node['Actual Rows'] ?? '?'
+      const actualLoops = node['Actual Loops'] ?? '?'
+      const subplan = node['Subplan Name'] ? `, subplan=${node['Subplan Name']}` : ''
+      const cte = node['CTE Name'] ? `, cte=${node['CTE Name']}` : ''
+      const index = node['Index Name'] ? `, index=${node['Index Name']}` : ''
+      return `${type}${subplan}${cte}${index}: planRows=${planRows}, actualRows=${actualRows}, actualLoops=${actualLoops}`
+    })
+    .join('\n')
+}
+
+function findRepeatedActiveGroupScan (nodes: PlanNode[]): PlanNode | undefined {
+  return nodes.find(node =>
+    node['Node Type'] === 'CTE Scan' &&
+    node['CTE Name']?.startsWith('active_group_') === true &&
+    (node['Actual Loops'] ?? 0) > 1
+  )
+}
+
+function expectNoRepeatedActiveGroupScan (nodes: PlanNode[]): void {
+  expect(findRepeatedActiveGroupScan(nodes), planSummary(nodes)).toBeUndefined()
+}
+
+function findRepeatedGroupRanking (nodes: PlanNode[]): PlanNode | undefined {
+  return nodes.find(node =>
+    node['Node Type'] === 'WindowAgg' &&
+    (node['Actual Loops'] ?? 0) > 1
+  )
+}
+
+function expectNoRepeatedGroupRanking (nodes: PlanNode[]): void {
+  expect(findRepeatedGroupRanking(nodes), planSummary(nodes)).toBeUndefined()
+}
+
+function findRepeatedJobTableScan (nodes: PlanNode[]): PlanNode | undefined {
+  return nodes.find(node =>
+    node['Relation Name'] === 'job_common' &&
+    (
+      node['Node Type'] === 'Index Only Scan' ||
+      node['Node Type'] === 'Index Scan' ||
+      node['Node Type'] === 'Seq Scan'
+    ) &&
+    (node['Actual Loops'] ?? 0) >= saturatedPendingCount
+  )
+}
+
+function expectNoRepeatedJobTableScan (nodes: PlanNode[]): void {
+  expect(findRepeatedJobTableScan(nodes), planSummary(nodes)).toBeUndefined()
+}
+
+function expectClaimedJobs (plan: PlanNode, expected: number): void {
+  expect(plan['Actual Rows']).toBe(expected)
+}
+
+async function explainGroupConcurrencyFetchPlan ({
+  refreshStatisticsAfterFixture,
+  groupConcurrency,
+  batchSize = 1
+}: {
+  refreshStatisticsAfterFixture: boolean
+  groupConcurrency: number
+  batchSize?: number
+}): Promise<ExplainedPlan> {
+  // The shared hooks create a schema unique to each test and drop it after a passing run.
+  // This repro owns cleanup explicitly because one case is expected to fail until the query is fixed.
+  ctx.boss = await helper.start(ctx.bossConfig)
+
+  const schema = ctx.schema
+  const queueName = ctx.schema
+  const db = await helper.getDb()
+
+  try {
+    // Seed one active saturated-group slot and analyze immediately. In the stale-statistics case
+    // this makes Postgres believe the active-group aggregate contains a single group with one row.
+    await db.executeSql(`
+      INSERT INTO ${schema}.job_common (name, data, state, group_id, start_after, created_on, started_on)
+      VALUES ($1, '{}'::jsonb, 'active'::${schema}.job_state, $2, now() - interval '5 minutes', now() - interval '5 minutes', now() - interval '5 minutes')
+    `, [queueName, saturatedGroup])
+
+    await db.executeSql(`ANALYZE ${schema}.job_common`)
+
+    // Fill the rest of the saturated group's active slots after ANALYZE. For groupConcurrency: 1
+    // this inserts no rows; for higher limits it keeps the group actually saturated while leaving
+    // planner stats stale.
+    await db.executeSql(`
+      INSERT INTO ${schema}.job_common (name, data, state, group_id, start_after, created_on, started_on)
+      SELECT $1, '{}'::jsonb, 'active'::${schema}.job_state, $2, now() - interval '5 minutes', now() - interval '5 minutes', now() - interval '5 minutes'
+      FROM generate_series(1, $3::int)
+    `, [queueName, saturatedGroup, groupConcurrency - 1])
+
+    // Add the real active-group cardinality after the first ANALYZE. Without a later ANALYZE,
+    // the fetch CTE actually returns about 100 active groups while planner stats can still
+    // estimate it near one row.
+    await db.executeSql(`
+      INSERT INTO ${schema}.job_common (name, data, state, group_id, start_after, created_on, started_on)
+      SELECT $1, '{}'::jsonb, 'active'::${schema}.job_state, 'active-group-' || g::text, now() - interval '5 minutes', now() - interval '5 minutes', now() - interval '5 minutes'
+      FROM generate_series(1, $2::int) g
+    `, [queueName, activeGroupCount - 1])
+
+    // Fill the front of the queue with one saturated group. Since every groupConcurrency slot is
+    // already active, these rows are runnable by state but ineligible by group.
+    await db.executeSql(`
+      INSERT INTO ${schema}.job_common (name, data, state, group_id, start_after, created_on)
+      SELECT $1, '{}'::jsonb, 'created'::${schema}.job_state, $2, now() - interval '5 minutes', now() - interval '4 minutes' + (g * interval '1 millisecond')
+      FROM generate_series(1, $3::int) g
+    `, [queueName, saturatedGroup, saturatedPendingCount])
+
+    // Add enough eligible groups behind the saturated backlog to fill the requested batch. This
+    // makes the large-batch case exercise both the hot-path filter and the post-LIMIT ranking work.
+    const availablePendingCount = Math.max(minimumAvailablePendingCount, batchSize)
+    await db.executeSql(`
+      INSERT INTO ${schema}.job_common (name, data, state, group_id, start_after, created_on)
+      SELECT $1, '{}'::jsonb, 'created'::${schema}.job_state, 'available-group-' || g::text, now() - interval '5 minutes', now() - interval '3 minutes' + (g * interval '1 millisecond')
+      FROM generate_series(1, $2::int) g
+    `, [queueName, availablePendingCount])
+
+    if (refreshStatisticsAfterFixture) {
+      // The passing control case refreshes stats after all rows exist. The stale-stats repro
+      // intentionally skips this to model the planner blind spot from production.
+      await db.executeSql(`ANALYZE ${schema}.job_common`)
+    }
+
+    // Use pg-boss's actual groupConcurrency fetch query. Current pg-boss fails the stale-stats
+    // check because Postgres can choose a CTE-rescan plan; the fix should make both cases pass.
+    const query = plans.fetchNextJob({
+      schema,
+      table: 'job_common',
+      name: queueName,
+      policy: 'standard',
+      limit: batchSize,
+      priority: false,
+      orderByCreatedOn: true,
+      ignoreSingletons: null,
+      groupConcurrency
+    })
+
+    const explain = await db.executeSql(`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${query.text}`, query.values)
+    const plan = extractPlan(explain.rows)
+    return { plan, nodes: collectPlanNodes(plan) }
+  } finally {
+    await db.close()
+
+    if (ctx.boss) {
+      await ctx.boss.stop({ timeout: 2000 })
+      ctx.boss = undefined
+    }
+
+    await helper.dropSchema(schema)
+  }
+}
+
+describeRepro('groupConcurrency fetch plan repro', function () {
+  it('does not rescan active_group_counts when table statistics are current', { timeout: 120000 }, async function () {
+    const { plan, nodes } = await explainGroupConcurrencyFetchPlan({
+      refreshStatisticsAfterFixture: true,
+      groupConcurrency: 1
+    })
+
+    expectClaimedJobs(plan, 1)
+    expectNoRepeatedActiveGroupScan(nodes)
+    expectNoRepeatedGroupRanking(nodes)
+  })
+
+  it('does not rescan active_group_counts once per saturated pending job with stale statistics', { timeout: 120000 }, async function () {
+    const { plan, nodes } = await explainGroupConcurrencyFetchPlan({
+      refreshStatisticsAfterFixture: false,
+      groupConcurrency: 1
+    })
+
+    // The pathological plan estimates active_group_counts as one row, then nested-loop scans that
+    // CTE once per saturated pending row. A robust query shape should avoid this even when stats
+    // are stale.
+    expectClaimedJobs(plan, 1)
+    expectNoRepeatedActiveGroupScan(nodes)
+    expectNoRepeatedGroupRanking(nodes)
+  })
+
+  it('does not rescan active_group_counts when table statistics are current and groupConcurrency is greater than 1', { timeout: 120000 }, async function () {
+    const { plan, nodes } = await explainGroupConcurrencyFetchPlan({
+      refreshStatisticsAfterFixture: true,
+      groupConcurrency: 2
+    })
+
+    expectClaimedJobs(plan, 1)
+    expectNoRepeatedActiveGroupScan(nodes)
+    expectNoRepeatedGroupRanking(nodes)
+    expectNoRepeatedJobTableScan(nodes)
+  })
+
+  it('does not rescan active_group_counts once per saturated pending job with stale statistics and groupConcurrency is greater than 1', { timeout: 120000 }, async function () {
+    const { plan, nodes } = await explainGroupConcurrencyFetchPlan({
+      refreshStatisticsAfterFixture: false,
+      groupConcurrency: 2
+    })
+
+    // The pathological plan estimates active_group_counts as one row, then nested-loop scans that
+    // CTE once per saturated pending row. A robust query shape should avoid this even when stats
+    // are stale.
+    expectClaimedJobs(plan, 1)
+    expectNoRepeatedActiveGroupScan(nodes)
+    expectNoRepeatedGroupRanking(nodes)
+    expectNoRepeatedJobTableScan(nodes)
+  })
+
+  it('does not rescan active counts or group ranking for a large batch with stale statistics', { timeout: 120000 }, async function () {
+    const batchSize = 100
+    const { plan, nodes } = await explainGroupConcurrencyFetchPlan({
+      refreshStatisticsAfterFixture: false,
+      groupConcurrency: 2,
+      batchSize
+    })
+
+    expectClaimedJobs(plan, batchSize)
+    expectNoRepeatedActiveGroupScan(nodes)
+    expectNoRepeatedGroupRanking(nodes)
+    expectNoRepeatedJobTableScan(nodes)
+  })
+
+  it('keeps the tiered fetch query shape independent of configured tier count', function () {
+    const buildQuery = (tiers: Record<string, number>) => plans.fetchNextJob({
+      schema: ctx.schema,
+      table: 'job_common',
+      name: ctx.schema,
+      policy: 'standard',
+      limit: 1,
+      priority: false,
+      orderByCreatedOn: true,
+      ignoreSingletons: null,
+      groupConcurrency: { default: 1, tiers }
+    })
+
+    const oneTier = buildQuery({ tier0: 2 })
+    const manyTiers = buildQuery(Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [`tier${index}`, 2])
+    ))
+
+    expect(manyTiers.text).toBe(oneTier.text)
+  })
+})


### PR DESCRIPTION
Closes https://github.com/timgit/pg-boss/issues/842

## Problem

Queues using `groupConcurrency` can hit a severe PostgreSQL plan regression when:

- A saturated group has many pending jobs near the front of the queue.
- Eligible jobs from other groups are behind that backlog.
- Table statistics underestimate the number of active groups.

The original fetch query materialized `active_group_counts`, then joined that relation both while finding candidates and after `LIMIT`. `MATERIALIZED` ensures the CTE is computed once, but PostgreSQL can still repeatedly scan its result. With stale statistics, it can choose nested-loop plans that rescan active counts and group ranking once per candidate or job-table row.

The regression fixture produces roughly 12,000 repeated scans in the pathological case.

## Changes

For `groupConcurrency: 1`, the fetch query uses `NOT EXISTS` to determine whether a candidate's group already has an active job.

For `groupConcurrency > 1` and tiered limits, the query now:

- Groups active jobs once and aggregates their counts into one materialized JSONB object mapping `group_id` to `active_cnt`.
- Reads candidate counts through keyed, uncorrelated scalar InitPlans instead of joining a multi-row count relation in the candidate path.
- Carries `active_cnt` through the post-`LIMIT` ranking rather than joining active counts again.
- Supplies the final filtered IDs to the update with `id = ANY (ARRAY(SELECT ...))`, preventing PostgreSQL from repeatedly executing the ranking query.
- Keeps tier limits in the JSONB parameter, making generated SQL independent of configured tier count.

This does not add tables, migrations, or persistent count state.

## Regression coverage

The first commit adds plan regression tests around pg-boss's generated fetch update. The fixture includes a saturated backlog, eligible jobs behind it, many active groups, and both current and deliberately stale statistics.

Coverage includes:

- `groupConcurrency: 1` and `groupConcurrency: 2`
- Current and stale statistics
- Batch size 1 and a large batch
- Correct claimed-job counts
- No repeated active-count CTE scan
- No repeated group-ranking execution
- No repeated job-table scan caused by the group-concurrency subplan
- Tiered query shape remaining independent of configured tier count
- Existing normal and tiered group-concurrency behavior

Before the fix, the stale-statistics cases reproduce the repeated-scan plan. The second commit changes the query shape and makes the full suite pass.

## Validation

- Standard CI and coverage
- Distributed test suite
- PGlite test suite
- CockroachDB test suite
- Existing group-concurrency behavior tests
- Local PostgreSQL 17 plan and performance comparison across the original, array, and current map implementations

The detailed three-way benchmark, plan-loop counts, representative SQL for all three implementations, and remaining tradeoffs are documented in [this PR discussion](https://github.com/timgit/pg-boss/pull/845#issuecomment-5030088177).
