### PR TITLE
add exact dead-letter redrive

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -529,6 +529,25 @@ do {
 } while (moved > 0)
 ```
 
+### `redriveJob(name, id, options)`
+
+Moves one exact, un-started job out of a dead letter queue and re-creates it as a
+fresh job on its original source queue. Returns the replacement job id, or `null`
+when the selected dead-letter job is absent, currently being processed, has no
+recorded source queue, or cannot be inserted under that queue's current policy.
+
+The source job is deleted only after its replacement is inserted. Pass a custom
+`db` in `options` to compose the redrive with application audit or state changes
+inside a caller-owned transaction.
+
+`id` is the selected job's id in the dead letter queue, not its earlier
+`sourceId`. Pass `db` in `options` to execute through a custom database adapter,
+including an existing transaction.
+
+```js
+const replacementId = await boss.redriveJob('email-dlq', deadLetterJobId)
+```
+
 ### `deleteQueuedJobs(name)`
 
 Deletes all queued jobs in a queue.

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,6 +363,10 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this.#manager.redrive(name, options)
   }
 
+  redriveJob (name: string, id: string, options?: types.RedriveJobOptions): Promise<string | null> {
+    return this.#manager.redriveJob(name, id, options)
+  }
+
   deleteQueuedJobs (name: string): Promise<void> {
     return this.#manager.deleteQueuedJobs(name)
   }
@@ -569,6 +573,7 @@ export type {
   QueueResult,
   QueueStats,
   QueueStatsOptions,
+  RedriveJobOptions,
   RedriveOptions,
   Request,
   Schedule,

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1638,6 +1638,16 @@ class Manager extends EventEmitter implements types.EventsMixin {
     return result.rows[0].moved as number
   }
 
+  async redriveJob (name: string, id: string, options: types.RedriveJobOptions = {}): Promise<string | null> {
+    Attorney.assertQueueName(name)
+
+    const db = this.assertDb(options)
+    const { table } = await this.getQueueCache(name)
+    const sql = plans.redriveJob(this.config.schema, table)
+    const result = await db.executeSql(sql, [name, id])
+    return (result.rows[0]?.id as string | undefined) ?? null
+  }
+
   async cancel (name: string, id: string | string[], options: types.ConnectionOptions = {}) {
     Attorney.assertQueueName(name)
     const db = this.assertDb(options)

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -2273,6 +2273,53 @@ export function redriveJobs (schema: string, table: string): string {
   `
 }
 
