### PR TITLE
Fix startAfter rejecting ISO 8601 date times without a Z suffix

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -89,10 +89,23 @@ All retry, expiration, and retention options can also be set on the queue and wi
 
 * **startAfter** int, string, or Date
   * int: seconds to delay starting the job
-  * string: Start after a UTC Date time string in 8601 format
+  * string: Start after an ISO 8601 date time string, or after a relative interval
   * Date: Start after a Date object
 
     Default: 0
+
+  A string that begins with an ISO 8601 calendar date (`YYYY-MM-DD`) is read as a date time. If it
+  carries an explicit zone designator (`Z` or an offset such as `+05:30`) it resolves to that exact
+  instant; without one it is resolved in the database's time zone.
+
+  Any other string is read as a relative delay from now, using Postgres interval syntax — so
+  `'5 minutes'`, `'1 hour'`, `'PT1H'` and `'90'` (bare seconds) are all valid.
+
+  ```js
+  await boss.send('email-reminder', { userId: 123 }, { startAfter: '2027-01-01T08:00:00Z' })
+  await boss.send('email-reminder', { userId: 123 }, { startAfter: '2027-01-01T13:30:00+05:30' })
+  await boss.send('email-reminder', { userId: 123 }, { startAfter: '1 hour' })
+  ```
 
 **Group options**
 
@@ -163,7 +176,9 @@ Send a job that should start after a number of seconds from now, or after a spec
 
 This is a convenience version of `send()` with the `startAfter` option assigned.
 
