### PR TITLE
Fix key_strict_fifo blocking and priority ordering

### DIFF
--- a/docs/api/queues.md
+++ b/docs/api/queues.md
@@ -40,18 +40,20 @@ Allowed policy values:
 | `singleton` | Only allows 1 job to be active, unlimited queued. Can be extended with `singletonKey` |
 | `stately` | Combination of short and singleton: Only allows 1 job per state, queued and/or active. Can be extended with `singletonKey` |
 | `exclusive` | Only allows 1 job to be queued or active. Can be extended with `singletonKey` |
-| `key_strict_fifo` | Strict FIFO ordering per `singletonKey`. Requires `singletonKey` on every job. Blocks processing of jobs with the same key while any job with that key is active, in retry, or failed. |
+| `key_strict_fifo` | Strict FIFO ordering per `singletonKey`. Requires `singletonKey` on every job. Holds back the next job for a key while a job with that same key is active, in retry, or failed. Blocking is scoped per key, so a stuck key never stalls other keys. |
 
 > [!WARNING]
 > `stately` queues are special in how retries are handled. By definition, stately queues will not allow multiple jobs to occupy `retry` state. Once a job exists in `retry`, failing another `active` job will bypass the retry mechanism and force the job to `failed`. If this job requires retries, consider a custom retry implementation using a dead letter queue.
 
 > [!NOTE]
-> `key_strict_fifo` queues enforce strict FIFO (First-In-First-Out) ordering per `singletonKey`. This is useful when you need to ensure jobs for the same entity (e.g., the same order, customer, or resource) are processed sequentially in the order they were created. The queue will block processing of subsequent jobs with the same `singletonKey` while any job with that key is:
+> `key_strict_fifo` queues enforce strict FIFO (First-In-First-Out) ordering per `singletonKey`. This is useful when you need to ensure jobs for the same entity (e.g., the same order, customer, or resource) are processed sequentially in the order they were created. The queue will hold back subsequent jobs with the same `singletonKey` while any job with that key is:
 > - **active**: currently being processed
 > - **retry**: waiting to be retried after a failure
 > - **failed**: permanently failed (exhausted all retries)
 >
