### PR TITLE
Add sitemap and robots.txt to docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   base: '/',
   cleanUrls: true,
   lastUpdated: true,
+  sitemap: {
+    hostname: 'https://pgboss.io'
+  },
   head: [
     ['meta', { name: 'theme-color', content: '#2f7cf6' }],
     ['script', {}, `(function(){

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1508,9 +1508,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "pg-boss-docs",
       "devDependencies": {
-        "vitepress": "^2.0.0-alpha.18"
+        "vitepress": "^2.0.0-alpha.19"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -263,9 +263,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -283,9 +280,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -303,9 +297,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -323,9 +314,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -343,9 +331,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -363,9 +348,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1267,9 +1249,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1291,9 +1270,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1315,9 +1291,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1339,9 +1312,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1984,31 +1954,31 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-Lk1G2/QqSf+MwNLICl9fmzWOtoCEwjZoWgaQy41QvWTfcGpLE9XwJDbcCyES/9rj6R2g1zFqFvLVkYKLLDALFw==",
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-WnBsb0Bwr43kXKyiis+lld/7ri3hnMbthS8N3hpFtjjwsdLO4IRmiAE08D7aud4q6oMDf9uwRowxzNqRFe/amw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docsearch/css": "^4.6.3",
-        "@docsearch/js": "^4.6.3",
-        "@docsearch/sidepanel-js": "^4.6.3",
-        "@iconify-json/simple-icons": "^1.2.87",
-        "@shikijs/core": "^4.3.0",
-        "@shikijs/transformers": "^4.3.0",
-        "@shikijs/types": "^4.3.0",
+        "@docsearch/css": "^4.7.0",
+        "@docsearch/js": "^4.7.0",
+        "@docsearch/sidepanel-js": "^4.7.0",
+        "@iconify-json/simple-icons": "^1.2.92",
+        "@shikijs/core": "^4.4.1",
+        "@shikijs/transformers": "^4.4.1",
+        "@shikijs/types": "^4.4.1",
         "@types/markdown-it": "^14.1.2",
-        "@vitejs/plugin-vue": "^6.0.7",
-        "@vue/devtools-api": "^8.1.4",
-        "@vue/shared": "^3.5.39",
-        "@vueuse/core": "^14.3.0",
-        "@vueuse/integrations": "^14.3.0",
+        "@vitejs/plugin-vue": "^6.0.8",
+        "@vue/devtools-api": "^8.2.1",
+        "@vue/shared": "^3.5.40",
+        "@vueuse/core": "^14.4.0",
+        "@vueuse/integrations": "^14.4.0",
         "focus-trap": "^8.2.2",
         "mark.js": "8.11.1",
         "minisearch": "^7.2.0",
-        "shiki": "^4.3.0",
-        "vite": "^8.1.3",
-        "vue": "^3.5.39"
+        "shiki": "^4.4.1",
+        "vite": "^8.2.0",
+        "vue": "^3.5.40"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
   "name": "pg-boss-docs",
   "type": "module",
   "devDependencies": {
-    "vitepress": "^2.0.0-alpha.18"
+    "vitepress": "^2.0.0-alpha.19"
   },
   "scripts": {
     "docs:dev": "vitepress dev",

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://pgboss.io/sitemap.xml


### PR DESCRIPTION
### Code Changes:

- `docs/.vitepress/config.ts`: added `sitemap.hostname` set to https://pgboss.io
- `docs/public/robots.txt`: new file, allows all crawlers and points at the sitemap
- `docs/package.json`, `docs/package-lock.json`: vitepress 2.0.0-alpha.18 to 2.0.0-alpha.19, run audit fix