-`value`: int: seconds | string: ISO date string | Date
+`value`: int: seconds | string: ISO 8601 date time or a relative interval | Date
+
+See [`startAfter`](#send-name-data-options) for how a string is interpreted.
 
 ```js
 // start in 5 minutes
@@ -171,6 +186,9 @@ await boss.sendAfter('email-reminder', { userId: 123 }, null, 300)
 
 // start at a specific date and time
 await boss.sendAfter('email-reminder', { userId: 123 }, null, new Date('2027-01-01T08:00:00Z'))
+
+// same instant, expressed with an offset instead of Z
+await boss.sendAfter('email-reminder', { userId: 123 }, null, '2027-01-01T13:30:00+05:30')
 ```
 
 ### `sendThrottled(name, data, options, seconds, key)`

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1636,6 +1636,21 @@ export function restoreJobs (schema: string, table: string) {
   `
 }
 
+// A `startAfter` string is either an absolute date time or a delay expressed as a Postgres
+// interval. A trailing 'Z' has always marked a date time; a leading ISO 8601 calendar date
+// (YYYY-MM-DD) marks one as well, which is what lets the other 8601 zone designators through
+// ('+00:00', '+05:30', '-08:00') along with zone-less and date-only strings — all of which
+// used to reach the interval cast and fail as 'invalid input syntax for type interval'.
+//
+// Recognition is only ever widened, so anything that resolves as an interval today still
+// does: bare seconds ('0', '300'), phrases ('5 minutes'), ISO 8601 durations ('PT1H') and
+// the year-month form ('2027-01', which Postgres reads as 2027 years 1 mon) carry neither
+// mark. A date time with an explicit offset resolves to that exact instant; one with no zone
+// designator is resolved by Postgres in the database's time zone.
+function isDateTimeString (expression: string) {
+  return `(right(${expression}, 1) = 'Z' OR ${expression} ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}')`
+}
+
 interface InsertJobsOptions {
   table: string
   name: string
@@ -1702,7 +1717,7 @@ export function insertJobs (schema: string, { table, name, returnId = true, noti
     FROM (
       SELECT *,
         CASE
-          WHEN right("startAfter", 1) = 'Z' THEN CAST("startAfter" as timestamp with time zone)
+          WHEN ${isDateTimeString('"startAfter"')} THEN CAST("startAfter" as timestamp with time zone)
           ELSE now() + CAST(COALESCE("startAfter",'0') as interval)
           END as start_after
       FROM json_to_recordset($1::json) as x (
@@ -2321,11 +2336,11 @@ export function updateJob (schema: string, table: string, name: string, by: 'id'
     ? `ORDER BY job.created_on ${match === 'oldest' ? 'ASC' : 'DESC'} LIMIT 1`
     : ''
 
-  // Resolve the incoming startAfter the same way insertJobs does (absolute 'Z' timestamp vs.
+  // Resolve the incoming startAfter the same way insertJobs does (absolute date time vs.
   // relative interval), falling back to the row's current start_after when not supplied.
   const resolvedStartAfter = `
         CASE WHEN jsonb_exists(o.data, 'startAfter')
-          THEN CASE WHEN right(o.data->>'startAfter', 1) = 'Z'
+          THEN CASE WHEN ${isDateTimeString("o.data->>'startAfter'")}
                  THEN (o.data->>'startAfter')::timestamptz
                  ELSE now() + CAST(o.data->>'startAfter' AS interval) END
           ELSE job.start_after END`

--- a/test/delayTest.ts
+++ b/test/delayTest.ts
@@ -1,5 +1,6 @@
 import { expect } from 'vitest'
 import * as helper from './testHelper.ts'
+import { assertTruthy } from './testHelper.ts'
 import { delay } from '../src/tools.ts'
 import { ctx } from './hooks.ts'
 
@@ -84,5 +85,98 @@ describe('delayed jobs', function () {
     const [job2] = await ctx.boss.fetch(ctx.schema)
 
     expect(job2).toBeTruthy()
+  })
+
+  // The instant 2027-01-01T08:00:00Z, written in each of the ISO 8601 zone designators.
+  // Only the 'Z' spelling used to be recognized as a date; the rest fell through to an
+  // interval cast and threw 'invalid input syntax for type interval'.
+  const INSTANT = '2027-01-01T08:00:00.000Z'
+  const zoned = [
+    ['Z', '2027-01-01T08:00:00Z'],
+    ['a zero UTC offset', '2027-01-01T08:00:00+00:00'],
+    ['a positive offset', '2027-01-01T13:30:00+05:30'],
+    ['a negative offset', '2027-01-01T00:00:00-08:00']
+  ] as const
+
+  for (const [label, startAfter] of zoned) {
+    it(`should resolve a date time string with ${label} to the same instant`, async function () {
+      ctx.boss = await helper.start(ctx.bossConfig)
+
+      const id = await ctx.boss.send(ctx.schema, null, { startAfter })
+      assertTruthy(id)
+
+      const job = await ctx.boss.getJobById(ctx.schema, id)
+      assertTruthy(job)
+      expect(new Date(job.startAfter).toISOString()).toBe(INSTANT)
+    })
+  }
+
+  it('should resolve a date time string with an offset passed to sendAfter()', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const id = await ctx.boss.sendAfter(ctx.schema, { something: 1 }, {}, '2027-01-01T13:30:00+05:30')
+    assertTruthy(id)
+
+    const job = await ctx.boss.getJobById(ctx.schema, id)
+    assertTruthy(job)
+    expect(new Date(job.startAfter).toISOString()).toBe(INSTANT)
+  })
+
+  // A string with no zone designator is resolved by Postgres in the database's time zone, so
+  // the exact instant depends on that setting. Asserting within a day of the nominal UTC
+  // instant keeps this independent of the server's time zone (max offset is ±14h) while still
+  // proving the string parsed as a date time rather than being rejected as an interval.
+  const ONE_DAY = 24 * 60 * 60 * 1000
+  for (const [label, startAfter, nominal] of [
+    ['a date time string with no zone', '2027-01-01T08:00:00', '2027-01-01T08:00:00Z'],
+    ['a space-separated date time string', '2027-01-01 08:00:00', '2027-01-01T08:00:00Z'],
+    ['a date-only string', '2027-01-01', '2027-01-01T00:00:00Z']
+  ] as const) {
+    it(`should accept ${label}`, async function () {
+      ctx.boss = await helper.start(ctx.bossConfig)
+
+      const id = await ctx.boss.send(ctx.schema, null, { startAfter })
+      assertTruthy(id)
+
+      const job = await ctx.boss.getJobById(ctx.schema, id)
+      assertTruthy(job)
+
+      const drift = Math.abs(new Date(job.startAfter).getTime() - new Date(nominal).getTime())
+      expect(drift).toBeLessThanOrEqual(ONE_DAY)
+    })
+  }
+
+  // Forms that reached the date time path only via the trailing 'Z' check, so they keep
+  // working: ISO 8601 basic format, and a value with leading whitespace.
+  for (const [label, startAfter] of [
+    ['in ISO 8601 basic format', '20270101T080000Z'],
+    ['with leading whitespace', '  2027-01-01T08:00:00Z']
+  ] as const) {
+    it(`should still resolve a date time string ${label}`, async function () {
+      ctx.boss = await helper.start(ctx.bossConfig)
+
+      const id = await ctx.boss.send(ctx.schema, null, { startAfter })
+      assertTruthy(id)
+
+      const job = await ctx.boss.getJobById(ctx.schema, id)
+      assertTruthy(job)
+      expect(new Date(job.startAfter).toISOString()).toBe(INSTANT)
+    })
+  }
+
+  // Relative interval strings must keep taking the interval path.
+  it('should still accept a relative interval string', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const before = Date.now()
+    const id = await ctx.boss.send(ctx.schema, null, { startAfter: '1 hour' })
+    assertTruthy(id)
+
+    const job = await ctx.boss.getJobById(ctx.schema, id)
+    assertTruthy(job)
+
+    const startAfterMs = new Date(job.startAfter).getTime()
+    expect(startAfterMs).toBeGreaterThan(before + 59 * 60 * 1000)
+    expect(startAfterMs).toBeLessThan(before + 61 * 60 * 1000)
   })
 })

--- a/test/updateTest.ts
+++ b/test/updateTest.ts
@@ -264,6 +264,37 @@ describe('update', function () {
       const [job] = await helper.fetchWithRetry(ctx.boss, ctx.schema)
       expect(job?.id).toBe(id)
     })
+
+    it('resolves a startAfter date time string with an offset to the same instant', async function () {
+      ctx.boss = await helper.start(ctx.bossConfig)
+
+      const id = await ctx.boss.send(ctx.schema, { v: 1 })
+      assertTruthy(id)
+
+      // the same instant as 2027-01-01T08:00:00Z, spelled with a +05:30 offset
+      await ctx.boss.update(ctx.schema, undefined, { id, startAfter: '2027-01-01T13:30:00+05:30' })
+
+      const job = await ctx.boss.getJobById(ctx.schema, id)
+      assertTruthy(job)
+      expect(new Date(job.startAfter).toISOString()).toBe('2027-01-01T08:00:00.000Z')
+    })
+
+    it('still accepts a relative interval string for startAfter', async function () {
+      ctx.boss = await helper.start(ctx.bossConfig)
+
+      const id = await ctx.boss.send(ctx.schema, { v: 1 })
+      assertTruthy(id)
+
+      const before = Date.now()
+      await ctx.boss.update(ctx.schema, undefined, { id, startAfter: '1 hour' })
+
+      const job = await ctx.boss.getJobById(ctx.schema, id)
+      assertTruthy(job)
+
+      const startAfterMs = new Date(job.startAfter).getTime()
+      expect(startAfterMs).toBeGreaterThan(before + 59 * 60 * 1000)
+      expect(startAfterMs).toBeLessThan(before + 61 * 60 * 1000)
+    })
   })
 
   describe('object API', function () {


### PR DESCRIPTION
A string `startAfter` is only treated as a date time when its **last character is `Z`**. Every other ISO 8601 spelling falls through to the interval cast and fails:

```js
await boss.send('q', {}, { startAfter: '2027-01-01T08:00:00+00:00' })
// error: invalid input syntax for type interval: "2027-01-01T08:00:00+00:00"
```

`+00:00` denotes exactly the UTC instant the option is documented to accept ("a UTC Date time string in 8601 format"), so this rejects a spelling of the documented input. The same applies to numeric offsets, zone-less date times, and date-only strings:

| `startAfter` | before | after |
| --- | --- | --- |
| `'2027-01-01T08:00:00Z'` | ✅ 08:00Z | ✅ 08:00Z |
| `'2027-01-01T08:00:00+00:00'` | ❌ interval error | ✅ 08:00Z |
| `'2027-01-01T13:30:00+05:30'` | ❌ interval error | ✅ 08:00Z |
| `'2027-01-01T00:00:00-08:00'` | ❌ interval error | ✅ 08:00Z |
| `'2027-01-01T08:00:00'` | ❌ interval error | ✅ 08:00 in the db's time zone |
| `'2027-01-01'` | ❌ interval error | ✅ midnight in the db's time zone |

The failure is easy to hit from application code, because a timestamp that has been through anything other than JS `toISOString()` — Postgres `to_char`, most date libraries' default formatting, an HTTP payload from another service — commonly carries `+00:00` rather than `Z`. The error names `interval`, a type the caller never mentioned, which makes it a confusing thing to land on.

## The fix

`startAfter` is deliberately overloaded: a date time, or a delay expressed as a Postgres interval (`'5 minutes'`, and the bare-seconds form the numeric option is coerced into). Those two have to be told apart by shape, and the trailing `Z` was doing that job.

This adds a second mark for a date time — a **leading ISO 8601 calendar date** (`YYYY-MM-DD`) — in the one helper both resolution sites now share (`insertJobs()`, covering send/sendAfter/insert/flows, and `updateJob()`, covering update/upsert; they previously carried the same check separately).

Recognition is only ever **widened**, so no string that works today changes path. That is what makes the change safe rather than merely tested:

- No valid interval can begin `YYYY-MM-DD`. Bare seconds (`'0'`, `'300'`), phrases (`'5 minutes'`), ISO 8601 durations (`'PT1H'`) and the year-month form (`'2027-01'`, which Postgres reads as *2027 years 1 mon*) all fail the new pattern and stay on the interval path. The 3-part shape is what keeps `'2027-01'` unambiguous.
- The original `Z` check is kept as an alternative rather than replaced, so anything that reached the date time path through it still does — including ISO 8601 basic format (`'20270101T080000Z'`) and values with leading whitespace, which a `^`-anchored pattern alone would have started rejecting. Both are covered by tests.

## Behavior worth a maintainer's call

A string with **no zone designator** (`'2027-01-01T08:00:00'`, `'2027-01-01'`) is resolved by Postgres in the database's time zone, since that is what casting to `timestamptz` does. It's the standard Postgres reading and it beats the current hard failure, but it is a real semantic where the docs say "UTC" — if you'd rather zone-less input be pinned to UTC, or keep being rejected, say so and I'll adjust. Everything with an explicit offset is an exact instant either way, so this only affects the two zone-less forms.

## Tests

13 tests added — `test/delayTest.ts` (send/sendAfter) and `test/updateTest.ts` (update):

- each offset spelling of the instant `2027-01-01T08:00:00Z` (`Z`, `+00:00`, `+05:30`, `-08:00`) resolves to that same instant, via `send()` and `sendAfter()`
- zone-less and date-only strings parse as date times (asserted within a day of the nominal instant, so the assertion doesn't depend on the server's time zone)
- ISO 8601 basic format and leading-whitespace values still resolve — the no-regression guarantee above
- relative interval strings (`'1 hour'`) still resolve as delays, through both `send()` and `update()`

All 13 fail on master with `invalid input syntax for type interval` and pass with the change (verified by reverting `src/plans.ts` alone and re-running).

Full suite green: **741 passed, 0 failed, 6 skipped**, `eslint` clean, `tsc --noEmit` clean, and `gen:manifest:check` reports the schema manifest unchanged (no schema object is touched — both edits are to runtime query text).

Verified against PGlite (`DB_TYPE=pglite`) rather than a local Postgres, so the standard and distributed CI legs are worth a look on this one.
