### PR TITLE
fix(dashboard): use renderToReadableStream for Bun compatibility

### DIFF
--- a/packages/dashboard/app/entry.server.tsx
+++ b/packages/dashboard/app/entry.server.tsx
@@ -1,0 +1,31 @@
+import { renderToReadableStream } from 'react-dom/server'
+import type { AppLoadContext, EntryContext } from 'react-router'
+import { ServerRouter } from 'react-router'
+
+/**
+ * Custom entry server using `renderToReadableStream` (Web Streams) instead of
+ * the default `renderToPipeableStream` (Node.js streams). This makes the
+ * dashboard compatible with Bun, which ships a `react-dom/server` build that
+ * omits `renderToPipeableStream`, while still working correctly on Node.js 18+
+ * (which supports the Web Streams API and the `Response` constructor natively).
+ */
+export default async function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: AppLoadContext,
+) {
+  const stream = await renderToReadableStream(
+    <ServerRouter context={routerContext} url={request.url} />,
+    {
+      onError(error: unknown) {
+        console.error(error)
+        responseStatusCode = 500
+      },
+    },
+  )
+
+  responseHeaders.set('Content-Type', 'text/html')
+  return new Response(stream, { headers: responseHeaders, status: responseStatusCode })
+}


### PR DESCRIPTION
## Problem

Running `@pg-boss/dashboard` under [Bun](https://bun.sh) fails immediately with:

```
SyntaxError: Export named 'renderToPipeableStream' not found in module 'react-dom/server.bun.js'
```

Bun ships its own `react-dom/server.bun.js` that only exports `renderToReadableStream` (Web Streams API) and intentionally omits `renderToPipeableStream` (Node.js streams). React Router's default entry server uses `renderToPipeableStream`, so the dashboard crashes on startup.

## Fix

Add a custom `app/entry.server.tsx` that uses `renderToReadableStream` instead. This is the [idiomatic React Router approach](https://reactrouter.com/how-to/custom-entry-files) for non-Node runtimes and edge environments.

`renderToReadableStream` returns a Web Streams `ReadableStream`, which can be passed directly to the standard `Response` constructor — no Node.js stream piping needed. This works on both **Bun** and **Node.js 18+** (which supports the Web Streams API natively), so no runtime detection is required.

## Testing

```bash
DATABASE_URL=postgresql://user:pass@localhost:5432/mydb bunx @pg-boss/dashboard
```