### PR TITLE
fix: stamp dead_letter on redrive from destination queue

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -506,7 +506,7 @@ dead letter queue to drain. Returns the number of jobs moved.
 Each job is routed back to the queue it originally failed on (its `sourceName`),
 so a single dead letter queue that collects from many source queues fans back out
 correctly. Re-created jobs get a new id, a reset retry count, cleared output, and
-the destination queue's current retry, retention, and policy configuration. Only
+the destination queue's current retry, retention, policy, and deadLetter configuration. Only
 jobs that are not currently being processed (still in the `created`/`retry` state)
 are moved.
 

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -2254,7 +2254,8 @@ export function insertDeadLetterJob (schema: string): string {
 // oldest-first, capped at $4. The JOIN in `candidates` only matches jobs whose destination queue
 // exists, so legacy/orphaned jobs (NULL source_name, no override) are never deleted — they stay
 // in the DLQ rather than being lost. Re-created jobs get a new id, `created` state, retry_count 0,
-// cleared output, NULL source_*, and the destination queue's current retry/retention/policy config.
+// cleared output, NULL source_*, and the destination queue's current retry/retention/policy/
+// dead_letter config (matching send()'s COALESCE(job option, queue.dead_letter) stamp).
 export function redriveJobs (schema: string, table: string): string {
   return `
     WITH candidates AS (
@@ -2276,11 +2277,12 @@ export function redriveJobs (schema: string, table: string): string {
     ins AS (
       INSERT INTO ${schema}.job
         (name, data, priority, retry_limit, retry_backoff, retry_delay, retry_delay_max,
-         expire_seconds, keep_until, deletion_seconds, policy, singleton_key, heartbeat_seconds)
+         expire_seconds, keep_until, deletion_seconds, policy, singleton_key, heartbeat_seconds,
+         dead_letter)
       SELECT COALESCE($2, m.source_name), m.data, m.priority, q.retry_limit, q.retry_backoff,
         q.retry_delay, q.retry_delay_max, q.expire_seconds,
         now() + q.retention_seconds * interval '1s', q.deletion_seconds, q.policy,
-        m.singleton_key, m.heartbeat_seconds
+        m.singleton_key, m.heartbeat_seconds, q.dead_letter
       FROM moved m JOIN ${schema}.queue q ON q.name = COALESCE($2, m.source_name)
       -- A destination queue's short/stately policy can still collide on (name, singleton_key)
       -- if two redriven jobs share a key (job_i1/job_i3); dropping just that row here, matching

--- a/test/failureTest.ts
+++ b/test/failureTest.ts
@@ -326,6 +326,41 @@ describe('failure', function () {
     assertTruthy(redrivenMeta)
     expect(redrivenMeta.retryCount).toBe(0)
     expect(redrivenMeta.sourceName).toBeNull()
+    // send() stamps dead_letter from the destination queue; redrive must do the same so a
+    // subsequent terminal failure still copies into the DLQ (fail uses job.dead_letter).
+    expect(redrivenMeta.deadLetter).toBe(deadLetter)
+  })
+
+  it('redrive stamps deadLetter so a second failure returns to the DLQ', async function () {
+    ctx.boss = await helper.start({ ...ctx.bossConfig, noDefault: true })
+
+    const deadLetter = `${ctx.schema}_dlq`
+
+    await ctx.boss.createQueue(deadLetter)
+    // retryLimit on the queue (not just send) so redrive inherits a terminal-on-first-fail config
+    await ctx.boss.createQueue(ctx.schema, { deadLetter, retryLimit: 0 })
+
+    const jobId = await ctx.boss.send(ctx.schema, { key: ctx.schema })
+    assertTruthy(jobId)
+
+    await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.fail(ctx.schema, jobId)
+
+    expect(await ctx.boss.redrive(deadLetter)).toBe(1)
+
+    const [redriven] = await helper.fetchWithRetry<{ key: string }>(ctx.boss, ctx.schema)
+    expect(redriven.data.key).toBe(ctx.schema)
+
+    // without dead_letter on the redriven row this stays failed on the source queue forever
+    await ctx.boss.fail(ctx.schema, redriven.id)
+
+    const [dlqJob] = await helper.fetchWithRetry<{ key: string }>(ctx.boss, deadLetter)
+    expect(dlqJob.data.key).toBe(ctx.schema)
+
+    const dlqMeta = await ctx.boss.getJobById(deadLetter, dlqJob.id)
+    assertTruthy(dlqMeta)
+    expect(dlqMeta.sourceName).toBe(ctx.schema)
+    expect(dlqMeta.sourceId).toBe(redriven.id)
   })
 
   it('redrive routes each job back to its own source queue', async function () {


### PR DESCRIPTION
redrive() copied retry/retention/policy from the destination queue but omitted dead_letter, so redriven jobs got null. fail() routes to the DLQ via job.dead_letter, so a second terminal failure never dead-lettered again even when the queue still had deadLetter configured.

Match send()'s queue stamp and document deadLetter as part of the inherited destination config.