### PR TITLE
Fix group id and tier not persisted by insert()

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1142,8 +1142,11 @@ class Manager extends EventEmitter implements types.EventsMixin {
         blocked,
         blocking,
         pendingDependencies,
-        ...rest
+        group,
+        ...jobFields
       } = j as types.JobInsert & { blocked?: unknown, blocking?: unknown, pendingDependencies?: unknown }
+
+      const rest = { ...jobFields, groupId: group?.id, groupTier: group?.tier }
 
       if (dataById) {
         // Best-effort spy bookkeeping, only reached when __test__enableSpies is set (a test-intended

--- a/test/insertTest.ts
+++ b/test/insertTest.ts
@@ -151,6 +151,22 @@ describe('insert', function () {
     expect(job!.deadLetter).toBe(input.deadLetter)
   })
 
+  it('should persist group id and tier', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const input = {
+      id: randomUUID(),
+      group: { id: 'group1', tier: 'tier1' }
+    }
+
+    await ctx.boss.insert(ctx.schema, [input])
+
+    const job = await ctx.boss.getJobById(ctx.schema, input.id)
+
+    expect(job!.groupId).toBe(input.group.id)
+    expect(job!.groupTier).toBe(input.group.tier)
+  })
+
   it('should attribute insert spy data to the right id when ON CONFLICT skips a job', async function () {
     // insertJobs ends in ON CONFLICT DO NOTHING; on a short-policy queue a duplicate singletonKey is
     // skipped, so the returned rows no longer align positionally with the input jobs. The spy must


### PR DESCRIPTION
Hello!

While testing a queue that must run sequentially for each tenant id (using `groupConcurrency`), my team noticed the group.id option was not being saved to the job table when using the `insert` function.

Looking at the code, we found that `send` has special handling for the `group` options that doesn't happen on `insert`.

This PR copies that logic and adds a regression test.

Thank you!