### PR TITLE
Reject an unusable schedule time zone and isolate cron evaluation failures

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -32,6 +32,7 @@ boss.on('warning', ({ message, data }) => {
 | `queue_backlog` | A queue has exceeded its warning threshold | `name`, `queuedCount`, `warningQueued` |
 | `clock_skew` | Database clock is out of sync with application server | `seconds`, `direction` |
 | `listen_notify_unavailable` | `useListenNotify` is enabled but a `LISTEN/NOTIFY` listener could not be established (for example a `db` adapter without `listen`, or PgBouncer transaction pooling); pg-boss continues with polling only | `type`, `error` |
+| `invalid_schedule` | A stored schedule could not be evaluated (for example an unusable `timezone` written by an older release) and was skipped for this cron pass; the remaining schedules are unaffected | `queue`, `key`, `cron`, `timezone` |
 
 ### Warning Persistence
 

--- a/docs/api/scheduling.md
+++ b/docs/api/scheduling.md
@@ -43,7 +43,8 @@ Schedules a job to be sent to the specified queue based on a cron expression. If
 
 * **tz**
 
-  An optional time zone name. If not specified, the default is UTC.
+  An optional time zone name. If not specified, the default is UTC. An unrecognized time zone is
+  rejected by `schedule()`, so a typo cannot be stored and then fail on the cron pass.
 
 * **key**
   

--- a/docs/sql/warning-table.md
+++ b/docs/sql/warning-table.md
@@ -15,7 +15,7 @@ CREATE TABLE pgboss.warning (
 | Column | Description |
 |--------|-------------|
 | `id` | Auto-incrementing primary key |
-| `type` | Warning type: `slow_query`, `queue_backlog`, or `clock_skew` |
+| `type` | Warning type: `slow_query`, `queue_backlog`, `clock_skew`, or `invalid_schedule` |
 | `message` | Human-readable warning message |
 | `data` | JSON object with warning-specific details |
 | `created_on` | Timestamp when the warning was recorded |

--- a/src/timekeeper.ts
+++ b/src/timekeeper.ts
@@ -25,8 +25,29 @@ const WARNINGS = {
 }
 
 const WARNING_TYPES = {
-  CLOCK_SKEW: 'clock_skew'
+  CLOCK_SKEW: 'clock_skew',
+  INVALID_SCHEDULE: 'invalid_schedule'
 } as const
+
+/**
+ * Asserts that `tz` is a time zone cron evaluation can actually use.
+ *
+ * cron-parser validates `tz` lazily: parsing without a reference date never constructs a CronDate,
+ * so every string is accepted and a bad zone only surfaces later, when a date is computed, as an
+ * opaque "CronDate: unhandled timestamp". Passing a reference date here forces that construction so
+ * a typo like 'America/New_Yrok' is rejected by schedule() rather than persisted to the schedule
+ * table. Deliberately reuses cron-parser rather than an independent Intl check, so what schedule()
+ * accepts is exactly what the cron pass can evaluate.
+ *
+ * The caller validates the cron expression first, so a failure here is attributable to the zone.
+ */
+function assertTimezone (tz: string): void {
+  try {
+    CronExpressionParser.parse('* * * * *', { tz, strict: false, currentDate: new Date() })
+  } catch {
+    throw new Error(`Unknown or unsupported time zone: ${tz}`)
+  }
+}
 
 class Timekeeper extends EventEmitter implements types.EventsMixin {
   db: types.IDatabase
@@ -178,9 +199,34 @@ class Timekeeper extends EventEmitter implements types.EventsMixin {
   async cron () {
     const schedules = await this.getSchedules()
 
-    const scheduled = schedules
-      .filter(i => this.shouldSendIt(i.cron, i.timezone))
-      .map(({ name, key, data, options }): types.JobInsert => ({ data: { name, data, options }, singletonKey: `${name}__${key}`, singletonSeconds: 60 }))
+    const scheduled: types.JobInsert[] = []
+
+    for (const { name, key, data, options, cron, timezone } of schedules) {
+      let due: boolean
+
+      try {
+        due = this.shouldSendIt(cron, timezone)
+      } catch (err) {
+        // Evaluating one row must not decide the fate of the others. schedule() now rejects an
+        // unusable time zone, but a row written by an earlier release — or straight into the table —
+        // still throws here. This was a single filter() over every schedule, so one such row
+        // propagated out of cron() and silently stopped scheduling for every queue in the
+        // deployment, on every pass, until someone found the row. Skip it and warn instead, naming
+        // the schedule so it is actually fixable.
+        await emitAndPersistWarning(
+          this.warningContext,
+          WARNING_TYPES.INVALID_SCHEDULE,
+          `Warning: schedule for queue "${name}" (key "${key}") could not be evaluated and was skipped: ${(err as Error).message}`,
+          { queue: name, key, cron, timezone }
+        )
+
+        continue
+      }
+
+      if (due) {
+        scheduled.push({ data: { name, data, options }, singletonKey: `${name}__${key}`, singletonSeconds: 60 })
+      }
+    }
 
     if (scheduled.length > 0 && !this.stopped) {
       await this.manager.insert(QUEUES.SEND_IT, scheduled)
@@ -230,7 +276,9 @@ class Timekeeper extends EventEmitter implements types.EventsMixin {
   async schedule (name: string, cron: string, data?: unknown, options: types.ScheduleOptions = {}): Promise<void> {
     const { tz = 'UTC', key = '', ...rest } = options
 
+    // cron expression first, so a bad expression reports as one rather than as a time zone problem
     CronExpressionParser.parse(cron, { tz, strict: false })
+    assertTimezone(tz)
 
     Attorney.checkSendArgs([name, data, { ...rest }])
     Attorney.assertKey(key)

--- a/test/scheduleTest.ts
+++ b/test/scheduleTest.ts
@@ -429,6 +429,40 @@ describe('schedule', function () {
     expect(schedules.length).toBe(1)
     expect(schedules[0].cron).toBe('* * * * *')
   })
+
+  it('a stored schedule with an unusable time zone does not stop other schedules from firing', async function () {
+    const config = {
+      ...ctx.bossConfig,
+      cronMonitorIntervalSeconds: 1,
+      cronWorkerIntervalSeconds: 1,
+      schedule: true
+    }
+
+    ctx.boss = await helper.start(config)
+
+    await ctx.boss.schedule(ctx.schema, '* * * * *')
+
+    // A row as an earlier release would have left it: schedule() accepted the zone because
+    // cron-parser only rejects it once a date is computed. Written directly, since schedule()
+    // now refuses it.
+    const broken = `${ctx.schema}_broken`
+    await ctx.boss.createQueue(broken)
+
+    const db = await helper.getDb()
+    await db.executeSql(
+      `INSERT INTO ${ctx.schema}.schedule (name, key, cron, timezone, data, options)
+       VALUES ($1, '', '* * * * *', 'Mars/Phobos', null, '{}'::jsonb)`,
+      [broken]
+    )
+
+    await delay(4000)
+
+    // the healthy schedule must still fire — it did not before, because evaluating the broken row
+    // threw straight out of the cron pass
+    const [job] = await ctx.boss.fetch(ctx.schema)
+
+    expect(job).toBeTruthy()
+  })
 })
 
 // Pure unit tests for the clock-domain logic — no database or running instance needed.
@@ -488,5 +522,54 @@ describe('timekeeper clock domain', function () {
     await (tk as any).onSendIt([{ data: { name: 'q', data: null, options: {} } }])
 
     expect(errors.some(e => e.message === 'forward failed')).toBe(true)
+  })
+
+  it('schedule() rejects a time zone postgres-style cron parsing does not validate', async function () {
+    const tk = makeTk(0)
+
+    // cron-parser accepts any string as `tz` at parse time and only fails later, when a date is
+    // actually computed. A typo therefore used to be stored happily and detonate on the cron pass.
+    await expect(tk.schedule('q', '* * * * *', null, { tz: 'America/New_Yrok' })).rejects.toThrow(/time zone/i)
+  })
+
+  it('schedule() still accepts the time zone spellings that already worked', async function () {
+    const tk = makeTk(0)
+
+    for (const tz of ['UTC', 'utc', 'America/New_York', 'EST5EDT', '+05:30', 'Etc/GMT+3']) {
+      await expect(tk.schedule('q', '* * * * *', null, { tz })).resolves.toBeUndefined()
+    }
+
+    // omitting tz entirely keeps defaulting to UTC
+    await expect(tk.schedule('q', '* * * * *')).resolves.toBeUndefined()
+  })
+
+  it('one unusable schedule row does not stop every other schedule from firing', async function () {
+    const tk = makeTk(0)
+    ;(tk as any).stopped = false
+
+    const inserted: any[] = []
+    ;(tk as any).manager = { insert: async (_q: string, jobs: any[]) => { inserted.push(...jobs) } }
+
+    // A row that predates validation (or was written straight to the table) carries a time zone
+    // that throws once prev() computes a date. It must be skipped, not allowed to abort the pass:
+    // cron() filtered every schedule through one shouldSendIt() call, so this single row silently
+    // stopped scheduling for every queue in the whole deployment, on every pass, forever.
+    ;(tk as any).getSchedules = async () => ([
+      { name: 'broken', key: '', data: null, options: {}, cron: '* * * * *', timezone: 'Mars/Phobos' },
+      { name: 'healthy', key: '', data: null, options: {}, cron: '* * * * *', timezone: 'UTC' }
+    ])
+
+    const warnings: any[] = []
+    tk.on('warning', (w: any) => warnings.push(w))
+    tk.on('error', () => {}) // must not be needed, but don't crash the run if it is
+
+    await tk.cron()
+
+    expect(inserted.length).toBe(1)
+    expect(inserted[0].singletonKey).toBe('healthy__')
+
+    // and the operator has to be told which schedule is broken, or it stays invisible
+    expect(warnings.length).toBe(1)
+    expect(warnings[0].message).toMatch(/broken/)
   })
 })


### PR DESCRIPTION
## The bug

`cron-parser` validates `tz` **lazily**. Parsing without a reference date never constructs a `CronDate`, so any string is accepted and a bad zone only fails later, when a date is actually computed:

```js
// both succeed — the zone is never checked
CronExpressionParser.parse('0 * * * *', { tz: 'America/New_Yrok', strict: false })
CronExpressionParser.parse('0 * * * *', { tz: 'Mars/Phobos', strict: false })
```

`schedule()` validated with exactly that call, so a typo passed validation and was written to the `schedule` table (`timezone` is plain `text`, no constraint).

The cron pass then filtered every schedule through a single `shouldSendIt()`:

```js
const scheduled = schedules
  .filter(i => this.shouldSendIt(i.cron, i.timezone))
  .map(...)
```

`shouldSendIt()` passes `currentDate`, which *does* force the `CronDate` construction — so the bad row throws `CronDate: unhandled timestamp: Invalid Date`. Because it throws inside the `filter`, it aborts the whole pass. `onCron()` catches it and emits `error`, but by then **nothing was scheduled**.

The result is worse than one broken schedule: `onCron()` has already claimed the cluster-wide cadence gate (`trySetCronTime`) before calling `cron()`, so **every schedule in the deployment stops firing, on every pass, indefinitely** — until someone works out which row is at fault. The only symptom is a repeating `error` event whose message mentions neither a schedule nor a time zone.

Zones that reach this state include plausible near-misses, not just nonsense: `America/New_Yrok` (typo) and `GMT+3` (`Etc/GMT+3` is the valid spelling).

## The fix

Two parts, because either alone leaves the bug reachable:

1. **`schedule()` rejects an unusable zone** (`Unknown or unsupported time zone: <tz>`), so no new bad row can be stored. Validation forces the date construction via `cron-parser` itself rather than an independent `Intl` check, so what `schedule()` accepts is exactly what the cron pass can evaluate. The cron expression is validated first, so a bad expression still reports as a cron error rather than as a time zone problem.

2. **The cron pass evaluates each schedule independently.** Validation cannot help a row written by an earlier release or inserted directly, so `cron()` now skips a row it cannot evaluate and emits an `invalid_schedule` warning carrying `queue`, `key`, `cron` and `timezone`. One unusable row costs that one schedule instead of all of them, and it is named rather than silent.

`warning.type` is free text, so no migration is needed. Docs updated for the new warning type in `docs/api/events.md` and `docs/sql/warning-table.md`, plus a note on `tz` in `docs/api/scheduling.md`.

## Verification

Five new tests, all failing before the change:

| Test | Proves |
|---|---|
| `schedule() rejects a time zone postgres-style cron parsing does not validate` | the typo is refused up front |
| `schedule() still accepts the time zone spellings that already worked` | no regression for `UTC`, `utc`, `America/New_York`, `EST5EDT`, `+05:30`, `Etc/GMT+3`, and omitting `tz` |
| `one unusable schedule row does not stop every other schedule from firing` | the healthy schedule is still inserted, and exactly one warning names the broken one |
| `a stored schedule with an unusable time zone does not stop other schedules from firing` | end-to-end against a running instance with a row written straight to the table |

Before the change the end-to-end test fails from the real background timer, not a stub:

```
Error: CronDate: unhandled timestamp: Mon Aug 03 2026 ...
 ❯ Timekeeper.shouldSendIt src/timekeeper.ts:193:43
 ❯ Timekeeper.cron src/timekeeper.ts:182:8
 ❯ Timekeeper.onCron src/timekeeper.ts:168:11
 ❯ Timeout._onTimeout src/timekeeper.ts:83:56
```

I also checked that the validation has no false positives: never-occurring or unsupported expressions (`0 0 30 2 *`, `@reboot`) still fail as *cron* errors from the existing expression check, before the zone check runs.

Suite green — `eslint`, `tsc --noEmit`, `gen:manifest:check`, and `vitest run` (`test/scheduleTest.ts`: 28 passed; full suite 761 passed, the only failures being known `beforeEach` hook timeouts under pglite worker parallelism, which pass when the same files are run with `--no-file-parallelism`).
