### PR TITLE
ci: pin actions to commit SHAs and add Dependabot to maintain them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keeps the SHA-pinned actions in .github/workflows current. Pinning without an
+# update path just trades a supply-chain risk for a staleness one, so the two
+# belong together.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# Actions are pinned to full commit SHAs; the trailing version comment lets
+# Dependabot keep them current. A mutable tag can be repointed at new code,
+# which matters most for the publish workflows that hold id-token: write.
 on:
   push:
     branches: [master]
@@ -46,10 +49,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: 24
 
@@ -64,7 +67,7 @@ jobs:
     # Only the standard leg produces coverage; the distributed leg uploads nothing.
     - name: Coveralls
       if: ${{ matrix.mode == 'standard' }}
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2
       with:
         flag-name: standard
         parallel: true
@@ -78,10 +81,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: 24
 
@@ -98,10 +101,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: 24
 
@@ -126,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2
       with:
         parallel-finished: true
         carryforward: "standard"

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: 24
         cache: npm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,20 +20,20 @@ jobs:
     if: github.repository == 'timgit/pg-boss'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0 # lastUpdated in docs config needs full git history
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: docs/package-lock.json
       - run: npm ci
         working-directory: docs
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - run: npm run docs:build
         working-directory: docs
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs/.vitepress/dist
 
@@ -45,4 +45,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: 24
 

--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -29,9 +29,9 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '24'
 

--- a/.github/workflows/publish-proxy.yml
+++ b/.github/workflows/publish-proxy.yml
@@ -29,9 +29,9 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '24'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '24'
       - run: npm publish --provenance


### PR DESCRIPTION
Pins every GitHub Action to a full commit SHA and adds a Dependabot config to keep those pins current.

### Why

Action tags are mutable — `@v5` can be repointed at new code by whoever controls the tag. That matters most in `publish.yml`, `publish-dashboard.yml` and `publish-proxy.yml`, which run `npm publish --provenance` with `id-token: write`. An action running in those jobs sits inside the trusted-publishing boundary, so a repointed tag there reaches everyone who installs pg-boss.

This is standard supply-chain hardening ([GitHub's own guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), and what OpenSSF Scorecard's `Pinned-Dependencies` check looks for). Nothing here suggests a problem with the current setup — it just removes a class of risk that's cheap to remove.

### Pins

Each SHA was resolved from the tag via the GitHub API (dereferencing annotated tags) and verified to exist in its repository:

| Action | Tag | Pinned SHA |
|---|---|---|
| `actions/checkout` | v5 | `fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09` |
| `actions/setup-node` | v5 | `a0853c24544627f65ddf259abe73b1d18a591444` |
| `coverallsapp/github-action` | v2 | `8d6379e14d29928660c4ba802d8e85393440b329` |
| `actions/configure-pages` | v6 | `45bfe0192ca1faeb007ade9deae92b16b8254a0d` |
| `actions/upload-pages-artifact` | v5 | `fc324d3547104276b827a68afc52ff2a11cc49c9` |
| `actions/deploy-pages` | v5 | `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` |

23 references across all 7 workflows. Every line keeps a trailing `# v5`-style comment — that isn't decoration, it's what Dependabot reads to know which version a SHA corresponds to.

### Dependabot

Pinning on its own just trades a supply-chain risk for a staleness one, so the two belong in the same change. The config is deliberately minimal — weekly, grouped into a single PR so it's one review rather than six:

```yaml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    groups:
      actions:
        patterns:
          - "*"
    commit-message:
      prefix: "ci"
```

No `ignore` rules and no `open-pull-requests-limit` — the first is your policy call to make once you've seen what it raises, and the second is already the default (5).

### Deliberately not included

**No `permissions:` changes.** `ci.yml`, `dashboard.yml` and `proxy.yml` have no `permissions:` block and inherit the repository default, and tightening that looked like an obvious companion change. It isn't a safe one: per [Coveralls' docs](https://docs.coveralls.io/common-issues-and-troubleshooting), when `service_name` is `github` Coveralls uses the forwarded `GITHUB_TOKEN` to "directly call back to github" and "for updating the build status". A bare `permissions: contents: read` sets every unlisted scope to `none`, including `statuses`, so the coverage status would quietly stop appearing with no job failing to explain why. If you want that hardening it needs `contents: read` **plus** `statuses: write`, and that depends on how your Coveralls integration is set up — your call, not something to slip into this PR.

Also out of scope: no workflow restructuring, no version bumps, no formatting changes.

### Verification

- All 7 workflow files still parse as YAML (checked before and after — the pristine files were the control).
- The diff contains only `uses:` lines plus one explanatory comment; nothing else changed.
- Every pinned SHA re-verified against its tag independently of how it was generated.

I can't run this repo's CI from a fork, so the pins are verified by construction rather than by a green run. Since the change is textual and the version comments are preserved, the risk is about as low as a CI change gets — but flagging it rather than implying otherwise.

### Where this came from

We ran a downstream fork of pg-boss carrying CockroachDB compatibility patches. 12.27.0's distributed-database support made every one of them unnecessary — including a `float8` cast for singleton scheduling we'd re-derived six weeks *after* you'd already shipped the identical line in #679 — so we're deleting the fork and moving to the released package. This hardening is the one thing we'd added that wasn't already upstream, so it seemed worth offering back on the way out. Happy to split it into two PRs, drop the Dependabot half, or close it if it's not wanted.
