### PR TITLE
Fix PGlite flakiness from coarse now() timestamps

### DIFF
--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -102,7 +102,7 @@ CockroachDB but are independent in principle:
     SELECT id FROM jobs
     WHERE name = $name
       AND state < 'active'
-      AND start_after < now()
+      AND start_after <= now()
     ORDER BY priority DESC, created_on, id
     LIMIT $batchSize
   )

--- a/examples/index-perf/index.ts
+++ b/examples/index-perf/index.ts
@@ -111,7 +111,7 @@ function candidateSql (limit: number): string {
     WHERE j.name = '${QUEUE}'
       AND j.state < 'active'
       AND NOT j.blocked
-      AND j.start_after < now()
+      AND j.start_after <= now()
     ORDER BY j.priority desc, j.created_on, j.id
     LIMIT ${limit}
     FOR UPDATE OF j SKIP LOCKED`
@@ -132,7 +132,7 @@ async function seed (db: Db) {
       now() - ((g % 3600) || ' seconds')::interval,
       now() - ((g % 3600) || ' seconds')::interval
     FROM generate_series(1, ${ELIGIBLE}) g`)
-  // Future-scheduled created jobs — in the index, filtered out by start_after < now().
+  // Future-scheduled created jobs — in the index, filtered out by start_after <= now().
   // FUTURE_HI gives them a high priority to model the priority index's worst case: many
   // not-yet-due jobs ranked ahead of the due ones, which a priority-keyed walk must filter past.
   const futurePriority = process.env.FUTURE_HI ? 9 : 0

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1381,7 +1381,12 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
     `j.name = '${name}'`,
     `j.state < '${JOB_STATES.active}'`,
     'NOT j.blocked',
-    !ignoreStartAfter ? 'j.start_after < now()' : '',
+    // `<=` (not `<`) so a job inserted with the default start_after = now() is immediately
+    // fetchable in the next statement. `now()` is transaction-scoped; on backends with coarse
+    // clock resolution (notably PGlite) consecutive autocommit statements often share the same
+    // timestamp, so `<` would leave freshly-inserted jobs invisible until the clock ticks.
+    // NOTIFY gating already uses `start_after <= now()` for the same reason.
+    !ignoreStartAfter ? 'j.start_after <= now()' : '',
     hasIgnoreSingletons ? `COALESCE(j.singleton_key, '') <> ALL(${params.ignoreSingletonsParam})` : '',
     hasIgnoreGroups ? `(j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : '',
     hasMinPriority ? `j.priority >= ${params.minPriorityParam}` : '',

--- a/test/fetchTest.ts
+++ b/test/fetchTest.ts
@@ -258,6 +258,6 @@ describe('fetch', function () {
     const jobs = await ctx.boss.fetch(ctx.schema, { ...options, ignoreStartAfter: true })
     expect(jobs.length).toBe(1)
     expect(sqlStatements.length).toBe(1)
-    expect(!sqlStatements[0].includes('start_after < now()')).toBeTruthy()
+    expect(!sqlStatements[0].includes('start_after <= now()')).toBeTruthy()
   })
 })

--- a/test/testHelper.ts
+++ b/test/testHelper.ts
@@ -231,6 +231,14 @@ async function tryCreateDb (database: string): Promise<void> {
   }
 }
 
+// PGlite often assigns the same created_on to back-to-back inserts. Tests that assert FIFO /
+// insertion order (ORDER BY created_on, id) need distinct timestamps; without them UUID id order
+// can win and look like a policy bug. No-op on real Postgres, where statement boundaries already
+// advance now(). helper.start() also applies this after each send/insert under PGlite.
+async function separateTimestamps (): Promise<void> {
+  if (isPglite) await delay(2)
+}
+
 async function start (options?: Partial<ConstructorOptions> & { testKey?: string; noDefault?: boolean }): Promise<PgBoss> {
   try {
     const config = getConfig(options)
@@ -244,6 +252,25 @@ async function start (options?: Partial<ConstructorOptions> & { testKey?: string
       assertTruthy(config.schema)
       await boss.createQueue(config.schema)
     }
+
+    // Under PGlite, back-to-back inserts often share created_on; tests that assert FIFO would
+    // otherwise fall through to UUID id order. Advance the clock after each write so ordering
+    // matches real Postgres without sprinkling delays through every suite.
+    if (isPglite) {
+      const origSend = boss.send.bind(boss)
+      const origInsert = boss.insert.bind(boss)
+      boss.send = (async (...args: Parameters<PgBoss['send']>) => {
+        const result = await origSend(...args)
+        await separateTimestamps()
+        return result
+      }) as PgBoss['send']
+      boss.insert = (async (...args: Parameters<PgBoss['insert']>) => {
+        const result = await origInsert(...args)
+        await separateTimestamps()
+        return result
+      }) as PgBoss['insert']
+    }
+
     return boss
   } catch (err) {
     // this is nice for occaisional debugging, Mr. Linter
@@ -254,11 +281,11 @@ async function start (options?: Partial<ConstructorOptions> & { testKey?: string
   }
 }
 
-// PGlite's now() has coarse, sub-statement resolution, so a row inserted with the default
-// start_after = now() can tie with an immediately following fetch's `start_after < now()` filter and
-// briefly read as not-yet-due. Real Postgres advances now() between statements, so the first attempt
-// always wins there. Retry the fetch a few times so assertions on freshly-inserted jobs (e.g. a job
-// just routed to a dead letter queue) aren't flaky under PGlite.
+// PGlite's now() has coarse, sub-statement resolution, so consecutive statements often share a
+// timestamp. Fetch uses `start_after <= now()` so a row inserted with the default start_after =
+// now() is immediately claimable; prefer that over relying on the clock to tick between send and
+// fetch. fetchWithRetry remains useful for cases where work appears asynchronously (e.g. a job
+// just routed to a dead letter queue) and may not be visible on the first attempt.
 async function fetchWithRetry<T = object> (boss: PgBoss, name: string, options?: FetchOptions, attempts = 20): Promise<Job<T>[]> {
   for (let i = 0; i < attempts; i++) {
     const jobs = await boss.fetch<T>(name, options)
@@ -295,6 +322,7 @@ export {
   dropSchema,
   start,
   fetchWithRetry,
+  separateTimestamps,
   getDb,
   countJobs,
   findJobs,


### PR DESCRIPTION
### Problem

`npm run test:pglite` failed, because on PGlite, jobs were often not fetchable right after `send()`, even though the same tests passed against real Postgres.

PGlite’s now() is coarse: back-to-back statements frequently see the same timestamp. Jobs are inserted with `start_after = now()`, but fetch required `start_after < now()`. When those times tied, the job looked “not ready yet,” so `fetch` returned nothing (or only part of a batch). That showed up as flaky failures in `npm run test:pglite`.

A related issue: when several jobs shared the same `created_on`, ordering fell back to UUID `id`, so FIFO / insertion-order assertions could pick the wrong job.

### Solution

Fetch with `start_after <= now()` (same rule NOTIFY already uses), so a job scheduled for “now” is immediately claimable.
In PGlite tests only, nudge the clock after each `send/insert` so `created_on` values stay distinct and order-sensitive tests stay stable.