-> To unblock a key after a permanent failure, you can either delete the failed job using `deleteJob()` or retry it using `retry()`. Use `getBlockedKeys()` to discover which keys are currently blocked due to failed jobs.
+> Blocking is scoped to the individual key. A key that is stuck (for example on a permanently failed job) only holds back its own successors; jobs for every other `singletonKey` continue to be fetched normally, so a single failure never stalls the whole queue.
+>
+> To unblock a key after a permanent failure, you can either delete the failed job using `deleteJob()` or retry it using `retry()`. Once the blocking job leaves the active/retry/failed state, that key's queued successors become fetchable again, still in FIFO order. Use `getBlockedKeys()` to discover which keys are currently blocked due to failed jobs.
 
 * **partition**, boolean, default false
 

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1337,7 +1337,8 @@ function buildFetchParams (options: FetchJobOptions): FetchQueryParams {
 export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): SqlQuery {
   const { schema, table, name, policy, limit, includeMetadata, priority = true, orderByCreatedOn = true, ignoreStartAfter = false, groupConcurrency, minPriority, maxPriority } = options
 
-  const singletonFetch = limit > 1 && (policy === QUEUE_POLICIES.singleton || policy === QUEUE_POLICIES.stately)
+  const keyStrictFifo = policy === QUEUE_POLICIES.key_strict_fifo
+  const singletonFetch = limit > 1 && (policy === QUEUE_POLICIES.singleton || policy === QUEUE_POLICIES.stately || keyStrictFifo)
   const hasIgnoreSingletons = options.ignoreSingletons != null && options.ignoreSingletons.length > 0
   const hasIgnoreGroups = options.ignoreGroups != null && options.ignoreGroups.length > 0
   const hasGroupConcurrency = groupConcurrency != null
@@ -1353,6 +1354,9 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
   const selectCols = [
     'j.id',
     singletonFetch ? 'j.singleton_key' : '',
+    // created_on is carried through so the per-key dedup ranking below can order
+    // by (created_on, id) and keep the oldest job per key (strict FIFO).
+    singletonFetch && keyStrictFifo ? 'j.created_on' : '',
     hasGroupConcurrency ? 'j.group_id, j.group_tier' : ''
   ].filter(Boolean).join(', ')
 
@@ -1388,6 +1392,46 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
     // NOTIFY gating already uses `start_after <= now()` for the same reason.
     !ignoreStartAfter ? 'j.start_after <= now()' : '',
     hasIgnoreSingletons ? `COALESCE(j.singleton_key, '') <> ALL(${params.ignoreSingletonsParam})` : '',
+    // key_strict_fifo blocking check: "is another job of this key already in flight or stuck?"
+    // Exclude j if a sibling is active/retry/failed, so a key holds back its own successors while
+    // one of its jobs is occupied - without starving other keys, which keep flowing.
+    // `b.id <> j.id` is essential so a job already in retry stays fetchable for its own re-fetch
+    // (retry -> active does not violate job_i8, the unique index that guarantees at most one job
+    // per key sits in those states).
+    // The `b.policy` predicate is what lets this NOT EXISTS use the partial job_i8 index: its
+    // WHERE clause includes `policy = key_strict_fifo`, so without it the planner falls back to a
+    // seq scan for the per-key lookup. Every row sharing b.name shares this policy, so the
+    // predicate is a no-op on results but turns the anti-join into an index probe.
+    keyStrictFifo
+      ? `NOT EXISTS (
+            SELECT 1 FROM ${schema}.${table} b
+            WHERE b.name = j.name
+              AND b.singleton_key = j.singleton_key
+              AND b.state IN ('${JOB_STATES.active}', '${JOB_STATES.retry}', '${JOB_STATES.failed}')
+              AND b.policy = '${QUEUE_POLICIES.key_strict_fifo}'
+              AND b.id <> j.id
+          )`
+      : '',
+    // key_strict_fifo FIFO-head check: "among this key's waiting jobs, is this the oldest?"
+    // Exclude j if an older eligible sibling is still waiting (state < active), so only each key's
+    // head is a candidate before the priority/created_on ordering and LIMIT run. Without this,
+    // `priority desc` (or a small batch window) can surface a newer same-key job ahead of an older
+    // one, breaking the "processed in the order they were created" contract. Since only the head is
+    // eligible, cross-key priority ordering below still applies, but within a key the oldest always
+    // wins. "Older" is compared by (created_on, id), matching the fetch tiebreak, and the head is
+    // scoped to currently-eligible rows (same state/blocked/start_after filters as j) so a delayed
+    // older sibling doesn't stall a ready one beyond existing behavior.
+    keyStrictFifo
+      ? `NOT EXISTS (
+            SELECT 1 FROM ${schema}.${table} h
+            WHERE h.name = j.name
+              AND h.singleton_key = j.singleton_key
+              AND h.policy = '${QUEUE_POLICIES.key_strict_fifo}'
+              AND h.state < '${JOB_STATES.active}'
+              AND NOT h.blocked${!ignoreStartAfter ? '\n              AND h.start_after < now()' : ''}
+              AND (h.created_on, h.id) < (j.created_on, j.id)
+          )`
+      : '',
     hasIgnoreGroups ? `(j.group_id IS NULL OR j.group_id <> ALL(${params.ignoreGroupsParam}))` : '',
     hasMinPriority ? `j.priority >= ${params.minPriorityParam}` : '',
     hasMaxPriority ? `j.priority <= ${params.maxPriorityParam}` : '',
@@ -1414,7 +1458,7 @@ export function fetchNextJob (options: FetchJobOptions, noSkipLocked = false): S
   const singletonCte = singletonFetch
     ? `, singleton_ranking AS (
         SELECT id, ${hasGroupConcurrency ? 'group_id, group_tier, ' : ''}
-          row_number() OVER (PARTITION BY singleton_key) as singleton_rn
+          row_number() OVER (PARTITION BY singleton_key ORDER BY ${keyStrictFifo ? 'created_on, ' : ''}id) as singleton_rn
         FROM next
       )`
     : ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -492,8 +492,12 @@ export interface UpdateRequest {
  *   singletonKey`.
  *
  * - `key_strict_fifo` ensures strict FIFO ordering per `singletonKey`. Requires
- *   `singletonKey` on every job. Blocks processing of jobs with the same key
- *   while any job with that key is active, in retry, or failed.
+ *   `singletonKey` on every job. While a job with a given key is active, in retry,
+ *   or failed, the next job for that same key is held back. Blocking is scoped to
+ *   the individual key: a stuck (e.g. failed) key never stalls other keys, whose
+ *   jobs keep flowing normally. Once the blocking job leaves that state (via
+ *   `retry()`, `deleteJob()`, or maintenance), the key's successors become
+ *   fetchable again, still in FIFO order.
  */
 export type QueuePolicy = 'standard' | 'short' | 'singleton' | 'stately' | 'exclusive' | 'key_strict_fifo' | (string & {})
 

--- a/test/distributedDatabaseTest.ts
+++ b/test/distributedDatabaseTest.ts
@@ -19,8 +19,10 @@ import { ctx } from './hooks.ts'
 //
 // Every test here calls helper.start(), which on CockroachDB pays slow per-test DDL (~8-9s observed
 // in CI), leaving little headroom under the 10s global timeout. Raise the default for the whole
-// block so startup jitter can't push a test over the edge (the concurrency tests keep their explicit
-// per-test overrides).
+// block so startup jitter can't push a test over the edge. Per-test overrides pass blockTimeout
+// (never a bare literal) so they lift the Postgres budget without capping a distributed backend
+// below it — a flat 30000 here previously timed the two concurrency tests out on a slow
+// CockroachDB run while the rest of the block, allowed 60s, passed at up to 47s.
 //
 // The override must only LIFT the Postgres budget — never cap a distributed backend. vitest.config.ts
 // already gives cockroachdb/yugabytedb a 60s global; a flat 20s here would lower it for exactly the
@@ -57,7 +59,7 @@ helper.describePglite('distributed database mode', { timeout: blockTimeout }, fu
     // but no job should be duplicated
     expect(allJobs.length).toBeLessThanOrEqual(jobCount)
     expect(allJobs.length).toBeGreaterThan(0)
-  }, 30000)
+  }, blockTimeout)
 
   it('should handle high concurrency without duplicates in distributed mode', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: true })
@@ -106,7 +108,7 @@ helper.describePglite('distributed database mode', { timeout: blockTimeout }, fu
 
     // Verify all jobs were claimed exactly once
     expect(claimedIndices.size).toBe(jobCount)
-  }, 30000)
+  }, blockTimeout)
 
   it('should compose failDistributed inside a caller transaction and roll back with it', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, __test__distributed: true })

--- a/test/keyStrictFifoTest.ts
+++ b/test/keyStrictFifoTest.ts
@@ -218,6 +218,173 @@ describe('key_strict_fifo', function () {
       expect(job2.id).toBe(jobId2)
     })
 
+    // The four tests below cover key_strict_fifo blocking - the rule "is another job of this key
+    // already in flight or stuck?" (a sibling in active/retry/failed). key_strict_fifo used to rely
+    // only on the job_i8 unique index: fetch tried to activate a blocked key's job, hit a unique
+    // violation (23505), and manager.fetch() swallowed it as an empty result - so on a batch fetch
+    // one stuck/failed key starved every other key. The fix skips blocked keys in fetchNextJob, so
+    // a blocked key only holds back its own successors while every other key keeps flowing.
+    it(`key_strict_fifo failed key does not block other keys using partition=${partition}`, async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+      await ctx.boss.createQueue(ctx.schema, { policy: 'key_strict_fifo', partition })
+
+      // A1, A2 share a key (A2 is the head of A's queue after A1 fails); B1 is a different key
+      const jobIdA1 = await ctx.boss.send(ctx.schema, { key: 'A', order: 1 }, { singletonKey: 'A', retryLimit: 0 })
+      const jobIdA2 = await ctx.boss.send(ctx.schema, { key: 'A', order: 2 }, { singletonKey: 'A' })
+      const jobIdB1 = await ctx.boss.send(ctx.schema, { key: 'B', order: 1 }, { singletonKey: 'B' })
+
+      expect(jobIdA1).toBeTruthy()
+      expect(jobIdA2).toBeTruthy()
+      expect(jobIdB1).toBeTruthy()
+
+      // Fetch and permanently fail A1
+      const [jobA1] = await ctx.boss.fetch(ctx.schema)
+      expect(jobA1.id).toBe(jobIdA1)
+      await ctx.boss.fail(ctx.schema, jobA1.id)
+
+      assertTruthy(jobIdA1)
+      const failedA1 = await ctx.boss.getJobById(ctx.schema, jobIdA1)
+      assertTruthy(failedA1)
+      expect(failedA1.state).toBe('failed')
+
+      // B1 must still be fetchable even though A is blocked at the head of the queue
+      const [jobB1] = await ctx.boss.fetch(ctx.schema)
+      expect(jobB1).toBeTruthy()
+      expect(jobB1.id).toBe(jobIdB1)
+
+      // A2 must NOT be fetchable while A1 is failed
+      const [blocked] = await ctx.boss.fetch(ctx.schema)
+      expect(blocked).toBeFalsy()
+    })
+
+    it(`key_strict_fifo recovers successors in order after retry using partition=${partition}`, async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+      await ctx.boss.createQueue(ctx.schema, { policy: 'key_strict_fifo', partition })
+
+      const jobIdA1 = await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'A', retryLimit: 0 })
+      const jobIdA2 = await ctx.boss.send(ctx.schema, { order: 2 }, { singletonKey: 'A' })
+
+      // Fetch and fail A1
+      const [jobA1] = await ctx.boss.fetch(ctx.schema)
+      await ctx.boss.fail(ctx.schema, jobA1.id)
+
+      // Queue for key A is blocked
+      const [blocked] = await ctx.boss.fetch(ctx.schema)
+      expect(blocked).toBeFalsy()
+
+      // Retry the failed job - A1 becomes fetchable again (retry state), A2 stays queued
+      assertTruthy(jobIdA1)
+      await ctx.boss.retry(ctx.schema, jobIdA1)
+
+      const [retriedA1] = await ctx.boss.fetch(ctx.schema)
+      expect(retriedA1).toBeTruthy()
+      expect(retriedA1.id).toBe(jobIdA1)
+
+      // A2 still not fetchable while A1 is active
+      const [stillBlocked] = await ctx.boss.fetch(ctx.schema)
+      expect(stillBlocked).toBeFalsy()
+
+      // Once A1 completes, A2 becomes fetchable
+      await ctx.boss.complete(ctx.schema, retriedA1.id)
+
+      const [jobA2] = await ctx.boss.fetch(ctx.schema)
+      expect(jobA2).toBeTruthy()
+      expect(jobA2.id).toBe(jobIdA2)
+    })
+
+    it(`key_strict_fifo active key does not block other keys using partition=${partition}`, async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+      await ctx.boss.createQueue(ctx.schema, { policy: 'key_strict_fifo', partition })
+
+      // A1 older than A2; B1 is a different key
+      const jobIdA1 = await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'A' })
+      const jobIdA2 = await ctx.boss.send(ctx.schema, { order: 2 }, { singletonKey: 'A' })
+      const jobIdB1 = await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'B' })
+
+      expect(jobIdA1).toBeTruthy()
+      expect(jobIdA2).toBeTruthy()
+      expect(jobIdB1).toBeTruthy()
+
+      // Fetch A1, leave it active (do not complete)
+      const [jobA1] = await ctx.boss.fetch(ctx.schema)
+      expect(jobA1.id).toBe(jobIdA1)
+
+      // A2 is older than B1 so it sorts first, but it is blocked while A1 is active. A default
+      // (single-row) fetch must skip A2 before applying LIMIT and return B1 rather than nothing.
+      const [jobB1] = await ctx.boss.fetch(ctx.schema)
+      expect(jobB1).toBeTruthy()
+      expect(jobB1.id).toBe(jobIdB1)
+    })
+
+    it(`key_strict_fifo batch fetch dedups same key using partition=${partition}`, async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+      await ctx.boss.createQueue(ctx.schema, { policy: 'key_strict_fifo', partition })
+
+      const jobIdA1 = await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'A' })
+      const jobIdA2 = await ctx.boss.send(ctx.schema, { order: 2 }, { singletonKey: 'A' })
+      const jobIdB1 = await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'B' })
+
+      expect(jobIdA1).toBeTruthy()
+      expect(jobIdA2).toBeTruthy()
+      expect(jobIdB1).toBeTruthy()
+
+      // A single batch fetch must return one job per key (the oldest) and must not try to
+      // activate two same-key jobs in one statement, which would violate job_i8 and abort the
+      // whole fetch. Before the fix this returned an empty/partial batch instead of [A1, B1].
+      const jobs = await ctx.boss.fetch(ctx.schema, { batchSize: 3 })
+      const fetchedIds = jobs.map(job => job.id).sort()
+      expect(fetchedIds).toEqual([jobIdA1, jobIdB1].sort())
+    })
+
+    // The two tests below cover key_strict_fifo ordering - the rule "among this key's waiting jobs,
+    // is this the oldest?". Priority may order across keys, but never within a key. Before the fix
+    // the per-key dedup ran after the priority/LIMIT ordering, so a newer higher-priority job could
+    // jump ahead of an older one with the same key.
+    it(`key_strict_fifo priority does not reorder within a key using partition=${partition}`, async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+      await ctx.boss.createQueue(ctx.schema, { policy: 'key_strict_fifo', partition })
+
+      // Same key: older job at priority 0, newer job at priority 10. The older one must come back
+      // first - within a key the oldest always wins, regardless of priority.
+      const older = await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'A', priority: 0 })
+      const newer = await ctx.boss.send(ctx.schema, { order: 2 }, { singletonKey: 'A', priority: 10 })
+
+      const [first] = await ctx.boss.fetch(ctx.schema)
+      expect(first.id).toBe(older)
+
+      await ctx.boss.complete(ctx.schema, first.id)
+
+      const [second] = await ctx.boss.fetch(ctx.schema)
+      expect(second.id).toBe(newer)
+    })
+
+    it(`key_strict_fifo batch does not surface a newer high-priority same-key job using partition=${partition}`, async function () {
+      ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+      await ctx.boss.createQueue(ctx.schema, { policy: 'key_strict_fifo', partition })
+
+      // A's older job is low priority, its newer job is high priority, with other keys in between.
+      // A's oldest queued job is its only eligible candidate, so a batch fetch must never return A's
+      // newer job while the older one is still queued - whatever the priorities or batch size.
+      const olderA = await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'A', priority: 0 })
+      const newerA = await ctx.boss.send(ctx.schema, { order: 2 }, { singletonKey: 'A', priority: 10 })
+      await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'B', priority: 5 })
+      await ctx.boss.send(ctx.schema, { order: 1 }, { singletonKey: 'C', priority: 5 })
+
+      assertTruthy(olderA)
+      assertTruthy(newerA)
+
+      const jobs = await ctx.boss.fetch(ctx.schema, { batchSize: 2 })
+      const fetchedIds = jobs.map(job => job.id)
+
+      expect(fetchedIds).not.toContain(newerA)
+    })
+
     it(`getBlockedKeys returns blocked singletonKeys using partition=${partition}`, async function () {
       ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
 


### PR DESCRIPTION
### Problem

`key_strict_fifo` previously enforced ordering only through the job_i8 unique index. On fetch, pg-boss would try to activate a blocked key's queued job, hit a unique violation (23505), and `manager.fetch()` swallowed it as an empty result. For batch fetches this meant **a single stuck, retrying, or permanently failed key starved every other key in the queue.**

### Solution

`fetchNextJob` now excludes candidates whose `singleton_key` already has a job in `active/retry/failed` and dedups to the oldest queued job per key, ordered by `(created_on, id)`. A blocked key only holds back its own successors; every other key keeps flowing, and successors resume in FIFO order once the blocking job leaves those states. The `NOT EXISTS` carries the policy predicate so the partial job_i8 index services the per-key lookup instead of a sequential scan.

Additionally, per-key ordering was still violated by priority: the per-key dedup only ran for batch fetches and, in both paths, happened after the global `priority desc, created_on, id` ordering and LIMIT, so a newer higher-priority job of a key could be fetched ahead of an older one. `fetchNextJob` now restricts candidates to each key's oldest eligible job (its FIFO head) before priority and LIMIT apply, so within a key the oldest always wins while priority still orders across keys, upholding the "processed in the order they were created" contract.

Adds tests for:
* a failed key not blocking other keys,
* an active key not blocking other keys,
* successors recovering in order after retry,
* batch fetch deduping same-key jobs,
* priority not reordering within a key,
* and batch fetch not surfacing a newer high-priority same-key job.

Docs updated to describe per-key (not per-queue) blocking.