### PR TITLE
Allow an expiration of exactly 24 hours

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -56,7 +56,7 @@ Creates a new job and returns the job id.
 
 * **expireInSeconds**, number
 
-  Default: 15 minutes.  How many seconds a job may be in active state before being retried or failed. Must be >=1
+  Default: 15 minutes.  How many seconds a job may be in active state before being retried or failed. Must be >=1 and <= 86400 (24 hours)
 
 **Retention options**
 

--- a/docs/api/queues.md
+++ b/docs/api/queues.md
@@ -132,7 +132,7 @@ Actual detection time is `heartbeatSeconds` + up to `monitorIntervalSeconds` (de
 
 * **expireInSeconds**, number
 
-  Default: 15 minutes.  How many seconds a job may be in active state before being retried or failed. Must be >=1
+  Default: 15 minutes.  How many seconds a job may be in active state before being retried or failed. Must be >=1 and <= 86400 (24 hours)
 
 **Retention options**
 

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -574,7 +574,10 @@ function validateExpirationConfig (config: any) {
   assert(!('expireInSeconds' in config) || config.expireInSeconds >= 1,
     'configuration assert: expireInSeconds must be at least every second')
 
-  assert(!config.expireInSeconds || config.expireInSeconds / 60 / 60 < POLICY.MAX_EXPIRATION_HOURS, `configuration assert: expiration cannot exceed ${POLICY.MAX_EXPIRATION_HOURS} hours`)
+  // inclusive, like every other option bounded by MAX_EXPIRATION_HOURS: an expiration of exactly
+  // the maximum does not "exceed" it. this is also the value the docs recommend for the longest
+  // jobs, and the value the maintenance interval defaults to.
+  assert(!config.expireInSeconds || config.expireInSeconds / 60 / 60 <= POLICY.MAX_EXPIRATION_HOURS, `configuration assert: expiration cannot exceed ${POLICY.MAX_EXPIRATION_HOURS} hours`)
 }
 
 function validateRetryConfig (config: any) {

--- a/test/configTest.ts
+++ b/test/configTest.ts
@@ -40,6 +40,33 @@ describe('config', function () {
     })
   })
 
