### PR TITLE
Fix ready sparkline overflowing the stat card

### DIFF
--- a/packages/dashboard/app/components/ui/sparkline.tsx
+++ b/packages/dashboard/app/components/ui/sparkline.tsx
@@ -39,16 +39,19 @@ export function Sparkline ({
   const n = data.length
 
   const x = (i: number) => (n === 1 ? width / 2 : pad + (i / (n - 1)) * innerW)
-  const y = (v: number) => pad + (1 - (v - min) / span) * innerH
+  // Flat series has no span to normalize against — center it instead of pinning it to the baseline.
+  const y = (v: number) => (max === min ? height / 2 : pad + (1 - (v - min) / span) * innerH)
 
   const points = data.map((v, i) => `${x(i).toFixed(2)},${y(v).toFixed(2)}`).join(' ')
+
+  // max-w-full keeps the fixed-width SVG from spilling out of a narrower container (e.g. a stat card).
 
   return (
     <svg
       width={width}
       height={height}
       viewBox={`0 0 ${width} ${height}`}
-      className={cn('overflow-visible', className)}
+      className={cn('max-w-full overflow-visible', className)}
       role="img"
       aria-label={ariaLabel}
     >

--- a/packages/dashboard/tests/frontend/sparkline.test.tsx
+++ b/packages/dashboard/tests/frontend/sparkline.test.tsx
@@ -22,6 +22,21 @@ describe('Sparkline', () => {
     expect(container.querySelector('circle')).not.toBeNull()
   })
 
+  it('centers a flat series instead of pinning it to the baseline', () => {
+    const { container } = render(<Sparkline data={[1, 1, 1]} height={24} showDot={false} />)
+    const ys = container.querySelector('polyline')!
+      .getAttribute('points')!
+      .trim()
+      .split(/\s+/)
+      .map((point) => Number(point.split(',')[1]))
+    expect(new Set(ys)).toEqual(new Set([12]))
+  })
+
+  it('stays within a container narrower than its nominal width', () => {
+    const { container } = render(<Sparkline data={[1, 2, 3]} width={160} />)
+    expect(container.querySelector('svg')!.getAttribute('class')).toContain('max-w-full')
+  })
+
   it('applies the provided color and aria-label', () => {
     const { container } = render(
       <Sparkline data={[1, 2, 3]} color="var(--error-600)" aria-label="trend" />


### PR DESCRIPTION
## Problem

On the queue detail page the `Ready` stat card renders a sparkline at `width={160}`, but a card in the six-column grid is narrower than that, and nothing clips the SVG — so the trend line runs out of the card and into `Active`. With a flat ready history the line also sits on the card's bottom edge rather than in the middle of its slot.

Two separate causes, both in `Sparkline`:

1. The fixed `width` had no CSS ceiling, so the SVG overflowed any narrower container.
2. For a flat series (`max === min`) the normalisation fell through to `span = 1`, giving `y = pad + 1 * innerH` — every point pinned to the bottom of the viewBox, despite the component comment stating a flat series draws a centered horizontal line.

## Change

- `max-w-full` on the SVG so a fixed-width sparkline scales down inside a narrower container.
- Center a flat series: `max === min ? height / 2 : ...`.

Both fixes are in the shared component, so the trend columns on the queues list and overview pages get them too.

## Tests

Two cases added to `tests/frontend/sparkline.test.tsx` (flat series centered, `max-w-full` present). `npm run test` and `npm run typecheck` pass in `packages/dashboard`.