### PR TITLE
Fix dashboard schedule frequency label ignoring day fields in cron expressions

### DIFF
--- a/packages/dashboard/app/routes/schedules.tsx
+++ b/packages/dashboard/app/routes/schedules.tsx
@@ -66,20 +66,42 @@ export function ErrorBoundary () {
   return <ErrorCard title="Failed to load schedules" />
 }
 
-// Readable description for the common cron patterns; falls back to the raw
-// fields for anything bespoke. Purely derived from the cron string.
-function cronHuman (cron: string): string {
-  const known: Record<string, string> = {
-    '0 2 * * *': 'Every day at 02:00',
-    '*/15 * * * *': 'Every 15 minutes',
-    '0 0 1 * *': 'Monthly on the 1st at 00:00',
-    '0 * * * *': 'Every hour on the hour',
-    '0 0 * * *': 'Every day at midnight',
+function ordinal (n: number): string {
+  const v = n % 100
+  if (v >= 11 && v <= 13) return `${n}th`
+  return `${n}${['th', 'st', 'nd', 'rd'][n % 10] ?? 'th'}`
+}
+
+const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
+// Readable description for the common cron patterns; falls back to
+// 'Custom schedule' for anything bespoke. A pattern is only described when
+// every field it ignores is a wildcard — '0 4 * * 0' is weekly on Sunday,
+// never 'Every day at 04:00'.
+export function cronHuman (cron: string): string {
+  const fields = cron.trim().split(/\s+/)
+  if (fields.length !== 5) return 'Custom schedule'
+  const [m, h, dom, mon, dow] = fields as [string, string, string, string, string]
+  const anyDom = dom === '*'
+  const anyMon = mon === '*'
+  const anyDow = dow === '*'
+
+  if (/^\*\/\d+$/.test(m) && h === '*' && anyDom && anyMon && anyDow) {
+    return `Every ${m.slice(2)} minutes`
   }
-  if (known[cron]) return known[cron]
-  const [m, h] = cron.split(' ')
-  if (m === '0' && h && h !== '*') return `Every day at ${h.padStart(2, '0')}:00`
-  if (m?.startsWith('*/')) return `Every ${m.slice(2)} minutes`
+  if (m === '0' && h === '*' && anyDom && anyMon && anyDow) return 'Every hour on the hour'
+
+  if (!/^\d+$/.test(m) || !/^\d+$/.test(h)) return 'Custom schedule'
+  const time = `${h.padStart(2, '0')}:${m.padStart(2, '0')}`
+  if (anyDom && anyMon && anyDow) {
+    return time === '00:00' ? 'Every day at midnight' : `Every day at ${time}`
+  }
+  if (anyDom && anyMon && /^[0-7]$/.test(dow)) {
+    return `Weekly on ${WEEKDAYS[Number(dow) % 7]} at ${time}`
+  }
+  if (anyMon && anyDow && /^\d+$/.test(dom)) {
+    return `Monthly on the ${ordinal(Number(dom))} at ${time}`
+  }
   return 'Custom schedule'
 }
 

--- a/packages/dashboard/tests/frontend/cron-human.test.ts
+++ b/packages/dashboard/tests/frontend/cron-human.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { cronHuman } from '~/routes/schedules'
+
+describe('cronHuman', () => {
+  it('describes daily times only when day fields are wildcards', () => {
+    expect(cronHuman('0 2 * * *')).toBe('Every day at 02:00')
+    expect(cronHuman('30 4 * * *')).toBe('Every day at 04:30')
+    expect(cronHuman('0 0 * * *')).toBe('Every day at midnight')
+  })
+
+  it('does not claim daily for a weekly schedule', () => {
+    expect(cronHuman('0 4 * * 0')).toBe('Weekly on Sunday at 04:00')
+    expect(cronHuman('30 9 * * 1')).toBe('Weekly on Monday at 09:30')
+    expect(cronHuman('0 4 * * 7')).toBe('Weekly on Sunday at 04:00')
+  })
+
+  it('describes minute intervals only when all other fields are wildcards', () => {
+    expect(cronHuman('*/15 * * * *')).toBe('Every 15 minutes')
+    expect(cronHuman('*/15 * * * 1')).toBe('Custom schedule')
+    expect(cronHuman('*/15 2 * * *')).toBe('Custom schedule')
+  })
+
+  it('describes hourly and monthly patterns', () => {
+    expect(cronHuman('0 * * * *')).toBe('Every hour on the hour')
+    expect(cronHuman('0 0 1 * *')).toBe('Monthly on the 1st at 00:00')
+    expect(cronHuman('0 12 22 * *')).toBe('Monthly on the 22nd at 12:00')
+    expect(cronHuman('0 12 11 * *')).toBe('Monthly on the 11th at 12:00')
+  })
+
+  it('falls back to Custom schedule for anything bespoke', () => {
+    expect(cronHuman('0 4 1 1 *')).toBe('Custom schedule')
+    expect(cronHuman('0 4 * * 1-5')).toBe('Custom schedule')
+    expect(cronHuman('not a cron')).toBe('Custom schedule')
+    expect(cronHuman('0 4 * *')).toBe('Custom schedule')
+  })
+})


### PR DESCRIPTION
## Problem

The dashboard's schedules page describes `0 4 * * 0` (weekly on Sunday) as **"Every day at 04:00"**. `cronHuman` only looked at the minute and hour fields, so any day-of-month/month/weekday restriction was silently dropped:

- `0 4 * * 0` → "Every day at 04:00" (actually weekly on Sunday)
- `*/15 * * * 1` → "Every 15 minutes" (actually only on Mondays)

## Fix

Rewrote `cronHuman` to consult all five fields. A pattern is only described when every field it ignores is a wildcard; otherwise it falls back to "Custom schedule" rather than making a wrong claim. Also derives the previously hardcoded known patterns (midnight, hourly, monthly) from the same logic, and now supports non-zero minutes (`30 4 * * *` → "Every day at 04:30") plus new weekly (`Weekly on Sunday at 04:00") and monthly ("Monthly on the 22nd at 12:00") descriptions.

Added `tests/frontend/cron-human.test.ts` covering daily/weekly/monthly/hourly/interval patterns, the misleading cases above, and bespoke fallbacks. `npm run test:frontend` (219 tests) and `npm run typecheck` pass.