+  describe('expiration limit', function () {
+    const MAX_EXPIRE_SECONDS = Attorney.POLICY.MAX_EXPIRATION_HOURS * 60 * 60
+
+    it('should accept an expiration of exactly the maximum', function () {
+      expect(() => Attorney.checkSendArgs(['queue', null, { expireInSeconds: MAX_EXPIRE_SECONDS }])).not.toThrow()
+      expect(() => Attorney.validateQueueArgs({ expireInSeconds: MAX_EXPIRE_SECONDS })).not.toThrow()
+    })
+
+    it('should reject an expiration above the maximum', function () {
+      const overLimit = MAX_EXPIRE_SECONDS + 1
+      expect(() => Attorney.checkSendArgs(['queue', null, { expireInSeconds: overLimit }])).toThrow('cannot exceed')
+      expect(() => Attorney.validateQueueArgs({ expireInSeconds: overLimit })).toThrow('cannot exceed')
+    })
+
+    // The other options measured against MAX_EXPIRATION_HOURS all treat the limit as inclusive,
+    // and the default maintenance interval sits exactly on it. Expiration must agree.
+    it('should treat the limit the same way as the other options bounded by it', function () {
+      const config = { connectionString: 'postgres://localhost/db' }
+
+      for (const option of ['superviseIntervalSeconds', 'maintenanceIntervalSeconds', 'monitorIntervalSeconds', 'queueCacheIntervalSeconds']) {
+        expect(() => Attorney.getConfig({ ...config, [option]: MAX_EXPIRE_SECONDS })).not.toThrow()
+      }
+
+      expect(Attorney.getConfig(config).maintenanceIntervalSeconds).toBe(MAX_EXPIRE_SECONDS)
+    })
+  })
+
   it('should allow a 50 character custom schema name', async function () {
     const config = ctx.bossConfig
 

--- a/test/expireTest.ts
+++ b/test/expireTest.ts
@@ -100,6 +100,27 @@ describe('expire', function () {
     expect(job.state).toBe('failed')
   })
 
+  it('should persist an expiration of exactly 24 hours', async function () {
+    const expireInSeconds = 24 * 60 * 60
+
+    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+    await ctx.boss.createQueue(ctx.schema, { expireInSeconds })
+
+    const queue = await ctx.boss.getQueue(ctx.schema)
+
+    assertTruthy(queue)
+    expect(queue.expireInSeconds).toBe(expireInSeconds)
+
+    const jobId = await ctx.boss.send(ctx.schema, null, { expireInSeconds })
+
+    assertTruthy(jobId)
+    const job = await ctx.boss.getJobById(ctx.schema, jobId)
+
+    assertTruthy(job)
+    expect(job.expireInSeconds).toBe(expireInSeconds)
+  })
+
   it('should abort signal when job handler times out', async function () {
     ctx.boss = await helper.start({ ...ctx.bossConfig, monitorIntervalSeconds: 1 })
 


### PR DESCRIPTION
## The problem

`expireInSeconds: 86400` is rejected:

```js
await boss.send('q', {}, { expireInSeconds: 86400 })
// AssertionError: configuration assert: expiration cannot exceed 24 hours
```

24 hours does not exceed 24 hours. The same applies to `createQueue`/`updateQueue`, so the only way to express a one-day expiration today is `86399`.

The docs recommend the value that throws — the "Heartbeat vs expiration" table in `docs/api/queues.md`:

| Job type | `expireInSeconds` | `heartbeatSeconds` | Dead worker detected in |
| --- | --- | --- | --- |
| Very long tasks (data migration) | 86400 (24 hr) | 300-600 | ~6-11 min |

## The cause

`validateExpirationConfig` bounds the value with a strict `<`, while every other option measured against the same `POLICY.MAX_EXPIRATION_HOURS` constant uses `<=`:

| Option | Comparison | `86400` accepted |
| --- | --- | --- |
| `expireInSeconds` | `<` | no |
| `superviseIntervalSeconds` | `<=` | yes |
| `maintenanceIntervalSeconds` | `<=` | yes (and it is the **default**) |
| `monitorIntervalSeconds` | `<=` | yes |
| `queueCacheIntervalSeconds` | `<=` | yes |

All five shared the strict comparison when the cap was introduced in v10 (4b3d9f4). The interval checks were later relaxed to inclusive in 25a8b52 — the same change that made `maintenanceIntervalSeconds` default to `MAX_EXPIRATION_HOURS * 60 * 60` — and expiration was left behind. All six assertions still share the "cannot exceed N hours" wording, which reads as inclusive.

## The fix

Widen the expiration check to `<=` so it agrees with its siblings and with the wording of its own error message. The upper bound is otherwise unchanged: `86401` still throws.

Also documented the maximum next to the existing "Must be >=1" in `docs/api/jobs.md` and `docs/api/queues.md` — the bound was never written down, which is what left the boundary ambiguous.

## Tests

- `test/configTest.ts` — a new `expiration limit` block: exactly the maximum is accepted by both `send()` and queue args, one second above it is still rejected, and a consistency test pinning that the four sibling options accept `86400` and that the maintenance default sits exactly on the limit.
- `test/expireTest.ts` — an end-to-end check that `expireInSeconds: 86400` survives to the database, asserted through `getQueue()` and `getJobById()`.

The first test fails on `master` with `configuration assert: expiration cannot exceed 24 hours`; the other two pass before and after, documenting the behavior the fix aligns to.

Full suite on PGlite: **760 passed**, plus lint and `tsc --noEmit` clean. One unrelated file (`queueStatsHistoryTest`) hit a 10s `beforeEach` hook timeout under parallel load and passes on its own.