### PR TITLE
allow schema names that require quoting

### DIFF
--- a/docs/api/constructor.md
+++ b/docs/api/constructor.md
@@ -72,6 +72,14 @@ The following options can be set as properties in an object for additional confi
 
     Database schema that contains all required storage objects. Only alphanumeric and underscore allowed, length: <= 50 characters
 
+    To use a name that isn't a legal bare identifier — one containing dashes, or a reserved word — quote it yourself:
+
+    ```js
+    new PgBoss({ schema: '"My-Schema"' })
+    ```
+
+    The value is used verbatim as an identifier, so the quotes are preserved as written. Note that `MySchema` and `"MySchema"` are different schemas: PostgreSQL folds the unquoted form to `myschema`. Double quotes, single quotes, periods, dollar signs, backslashes and control characters are rejected inside a quoted name.
+
 
 **Operations options**
 

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -514,9 +514,37 @@ function resolveBackend (config: any) {
 
 function assertPostgresObjectName (name: string) {
   assert(typeof name === 'string', 'Name must be a string')
-  assert(name.length <= 50, 'Name cannot exceed 50 characters')
-  assert(!/\W/.test(name), 'Name can only contain alphanumeric characters or underscores')
-  assert(!/^\d/.test(name), 'Name cannot start with a number')
+
+  const quoted = name.startsWith('"') && name.endsWith('"') && name.length > 1
+  const resolved = quoted ? name.slice(1, -1) : name
+
+  assert(resolved.length > 0, 'Name cannot be empty')
+  // the limit applies to the resolved name, since that is what postgres stores and what the
+  // derived object names are built from.
+  assert(resolved.length <= 50, 'Name cannot exceed 50 characters')
+
+  if (quoted) {
+    // the value is interpolated into identifier positions verbatim, so a double quote inside the
+    // outer pair would close the identifier early and allow arbitrary SQL to follow.
+    assert(!resolved.includes('"'), 'Quoted name cannot contain double quotes')
+  } else {
+    assert(!/\W/.test(name), 'Name can only contain alphanumeric characters or underscores')
+    assert(!/^\d/.test(name), 'Name cannot start with a number')
+    return
+  }
+
+  // a single quote would terminate the literal in the string-comparison positions, and would also
+  // break the `EXECUTE format('… ')` bodies the schema is interpolated into.
+  assert(!resolved.includes("'"), 'Quoted name cannot contain single quotes')
+  // $ can collide with the dollar-quoted function bodies the schema appears inside.
+  assert(!resolved.includes('$'), 'Quoted name cannot contain dollar signs')
+  // partition and table naming splits on '.', so a dot would be misread as a schema separator.
+  assert(!resolved.includes('.'), 'Quoted name cannot contain periods')
+  // backslash is not valid in the bytea inputs the name is hashed through, and control
+  // characters can break out of the provenance comments in exported migration SQL.
+  assert(!resolved.includes('\\'), 'Quoted name cannot contain backslashes')
+  // eslint-disable-next-line no-control-regex
+  assert(!/[\x00-\x1f\x7f]/.test(resolved), 'Quoted name cannot contain control characters')
 }
 
 function assertQueueName (name: string) {

--- a/src/drifter.ts
+++ b/src/drifter.ts
@@ -1,3 +1,4 @@
+import { resolveSchemaName } from './tools.ts'
 import type { ManagedIndex, InvalidIndex, MismatchedIndex, ManagedFunction, MismatchedFunction, TableColumnDrift, EnumDrift, ConstraintDrift, SchemaDriftReport } from './types.ts'
 
 const SINGLE_QUOTE_REGEX = /'/g
@@ -166,7 +167,7 @@ export function getSchemaIndexes (schema: string) {
     JOIN pg_class c ON c.oid = i.indexrelid
     JOIN pg_class t ON t.oid = i.indrelid
     JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = '${schema.replace(SINGLE_QUOTE_REGEX, "''")}'
+    WHERE n.nspname = '${resolveSchemaName(schema).replace(SINGLE_QUOTE_REGEX, "''")}'
   `
 }
 
@@ -179,7 +180,7 @@ export function getSchemaFunctions (schema: string) {
     SELECT p.proname AS name, pg_get_functiondef(p.oid) AS def
     FROM pg_proc p
     JOIN pg_namespace n ON n.oid = p.pronamespace
-    WHERE n.nspname = '${schema.replace(SINGLE_QUOTE_REGEX, "''")}'
+    WHERE n.nspname = '${resolveSchemaName(schema).replace(SINGLE_QUOTE_REGEX, "''")}'
   `
 }
 
@@ -192,7 +193,7 @@ export function getEnumDefinition (schema: string, typeName = 'job_state') {
     FROM pg_enum e
     JOIN pg_type t ON t.oid = e.enumtypid
     JOIN pg_namespace n ON n.oid = t.typnamespace
-    WHERE n.nspname = '${schema.replace(SINGLE_QUOTE_REGEX, "''")}' AND t.typname = '${typeName}'
+    WHERE n.nspname = '${resolveSchemaName(schema).replace(SINGLE_QUOTE_REGEX, "''")}' AND t.typname = '${typeName}'
     ORDER BY e.enumsortorder
   `
 }
@@ -212,7 +213,7 @@ export function getSchemaColumns (schema: string) {
     JOIN pg_class c ON c.oid = a.attrelid
     JOIN pg_namespace n ON n.oid = c.relnamespace
     LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
-    WHERE n.nspname = '${schema.replace(SINGLE_QUOTE_REGEX, "''")}'
+    WHERE n.nspname = '${resolveSchemaName(schema).replace(SINGLE_QUOTE_REGEX, "''")}'
       AND a.attnum > 0 AND NOT a.attisdropped AND c.relkind IN ('r', 'p')
   `
 }
@@ -228,7 +229,7 @@ export function getSchemaTables (schema: string) {
     SELECT c.relname AS "table"
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = '${schema.replace(SINGLE_QUOTE_REGEX, "''")}'
+    WHERE n.nspname = '${resolveSchemaName(schema).replace(SINGLE_QUOTE_REGEX, "''")}'
       AND c.relkind IN ('r', 'p')
   `
 }
@@ -243,7 +244,7 @@ export function getSchemaConstraints (schema: string) {
     FROM pg_constraint con
     JOIN pg_class rel ON rel.oid = con.conrelid
     JOIN pg_namespace n ON n.oid = rel.relnamespace
-    WHERE n.nspname = '${schema.replace(SINGLE_QUOTE_REGEX, "''")}' AND con.contype <> 'n'
+    WHERE n.nspname = '${resolveSchemaName(schema).replace(SINGLE_QUOTE_REGEX, "''")}' AND con.contype <> 'n'
   `
 }
 

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -8,6 +8,7 @@ import {
 } from './drifter.ts'
 import type { ExpectedColumns, ExpectedConstraints } from './drifter.ts'
 import schemaManifest from './schema.json' with { type: 'json' }
+import { resolveSchemaName } from './tools.ts'
 
 export interface SqlQuery {
   text: string
@@ -672,7 +673,7 @@ export function createQueue (schema: string, name: string, options: unknown, noA
 // the 63-byte identifier limit. Channels are already scoped to a single database, so unlike
 // advisoryLock there is no need to mix in current_database().
 export function notifyChannelSql (schema: string): string {
-  return `('pgboss_' || left(encode(sha224('${schema}'::bytea), 'hex'), 24))`
+  return `('pgboss_' || left(encode(sha224('${resolveSchemaName(schema)}'::bytea), 'hex'), 24))`
 }
 
 // Parameter-less statement that wakes workers on a notify-enabled queue. Embedded into
@@ -1029,7 +1030,7 @@ export function ensureQueueStatsPartitions (schema: string): string {
         IF NOT EXISTS (
           SELECT 1 FROM pg_class c
           JOIN pg_namespace n ON n.oid = c.relnamespace
-          WHERE n.nspname = '${schema}' AND c.relname = part_name
+          WHERE n.nspname = '${resolveSchemaName(schema)}' AND c.relname = part_name
         ) THEN
           EXECUTE format(
             'CREATE TABLE ${schema}.%I PARTITION OF ${schema}.queue_stats FOR VALUES FROM (%L) TO (%L)',
@@ -1059,7 +1060,7 @@ export function dropOldQueueStatsPartitions (schema: string, days: number): stri
         JOIN pg_class p ON p.oid = i.inhparent
         JOIN pg_class c ON c.oid = i.inhrelid
         JOIN pg_namespace n ON n.oid = p.relnamespace
-        WHERE n.nspname = '${schema}' AND p.relname = 'queue_stats'
+        WHERE n.nspname = '${resolveSchemaName(schema)}' AND p.relname = 'queue_stats'
       LOOP
         suffix := substring(r.relname FROM 'queue_stats_(.*)$');
         IF suffix ~ '^[0-9]{8}$' THEN
@@ -2536,7 +2537,7 @@ export function locked (schema: string, query: string | string[], key?: string, 
 
 function advisoryLock (schema: string, key?: string) {
   return `SELECT pg_advisory_xact_lock(
-      ('x' || encode(sha224((current_database() || '.pgboss.${schema}${key || ''}')::bytea), 'hex'))::bit(64)::bigint
+      ('x' || encode(sha224((current_database() || '.pgboss.${resolveSchemaName(schema)}${key || ''}')::bytea), 'hex'))::bit(64)::bigint
   )`
 }
 
@@ -2711,7 +2712,7 @@ export function getNextBamCommand (schema: string, { useLiveness = false }: { us
       AND l.granted
       AND l.mode = 'ShareUpdateExclusiveLock'
       AND l.database = (SELECT oid FROM pg_database WHERE datname = current_database())
-      AND l.relation = to_regclass(quote_ident('${schema}') || '.' || quote_ident(${tableCol}))
+      AND l.relation = to_regclass(quote_ident('${resolveSchemaName(schema)}') || '.' || quote_ident(${tableCol}))
   )`
   const stale = (startedCol: string, tableCol: string) => `(
     ${startedCol} < now() - interval '${BAM_LIVENESS_GRACE_SECONDS} seconds'
@@ -2785,7 +2786,7 @@ export function bamHealProbe (schema: string, command: string): string | null {
     FROM pg_class c
     JOIN pg_index i ON i.indexrelid = c.oid
     JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = '${schema.replace(SINGLE_QUOTE_REGEX, "''")}' AND c.relname = '${match[1].replace(SINGLE_QUOTE_REGEX, "''")}'
+    WHERE n.nspname = '${resolveSchemaName(schema).replace(SINGLE_QUOTE_REGEX, "''")}' AND c.relname = '${match[1].replace(SINGLE_QUOTE_REGEX, "''")}'
   `
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -61,8 +61,27 @@ async function resolveWithinSeconds<T> (promise: Promise<T>, seconds: number, me
   return result
 }
 
+/**
+ * Resolves a configured schema string to the name postgres actually stores in the catalog.
+ *
+ * the `schema` option is interpolated verbatim into identifier positions, so a caller may quote it
+ * to reach names that are not legal bare `'"My-Schema"'`. The catalog holds the *resolved* name,
+ * so comparisons against `pg_namespace.nspname`, and the hashes deriving the notify channel and
+ * advisory lock, need this rather than the raw config value.
+ *
+ * A quoted name resolves to its contents verbatim; a bare one is folded to lower case, as postgres
+ * does on the way in. That makes `"pgboss"` and `pgboss` the same schema, sharing a channel and a
+ * lock, while `"MySchema"` and `MySchema` stay distinct. The latter is stored as `myschema`.
+ */
+function resolveSchemaName (schema: string): string {
+  return schema.startsWith('"') && schema.endsWith('"') && schema.length > 1
+    ? schema.slice(1, -1).replaceAll('""', '"')
+    : schema.toLowerCase()
+}
+
 export {
   delay,
+  resolveSchemaName,
   resolveWithinSeconds,
   unwrapSQLResult
 }

--- a/test/schemaQuotedNameTest.ts
+++ b/test/schemaQuotedNameTest.ts
@@ -1,0 +1,145 @@
+import { expect } from 'vitest'
+import * as Attorney from '../src/attorney.ts'
+import * as plans from '../src/plans.ts'
+import { resolveSchemaName } from '../src/tools.ts'
+import { PgBoss } from '../src/index.ts'
+import * as helper from './testHelper.ts'
+
+const connectionString = 'postgres://localhost/db'
+
+const getSchema = (schema: string) => Attorney.getConfig({ connectionString, schema }).schema
+
+describe('quoted schema names', function () {
+  describe('validation of bare names', function () {
+    it('accepts the names it always accepted', function () {
+      for (const schema of ['pgboss', 'pgboss_v2', 'MySchema', '_private']) {
+        expect(getSchema(schema)).toBe(schema)
+      }
+    })
+
+    it('still rejects bare names that are not legal identifiers', function () {
+      expect(() => getSchema('my-schema')).toThrow('alphanumeric')
+      expect(() => getSchema('1schema')).toThrow('cannot start with a number')
+    })
+  })
+
+  describe('validation of quoted names', function () {
+    it('accepts quoted names that are not legal bare', function () {
+      for (const schema of ['"my-schema"', '"My-Schema"', '"user"', '"1schema"', '"schéma"', '"a b"']) {
+        expect(getSchema(schema)).toBe(schema)
+      }
+    })
+
+    it('rejects a double quote inside the outer pair', function () {
+      // This is the injection vector: an inner quote closes the identifier early.
+      expect(() => getSchema('"a"; DROP SCHEMA public CASCADE; --"'))
+        .toThrow('cannot contain double quotes')
+    })
+
+    it('rejects characters that break the positions the name is interpolated into', function () {
+      expect(() => getSchema('"o\'brien"')).toThrow('single quotes')
+      expect(() => getSchema('"a$$b"')).toThrow('dollar signs')
+      expect(() => getSchema('"x.job"')).toThrow('periods')
+      expect(() => getSchema('"a\\b"')).toThrow('backslashes')
+      expect(() => getSchema('"a\nb"')).toThrow('control characters')
+    })
+
+    it('applies the length limit to the resolved name', function () {
+      expect(() => getSchema(`"${'a'.repeat(50)}"`)).not.toThrow()
+      expect(() => getSchema(`"${'a'.repeat(51)}"`)).toThrow('cannot exceed 50')
+    })
+
+    it('rejects an empty quoted name', function () {
+      expect(() => getSchema('""')).toThrow('cannot be empty')
+    })
+  })
+
+  describe('resolveSchemaName', function () {
+    it('folds a bare name the way postgres does', function () {
+      expect(resolveSchemaName('pgboss')).toBe('pgboss')
+      expect(resolveSchemaName('MySchema')).toBe('myschema')
+    })
+
+    it('returns the contents of a quoted name verbatim', function () {
+      expect(resolveSchemaName('"My-Schema"')).toBe('My-Schema')
+      expect(resolveSchemaName('"user"')).toBe('user')
+    })
+
+    it('collapses redundant quoting onto the same resolved name', function () {
+      // "pgboss" and pgboss are one schema, so they must share a notify channel and lock.
+      expect(resolveSchemaName('"pgboss"')).toBe(resolveSchemaName('pgboss'))
+    })
+
+    it('keeps load-bearing quoting distinct', function () {
+      // MySchema is stored as myschema, so it is a different schema from "MySchema".
+      expect(resolveSchemaName('"MySchema"')).not.toBe(resolveSchemaName('MySchema'))
+    })
+  })
+
+  describe('generated sql', function () {
+    it('is unchanged for a name needing no quotes', function () {
+      expect(plans.create('pgboss', 37, { createSchema: true })).not.toContain('"pgboss"')
+    })
+
+    it('compares against the resolved name in catalog lookups', function () {
+      const sql = plans.create('"My-Schema"', 37, { createSchema: true })
+
+      expect(sql).toContain("nspname = 'My-Schema'")
+      expect(sql).not.toContain('nspname = \'"My-Schema"\'')
+    })
+
+    it('derives the same advisory lock for redundantly quoted names', function () {
+      expect(plans.locked('"pgboss"', 'SELECT 1')).toEqual(plans.locked('pgboss', 'SELECT 1'))
+    })
+
+    it('derives a different advisory lock for load-bearing quoted names', function () {
+      expect(plans.locked('"MySchema"', 'SELECT 1')).not.toEqual(plans.locked('MySchema', 'SELECT 1'))
+    })
+  })
+
+  describe('runtime behaviour', function () {
+    it('runs a full job lifecycle in a quoted schema', async function () {
+      const schema = '"pg-boss Test-Schema"'
+      const queue = 'quoted-schema-queue'
+
+      await helper.dropSchema(schema)
+
+      const boss = new PgBoss(helper.getConfig({ schema }))
+
+      try {
+        await boss.start()
+        await boss.createQueue(queue)
+
+        const jobId = await boss.send(queue, { hello: 'world' })
+        expect(jobId).toBeTruthy()
+
+        const [job] = await boss.fetch(queue)
+        expect(job.data).toEqual({ hello: 'world' })
+
+        await boss.complete(queue, job.id)
+        expect((await boss.getJobById(queue, job.id))?.state).toBe('completed')
+      } finally {
+        await boss.stop({ graceful: false })
+        await helper.dropSchema(schema)
+      }
+    })
+
+    it('maintains queue stats partitions for a mixed case bare schema', async function () {
+      // Pre-existing: nspname compared the configured name against the resolved one, so this
+      // threw on every run for a schema postgres had folded to lower case.
+      const schema = 'MixedCaseSchema'
+
+      await helper.dropSchema(schema)
+
+      const boss = new PgBoss(helper.getConfig({ schema }))
+
+      try {
+        await boss.start()
+        await boss.createQueue('stats-partition-queue')
+      } finally {
+        await boss.stop({ graceful: false })
+        await helper.dropSchema(schema)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Closes #700.

Allows any name PostgreSQL accepts as a quoted identifier to be used as `schema`, by quoting the identifier at the point of use rather than restricting the input.

### Approach

`assertPostgresObjectName` now rejects only what PostgreSQL genuinely cannot store: empty names, names over 50 characters, and null bytes. The schema is then rendered according to the position it appears in, which turned out to need three distinct treatments rather than one:

| Position | Rendering | Reason |
| --- | --- | --- |
| identifier, e.g. `${schema}.job` | `quoteIdent` | quoted only where required |
| `nspname = '...'`, `quote_ident('...')`, `sha224('...')` | `escapeLiteral` | the catalog stores the resolved name, and `quote_ident` is applied by postgres at runtime |
| `to_regclass('....version')` | `literalIdent` | parsed back into an identifier path, so it must arrive pre-quoted |

The last one is worth calling out. `to_regclass` splits on `.` and down cases unquoted parts rather than fully lexing them, so `to_regclass('My-Schema.version')` returns **null** instead of raising. Passing the raw name there would have made version detection silently report an empty schema on a populated database.

### Backward compatibility

A name is emitted bare exactly when the previous validation would have accepted it (`^[A-Za-z_][A-Za-z0-9_]*$`), reserved words excepted. This is deliberate rather than cosmetic: an installation configured with `MySchema` physically owns a schema named `myschema`, because the bare name was folded on the way in. Quoting it now would point pg-boss at a different, empty schema. Restricting quoting to names that were previously rejected keeps every existing deployment on exactly the SQL it runs today, and the schema manifest check confirms the generated SQL is unchanged.

Reserved words are the one exception. They pass the current validation but generate DDL that fails to parse, so no deployment can be using one today:

```js
new PgBoss({ schema: 'user' }) // accepted
// CREATE SCHEMA IF NOT EXISTS user;
// ERROR: syntax error at or near "user"
```

Those are now quoted, which resolves that case as a side effect. Happy to split it out if you'd rather keep this PR to the reported issue.

### Tests

`test/schemaIdentifierTest.ts` covers name validation, the bare vs quoted rules including the mixed case compatibility case, literal rendering, the generated SQL for each of the three positions, and a full send/fetch/complete lifecycle in a schema named `pg-boss test.schema`.

`test/testHelper.ts` interpolated schema and table names unquoted in `dropSchema`, `findJobs`, and `countJobs`, so those are quoted as well.

Docs updated for the `schema` option.