+// Exact dead-letter redrive. The source row is deleted only when its replacement insert succeeds,
+// so a destination policy collision leaves the selected job available for a later decision.
+export function redriveJob (schema: string, table: string): string {
+  return `
+    WITH candidate AS (
+      SELECT j.*, gen_random_uuid() AS replacement_id,
+        q.retry_limit AS destination_retry_limit,
+        q.retry_backoff AS destination_retry_backoff,
+        q.retry_delay AS destination_retry_delay,
+        q.retry_delay_max AS destination_retry_delay_max,
+        q.expire_seconds AS destination_expire_seconds,
+        q.retention_seconds AS destination_retention_seconds,
+        q.deletion_seconds AS destination_deletion_seconds,
+        q.policy AS destination_policy
+      FROM ${schema}.${table} j
+      JOIN ${schema}.queue q ON q.name = j.source_name
+      WHERE j.name = $1
+        AND j.id = $2
+        AND j.state < '${JOB_STATES.active}'
+      FOR UPDATE OF j SKIP LOCKED
+    ),
+    ins AS (
+      INSERT INTO ${schema}.job
+        (id, name, data, priority, retry_limit, retry_backoff, retry_delay, retry_delay_max,
+         expire_seconds, keep_until, deletion_seconds, policy, singleton_key, heartbeat_seconds)
+      SELECT c.replacement_id, c.source_name, c.data, c.priority,
+        c.destination_retry_limit, c.destination_retry_backoff, c.destination_retry_delay,
+        c.destination_retry_delay_max, c.destination_expire_seconds,
+        now() + c.destination_retention_seconds * interval '1s',
+        c.destination_deletion_seconds, c.destination_policy, c.singleton_key, c.heartbeat_seconds
+      FROM candidate c
+      ON CONFLICT DO NOTHING
+      RETURNING id
+    ),
+    deleted AS (
+      DELETE FROM ${schema}.${table} j
+      USING candidate c, ins i
+      WHERE j.id = c.id
+        AND i.id = c.replacement_id
+      RETURNING j.id
+    )
+    SELECT i.id
+    FROM ins i
+    WHERE EXISTS (SELECT 1 FROM deleted)
+  `
+}
+
 export function deletion (schema: string, table: string, queues: string[], noAdvisoryLocks?: boolean): string {
   const sql = `
     DELETE FROM ${schema}.${table}

--- a/src/types.ts
+++ b/src/types.ts
@@ -446,6 +446,8 @@ export interface RedriveOptions extends ConnectionOptions {
   limit?: number;
 }
 
+export type RedriveJobOptions = ConnectionOptions
+
 export type InsertOptions = ConnectionOptions & { returnId?: boolean }
 
 export type SendOptions = JobOptions & QueueOptions & ConnectionOptions

--- a/test/adapterTest.ts
+++ b/test/adapterTest.ts
@@ -140,6 +140,35 @@ describe('knex adapter', () => {
     helper.assertTruthy(job)
     expect(job.data).toEqual({ v: 2 })
   })
+
+  it('should roll back an exact redrive through a knex transaction', async () => {
+    const boss = ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+    if (!db) db = knex({ client: 'pg', connection: connString })
+
+    const deadLetter = `${ctx.schema}_dlq`
+    await boss.createQueue(deadLetter)
+    await boss.createQueue(ctx.schema, { deadLetter })
+
+    const sourceId = await boss.send(ctx.schema, { selected: true }, { retryLimit: 0 })
+    helper.assertTruthy(sourceId)
+    await boss.fetch(ctx.schema)
+    await boss.fail(ctx.schema, sourceId)
+
+    const [source] = await boss.findJobs(deadLetter)
+    helper.assertTruthy(source)
+
+    let replacementId: string | null = null
+    try {
+      await db.transaction(async (trx) => {
+        replacementId = await boss.redriveJob(deadLetter, source.id, { db: fromKnex(trx) })
+        throw new Error('force rollback')
+      })
+    } catch {}
+
+    helper.assertTruthy(replacementId)
+    await expect(boss.findJobs(deadLetter, { id: source.id })).resolves.toHaveLength(1)
+    await expect(boss.findJobs(ctx.schema, { id: replacementId })).resolves.toEqual([])
+  })
 })
 
 describe('kysely adapter', () => {

--- a/test/failureTest.ts
+++ b/test/failureTest.ts
@@ -328,6 +328,42 @@ describe('failure', function () {
     expect(redrivenMeta.sourceName).toBeNull()
   })
 
+  it('redriveJob moves only the selected dead-lettered job and returns its replacement id', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+    const deadLetter = `${ctx.schema}_dlq`
+
+    await ctx.boss.createQueue(deadLetter)
+    await ctx.boss.createQueue(ctx.schema, { deadLetter })
+
+    const firstSourceId = await ctx.boss.send(ctx.schema, { selected: false }, { retryLimit: 0 })
+    const secondSourceId = await ctx.boss.send(ctx.schema, { selected: true }, { retryLimit: 0 })
+    assertTruthy(firstSourceId)
+    assertTruthy(secondSourceId)
+
+    await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.fail(ctx.schema, firstSourceId)
+    await ctx.boss.fail(ctx.schema, secondSourceId)
+
+    const deadLetterJobs = await ctx.boss.findJobs<{ selected: boolean }>(deadLetter)
+    const selectedDeadLetter = deadLetterJobs.find(job => job.sourceId === secondSourceId)
+    const unselected = deadLetterJobs.find(job => job.sourceId === firstSourceId)
+    assertTruthy(selectedDeadLetter)
+    assertTruthy(unselected)
+
+    const replacementId = await ctx.boss.redriveJob(deadLetter, selectedDeadLetter.id)
+
+    assertTruthy(replacementId)
+    expect(replacementId).not.toBe(selectedDeadLetter.id)
+    await expect(ctx.boss.findJobs(deadLetter, { id: selectedDeadLetter.id })).resolves.toEqual([])
+    await expect(ctx.boss.findJobs(deadLetter, { id: unselected.id })).resolves.toHaveLength(1)
+    await expect(ctx.boss.findJobs(ctx.schema, { id: replacementId })).resolves.toMatchObject([
+      { id: replacementId, data: { selected: true }, retryCount: 0, sourceName: null }
+    ])
+    await expect(ctx.boss.redriveJob(deadLetter, selectedDeadLetter.id)).resolves.toBeNull()
+  })
+
   it('redrive routes each job back to its own source queue', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
 


### PR DESCRIPTION
## What changed

- add `redriveJob(name, deadLetterJobId, options)` for one exact dead-letter row
- return the fresh replacement job ID, or `null` when the selected row is not eligible
- accept the existing `db` option so the redrive composes inside a caller-owned transaction
- preserve the source row when the replacement insert cannot succeed

## Why

The existing batch `redrive()` API selects jobs oldest-first through `limit`; it cannot safely target an operator-selected dead-letter job. Applications that require audited, single-job recovery need a native exact-ID primitive without reaching into pg-boss tables themselves.

The `id` argument is explicitly the selected row's ID in the dead-letter queue, not its earlier `sourceId` metadata.

## Implementation

The PostgreSQL plan locks only the selected eligible row, creates a fresh replacement using the destination queue's current policy, deletes the dead-letter row only after insertion succeeds, and returns the replacement UUID. Passing a custom `db` keeps the operation within that adapter's existing transaction.

## Validation

- `npm run test:pglite -- test/failureTest.ts` — 19 passed, 1 skipped
- `npm test -- test/adapterTest.ts -t "should roll back an exact redrive through a knex transaction"` — passed against PostgreSQL
- TypeScript, ESLint, and schema-manifest checks pass as part of those commands
