### PR TITLE
feat(jobs): add state, limit, ordering and cursor filters to findJobs()

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -791,7 +791,7 @@ Retrieves a job with all metadata by name and id
 
 ### `findJobs(name, options)`
 
-Finds jobs in a queue by id, singleton key, and/or data. Returns an array of jobs with all metadata.
+Finds jobs in a queue by id, singleton key, data, and/or state. Returns an array of jobs with all metadata.
 
 **Arguments**
 - `name`: string, *required*
@@ -815,7 +815,31 @@ Finds jobs in a queue by id, singleton key, and/or data. Returns an array of job
 
   If `true`, only return jobs in queued state (created or retry). If `false`, return jobs in any state.
 
+  Cannot be combined with `states`, which expresses the same filter and more.
+
+* **states**, array of string
+
+  Only return jobs in one of these states: `created`, `retry`, `active`, `completed`, `cancelled`, `failed`. An unknown state is rejected.
+
+* **limit**, int
+
+  Maximum number of jobs to return. Without it the result is unbounded, so a busy queue or a long-lived singleton key returns its whole retained history.
+
+* **orderBy**, string, *default: `createdOn`*
+
+  Column to sort by: `createdOn` or `startAfter`. Both are immutable for the life of a job, which is what makes them safe to page on.
+
+* **direction**, string, *default: `asc`*
+
+  `asc` or `desc`.
+
+* **cursor**, string
+
+  Id of the last job from the previous page. The next page starts strictly after it in the current ordering. An id that does not name a job in this queue returns no rows.
+
 * **db**, object, see notes in `send()`
+
+Ordering is off unless the call asks for something that needs it. Supplying any of `limit`, `orderBy`, `direction`, or `cursor` turns it on, defaulting to `createdOn` ascending; a call using none of them returns rows in no defined order, as it always has.
 
 **Examples**
 
@@ -832,12 +856,63 @@ const jobs = await boss.findJobs('my-queue', { data: { type: 'email' } })
 // Find queued jobs only
 const jobs = await boss.findJobs('my-queue', { key: 'user-123', queued: true })
 
+// Find by state
+const jobs = await boss.findJobs('my-queue', { states: ['failed', 'cancelled'] })
+
+// Newest 20 jobs
+const jobs = await boss.findJobs('my-queue', { limit: 20, direction: 'desc' })
+
 // Combine filters
 const jobs = await boss.findJobs('my-queue', {
   key: 'user-123',
   data: { type: 'email' },
   queued: true
 })
+```
+
+**Paging**
+
+Paging is keyset-based rather than offset-based: the cursor names a row, and the next page starts strictly after it. A job inserted or deleted between calls cannot shift the window into repeating or skipping a row, and the cost of page N does not grow with N.
+
+```js
+let cursor
+
+for (;;) {
+  const page = await boss.findJobs('my-queue', { states: ['failed'], limit: 100, cursor })
+
+  if (page.length === 0) break
+
+  for (const job of page) {
+    // ...
+  }
+
+  cursor = page[page.length - 1].id
+}
+```
+
+### `getJobByKey(name, key, options)`
+
+Returns the most recently created job for a singleton key, or `null` if the queue has none. The singleton-key counterpart of `getJobById()`: a key identifies a series of jobs rather than a single row, so this answers with the latest.
+
+**Arguments**
+- `name`: string, *required*
+- `key`: string, *required*
+- `options`: object
+
+**options**
+
+* **queued**, bool, *default: false*
+
+  Only consider jobs in queued state (created or retry). On a `short`, `singleton`, `stately`, or `exclusive` queue this is the job the key currently has outstanding.
+
+* **db**, object, see notes in `send()`
+
+```js
+// what happened last for this key
+const last = await boss.getJobByKey('order-processing', 'order-42')
+
+// what is pending for this key right now
+const pending = await boss.getJobByKey('order-processing', 'order-42', { queued: true })
 ```
 
 ## Inspecting dependencies

--- a/src/attorney.ts
+++ b/src/attorney.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { DEFAULT_SCHEMA } from './plans.ts'
+import { DEFAULT_SCHEMA, JOB_STATES } from './plans.ts'
 import type * as types from './types.ts'
 
 const POLICY = {
@@ -456,6 +456,38 @@ function checkFetchArgs (name: string, options: any) {
   validatePriorityRangeConfig(options)
 }
 
+const FIND_JOBS_ORDER_BY = ['createdOn', 'startAfter']
+
+function checkFindJobsArgs (options: any) {
+  assert(typeof options === 'object' && options !== null, 'options must be an object')
+
+  // Both narrow by state, and `states` is the superset. Silently letting one win would make
+  // findJobs({ queued: true, states: ['completed'] }) return something no reading of the call
+  // predicts, so it is rejected instead.
+  assert(!('queued' in options && options.queued !== undefined) || !('states' in options && options.states !== undefined),
+    'queued and states cannot be combined: states already expresses the queued filter')
+
+  if (options.states !== undefined) {
+    assert(Array.isArray(options.states) && options.states.length > 0, 'states must be a non-empty array')
+
+    for (const state of options.states) {
+      assert(Object.hasOwn(JOB_STATES, state), `unknown job state: ${state}`)
+    }
+  }
+
+  assert(!('limit' in options && options.limit !== undefined) || (Number.isInteger(options.limit) && options.limit >= 1),
+    'limit must be an integer >= 1')
+
+  assert(!('orderBy' in options && options.orderBy !== undefined) || FIND_JOBS_ORDER_BY.includes(options.orderBy),
+    `orderBy must be one of ${FIND_JOBS_ORDER_BY.join(', ')}`)
+
+  assert(!('direction' in options && options.direction !== undefined) || options.direction === 'asc' || options.direction === 'desc',
+    "direction must be 'asc' or 'desc'")
+
+  assert(!('cursor' in options && options.cursor !== undefined) || typeof options.cursor === 'string',
+    'cursor must be a job id')
+}
+
 function getConfig (value: string | types.ConstructorOptions): types.ResolvedConstructorOptions {
   assert(value && (typeof value === 'object' || typeof value === 'string'),
     'configuration assert: string or config object is required to connect to postgres')
@@ -806,6 +838,7 @@ export {
   assertPostgresObjectName,
   assertQueueName,
   checkFetchArgs,
+  checkFindJobsArgs,
   checkSendArgs,
   checkUpdateArgs,
   checkWorkArgs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,6 +407,10 @@ export class PgBoss extends EventEmitter<types.PgBossEventMap> {
     return this.#manager.findJobs<T>(name, options)
   }
 
+  getJobByKey<T>(name: string, key: string, options?: types.GetJobByKeyOptions): Promise<types.JobWithMetadata<T> | null> {
+    return this.#manager.getJobByKey<T>(name, key, options)
+  }
+
   createQueue (name: string, options?: Omit<types.Queue, 'name'>): Promise<void> {
     return this.#manager.createQueue(name, options)
   }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -2002,17 +2002,27 @@ class Manager extends EventEmitter implements types.EventsMixin {
 
   async findJobs<T>(name: string, options: types.FindJobsOptions = {}): Promise<types.JobWithMetadata<T>[]> {
     Attorney.assertQueueName(name)
+    Attorney.checkFindJobsArgs(options)
 
     const db = this.assertDb(options)
 
     const { table } = await this.getQueueCache(name)
 
-    const { id, key, data, queued = false } = options
+    const { id, key, data, states, cursor, limit, direction, queued = false } = options
+
+    // Anything that needs a defined order turns ordering on. A caller that asks for none of them
+    // gets the unordered statement findJobs has always issued.
+    const orderBy = (options.orderBy ?? (limit !== undefined || cursor !== undefined || direction !== undefined ? 'createdOn' : undefined))
 
     const sql = plans.findJobs(this.config.schema, table, {
       byId: id !== undefined,
       byKey: key !== undefined,
       byData: data !== undefined,
+      byStates: states !== undefined,
+      byCursor: cursor !== undefined,
+      limited: limit !== undefined,
+      orderBy,
+      descending: direction === 'desc',
       queued
     })
 
@@ -2020,10 +2030,45 @@ class Manager extends EventEmitter implements types.EventsMixin {
     if (id !== undefined) values.push(id)
     if (key !== undefined) values.push(key)
     if (data !== undefined) values.push(JSON.stringify(data))
+    if (states !== undefined) values.push(states)
+    if (cursor !== undefined) values.push(cursor)
+    if (limit !== undefined) values.push(limit)
 
     const result = await db.executeSql(sql, values)
 
-    return result?.rows || []
+    const rows = result?.rows || []
+
+    // CockroachDB returns integer columns as strings; normalize them so a job read here has the
+    // same shape as one from fetch() or getJobById().
+    if (this.config.backend === 'cockroachdb') {
+      for (const row of rows) {
+        for (const field of NUMERIC_METADATA_FIELDS) {
+          if (row[field] !== undefined && row[field] !== null) row[field] = Number(row[field])
+        }
+      }
+    }
+
+    return rows
+  }
+
+  // The singleton-key counterpart of getJobById. A key identifies a series rather than a row, so
+  // this answers with the most recent one; pass `queued: true` for the job the key currently has
+  // outstanding under a short/singleton/stately/exclusive policy.
+  async getJobByKey<T>(name: string, key: string, options: types.GetJobByKeyOptions = {}): Promise<types.JobWithMetadata<T> | null> {
+    assert(typeof key === 'string', 'getJobByKey() requires a singleton key')
+
+    const { queued, db } = options
+
+    const [job] = await this.findJobs<T>(name, {
+      key,
+      queued,
+      db,
+      limit: 1,
+      orderBy: 'createdOn',
+      direction: 'desc'
+    })
+
+    return job ?? null
   }
 
   async getDependencies (name: string, id: string, options: types.ConnectionOptions = {}): Promise<types.DependencyRef[]> {

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -2659,8 +2659,28 @@ export function assertMigration (schema: string, version: number) {
   return `SELECT version::int/(version::int-${version}) from ${schema}.version`
 }
 
-export function findJobs (schema: string, table: string, options: { queued: boolean, byKey: boolean, byData: boolean, byId: boolean }) {
-  const { queued, byKey, byData, byId } = options
+// Columns findJobs can sort and page on. Both are immutable for the life of a job, which is what
+// makes them usable as a cursor anchor: a job that changes state mid-pagination keeps its place in
+// the ordering instead of jumping to another page.
+const FIND_JOBS_ORDER_COLUMNS = {
+  createdOn: 'created_on',
+  startAfter: 'start_after'
+} as const
+
+export type FindJobsOrderBy = keyof typeof FIND_JOBS_ORDER_COLUMNS
+
+export function findJobs (schema: string, table: string, options: {
+  queued: boolean,
+  byKey: boolean,
+  byData: boolean,
+  byId: boolean,
+  byStates: boolean,
+  byCursor: boolean,
+  limited: boolean,
+  orderBy?: FindJobsOrderBy,
+  descending?: boolean
+}) {
+  const { queued, byKey, byData, byId, byStates, byCursor, limited, orderBy, descending } = options
 
   let paramIndex = 1
   const whereConditions = []
@@ -2680,15 +2700,48 @@ export function findJobs (schema: string, table: string, options: { queued: bool
     whereConditions.push(`AND data @> $${paramIndex}`)
   }
 
+  if (byStates) {
+    ++paramIndex
+    whereConditions.push(`AND state = ANY($${paramIndex}::${schema}.job_state[])`)
+  }
+
   if (queued) {
     whereConditions.push(`AND state < '${JOB_STATES.active}'`)
   }
+
+  // Ordering is opt-in so an existing unbounded findJobs() keeps the plan it has always had. It
+  // turns on as soon as the caller asks for something that needs a defined order: orderBy itself,
+  // a limit, or a cursor.
+  const column = orderBy ? FIND_JOBS_ORDER_COLUMNS[orderBy] : null
+  let ordering = ''
+
+  if (column) {
+    const direction = descending ? 'DESC' : 'ASC'
+
+    // Keyset pagination rather than OFFSET: the anchor's sort value and id are read back from the
+    // row the cursor names, and the row comparison walks strictly past it. A row inserted or
+    // deleted between pages cannot shift the window, and the cost of page N does not grow with N.
+    //
+    // id breaks ties so the order is total. Without it two jobs sharing a created_on could sort
+    // either way between calls, which repeats or skips one of them at a page boundary.
+    if (byCursor) {
+      ++paramIndex
+      const comparison = descending ? '<' : '>'
+      whereConditions.push(`AND (${column}, id) ${comparison} (SELECT ${column}, id FROM ${schema}.${table} WHERE name = $1 AND id = $${paramIndex})`)
+    }
+
+    ordering = `ORDER BY ${column} ${direction}, id ${direction}`
+  }
+
+  const limit = limited ? `LIMIT $${++paramIndex}` : ''
 
   return `
     SELECT ${JOB_COLUMNS_ALL}
     FROM ${schema}.${table}
     WHERE name = $1
       ${whereConditions.join('\n      ')}
+    ${ordering}
+    ${limit}
     `
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -536,10 +536,56 @@ export interface CompleteOptions extends ConnectionOptions {
   includeQueued?: boolean;
 }
 
+export type JobState = 'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed'
+
+/** Columns `findJobs()` can sort and page on. Both are immutable for the life of a job. */
+export type FindJobsOrderBy = 'createdOn' | 'startAfter'
+
 export interface FindJobsOptions extends ConnectionOptions {
   id?: string;
   key?: string;
   data?: object;
+  /**
+   * Only return jobs in queued state (`created` or `retry`).
+   *
+   * Mutually exclusive with `states`, which expresses the same filter and more.
+   */
+  queued?: boolean;
+  /**
+   * Only return jobs in one of these states. Mutually exclusive with `queued`.
+   */
+  states?: JobState[];
+  /**
+   * Maximum number of jobs to return. Without it the result is unbounded, so a busy queue or a
+   * long-lived singleton key returns its whole retained history.
+   *
+   * Supplying it turns ordering on, defaulting to `createdOn` ascending.
+   */
+  limit?: number;
+  /**
+   * Column to sort by. Supplying it turns ordering on.
+   * @default 'createdOn' when any of `limit`, `cursor`, or `direction` is supplied, otherwise unordered
+   */
+  orderBy?: FindJobsOrderBy;
+  /**
+   * Sort direction. Supplying it turns ordering on.
+   * @default 'asc'
+   */
+  direction?: 'asc' | 'desc';
+  /**
+   * Id of the last job from the previous page. The next page starts strictly after it in the
+   * current ordering, so rows inserted or deleted between calls cannot shift the window.
+   *
+   * Supplying it turns ordering on. An id that does not name a job in this queue returns no rows.
+   */
+  cursor?: string;
+}
+
+export interface GetJobByKeyOptions extends ConnectionOptions {
+  /**
+   * Only consider jobs in queued state (`created` or `retry`).
+   * @default false
+   */
   queued?: boolean;
 }
 
@@ -915,7 +961,7 @@ export interface Job<T = object> {
 
 export interface JobWithMetadata<T = object> extends Job<T> {
   priority: number;
-  state: 'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed';
+  state: JobState;
   retryLimit: number;
   retryCount: number;
   retryDelay: number;

--- a/test/findJobsFiltersTest.ts
+++ b/test/findJobsFiltersTest.ts
@@ -1,0 +1,289 @@
+import { expect } from 'vitest'
+import * as helper from './testHelper.ts'
+import { ctx } from './hooks.ts'
+
+// Sends `count` jobs one at a time so created_on is strictly increasing, which is what the default
+// ordering and the cursor are defined against.
+async function sendSequence (queue: string, count: number): Promise<string[]> {
+  const ids: string[] = []
+
+  for (let i = 0; i < count; i++) {
+    const id = await ctx.boss!.send(queue, { seq: i })
+    helper.assertTruthy(id)
+    ids.push(id)
+  }
+
+  return ids
+}
+
+describe('findJobs filters', function () {
+  it('should filter by an explicit state list', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const created = await ctx.boss.send(ctx.schema, { keep: true })
+    helper.assertTruthy(created)
+
+    const toComplete = await ctx.boss.send(ctx.schema, { keep: false })
+    helper.assertTruthy(toComplete)
+
+    const [job] = await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.complete(ctx.schema, job.id)
+
+    const completed = await ctx.boss.findJobs(ctx.schema, { states: ['completed'] })
+
+    expect(completed.length).toBe(1)
+    expect(completed[0].id).toBe(job.id)
+
+    const rest = await ctx.boss.findJobs(ctx.schema, { states: ['created', 'retry'] })
+
+    expect(rest.length).toBe(1)
+    expect(rest[0].id).not.toBe(job.id)
+  })
+
+  it('should accept several states at once', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await sendSequence(ctx.schema, 3)
+
+    const [job] = await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.complete(ctx.schema, job.id)
+
+    const jobs = await ctx.boss.findJobs(ctx.schema, { states: ['created', 'completed'] })
+
+    expect(jobs.length).toBe(3)
+  })
+
+  it('should reject combining states with queued', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await expect(async () => {
+      await ctx.boss!.findJobs(ctx.schema, { queued: true, states: ['completed'] })
+    }).rejects.toThrow(/states/)
+  })
+
+  it('should reject an unknown state', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await expect(async () => {
+      // @ts-expect-error deliberately passing a state that does not exist
+      await ctx.boss.findJobs(ctx.schema, { states: ['nope'] })
+    }).rejects.toThrow(/unknown job state/)
+  })
+
+  it('should reject an empty state list', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await expect(async () => {
+      await ctx.boss!.findJobs(ctx.schema, { states: [] })
+    }).rejects.toThrow(/non-empty/)
+  })
+
+  it('should bound the result with limit', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await sendSequence(ctx.schema, 5)
+
+    const jobs = await ctx.boss.findJobs(ctx.schema, { limit: 2 })
+
+    expect(jobs.length).toBe(2)
+  })
+
+  it('should reject a limit below one', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await expect(async () => {
+      await ctx.boss!.findJobs(ctx.schema, { limit: 0 })
+    }).rejects.toThrow(/limit/)
+  })
+
+  it('should return the oldest jobs first by default once ordering is on', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const ids = await sendSequence(ctx.schema, 4)
+
+    const jobs = await ctx.boss.findJobs(ctx.schema, { limit: 4 })
+
+    expect(jobs.map(j => j.id)).toEqual(ids)
+  })
+
+  it('should reverse the order on request', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const ids = await sendSequence(ctx.schema, 4)
+
+    const jobs = await ctx.boss.findJobs(ctx.schema, { limit: 4, direction: 'desc' })
+
+    expect(jobs.map(j => j.id)).toEqual([...ids].reverse())
+  })
+
+  it('should order by startAfter', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const later = await ctx.boss.send(ctx.schema, { when: 'later' }, { startAfter: 60 })
+    const sooner = await ctx.boss.send(ctx.schema, { when: 'sooner' }, { startAfter: 10 })
+
+    const jobs = await ctx.boss.findJobs(ctx.schema, { orderBy: 'startAfter' })
+
+    expect(jobs.map(j => j.id)).toEqual([sooner, later])
+  })
+
+  it('should reject an unsupported orderBy column', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await expect(async () => {
+      // @ts-expect-error deliberately sorting on a column that is not offered
+      await ctx.boss.findJobs(ctx.schema, { orderBy: 'output' })
+    }).rejects.toThrow(/orderBy/)
+  })
+
+  it('should page forward with a cursor', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const ids = await sendSequence(ctx.schema, 5)
+
+    const pages: string[] = []
+    let cursor: string | undefined
+
+    for (;;) {
+      const page: { id: string }[] = await ctx.boss.findJobs(ctx.schema, { limit: 2, cursor })
+
+      if (page.length === 0) break
+
+      pages.push(...page.map(j => j.id))
+      cursor = page[page.length - 1].id
+    }
+
+    expect(pages).toEqual(ids)
+  })
+
+  it('should page backward with a cursor', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const ids = await sendSequence(ctx.schema, 4)
+
+    const first = await ctx.boss.findJobs(ctx.schema, { limit: 2, direction: 'desc' })
+    const second = await ctx.boss.findJobs(ctx.schema, { limit: 2, direction: 'desc', cursor: first[1].id })
+
+    expect([...first, ...second].map(j => j.id)).toEqual([...ids].reverse())
+  })
+
+  it('should not repeat a row when one is deleted between pages', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const ids = await sendSequence(ctx.schema, 5)
+
+    const first = await ctx.boss.findJobs(ctx.schema, { limit: 2 })
+
+    expect(first.map(j => j.id)).toEqual(ids.slice(0, 2))
+
+    // an OFFSET-based pager would now shift and skip ids[2]
+    await ctx.boss.deleteJob(ctx.schema, ids[0])
+
+    const second = await ctx.boss.findJobs(ctx.schema, { limit: 2, cursor: first[1].id })
+
+    expect(second.map(j => j.id)).toEqual(ids.slice(2, 4))
+  })
+
+  it('should return nothing for a cursor that names no job', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await sendSequence(ctx.schema, 3)
+
+    const jobs = await ctx.boss.findJobs(ctx.schema, { limit: 2, cursor: '3f2b1c8e-0000-4000-8000-000000000000' })
+
+    expect(jobs.length).toBe(0)
+  })
+
+  it('should combine a state filter with paging', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const ids = await sendSequence(ctx.schema, 4)
+
+    const jobs = await ctx.boss.fetch(ctx.schema, { batchSize: 2 })
+    await ctx.boss.complete(ctx.schema, jobs.map(j => j.id))
+
+    const page = await ctx.boss.findJobs(ctx.schema, { states: ['completed'], limit: 1 })
+
+    expect(page.length).toBe(1)
+    expect(page[0].id).toBe(ids[0])
+
+    const next = await ctx.boss.findJobs(ctx.schema, { states: ['completed'], limit: 1, cursor: page[0].id })
+
+    expect(next.map(j => j.id)).toEqual([ids[1]])
+  })
+
+  it('should leave an unordered call unordered', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await sendSequence(ctx.schema, 3)
+
+    // no limit, cursor, orderBy or direction: the statement is the one findJobs has always issued
+    const jobs = await ctx.boss.findJobs(ctx.schema, { queued: true })
+
+    expect(jobs.length).toBe(3)
+  })
+})
+
+describe('getJobByKey', function () {
+  it('should return the most recent job for a key', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const first = await ctx.boss.send(ctx.schema, { attempt: 1 }, { singletonKey: 'order-1' })
+    helper.assertTruthy(first)
+
+    const [job] = await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.complete(ctx.schema, job.id)
+
+    const second = await ctx.boss.send(ctx.schema, { attempt: 2 }, { singletonKey: 'order-1' })
+    helper.assertTruthy(second)
+
+    const found = await ctx.boss.getJobByKey<{ attempt: number }>(ctx.schema, 'order-1')
+
+    helper.assertTruthy(found)
+    expect(found.id).toBe(second)
+    expect(found.data.attempt).toBe(2)
+  })
+
+  it('should narrow to the queued job for a key', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    const first = await ctx.boss.send(ctx.schema, { attempt: 1 }, { singletonKey: 'order-2' })
+    helper.assertTruthy(first)
+
+    const second = await ctx.boss.send(ctx.schema, { attempt: 2 }, { singletonKey: 'order-2' })
+    helper.assertTruthy(second)
+
+    // the newest is fetched and completed, so only the older one is still queued
+    const [job] = await ctx.boss.fetch(ctx.schema)
+    await ctx.boss.complete(ctx.schema, job.id)
+
+    const found = await ctx.boss.getJobByKey(ctx.schema, 'order-2', { queued: true })
+
+    helper.assertTruthy(found)
+    expect(found.id).toBe(second)
+    expect(found.state).toBe('created')
+  })
+
+  it('should not see another key', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await ctx.boss.send(ctx.schema, { n: 1 }, { singletonKey: 'order-3' })
+
+    expect(await ctx.boss.getJobByKey(ctx.schema, 'order-4')).toBeNull()
+  })
+
+  it('should return null when the queue has no job for the key', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    expect(await ctx.boss.getJobByKey(ctx.schema, 'never-used')).toBeNull()
+  })
+
+  it('should reject a missing key', async function () {
+    ctx.boss = await helper.start(ctx.bossConfig)
+
+    await expect(async () => {
+      // @ts-expect-error deliberately calling without the required key
+      await ctx.boss.getJobByKey(ctx.schema)
+    }).rejects.toThrow(/singleton key/)
+  })
+})


### PR DESCRIPTION
`findJobs()` has no bound and no order. Every call returns the queue's entire retained history for the given filters, in whatever order the planner produces. That makes it awkward for the admin and inspection work it exists for:

- `findJobs('email-send', { key: 'user-123' })` on a key that has been busy for a year returns a year of jobs. There is no way to ask for the last twenty.
- Filtering on state means fetching everything and filtering in JavaScript, or using `queued`, which only expresses `created` + `retry`. "Show me the failed ones" is a full table read.
- Nothing is orderable, so there is no stable way to walk a large result set.

This adds four options, plus a companion read.

### `states`

```js
await boss.findJobs('email-send', { states: ['failed', 'cancelled'] })
```

`queued` is the special case `['created', 'retry']`. Supplying both is rejected rather than silently resolved in favour of one: `{ queued: true, states: ['completed'] }` has no reading that a caller would predict.

### `limit`, `orderBy`, `direction`

```js
await boss.findJobs('email-send', { limit: 20, direction: 'desc' })
```

`orderBy` is `createdOn` (default) or `startAfter`. Both are immutable for the life of a job, which is what makes them safe to sort on: a job that changes state mid-pagination keeps its place in the ordering instead of jumping to another page.

### `cursor`

Keyset pagination on `(order column, id)`, not `OFFSET`:

```js
let cursor

for (;;) {
  const page = await boss.findJobs('email-send', { states: ['failed'], limit: 100, cursor })
  if (page.length === 0) break
  cursor = page[page.length - 1].id
}
```

The anchor's sort value is read back from the row the cursor names and the row comparison walks strictly past it. A job inserted or deleted between pages cannot shift the window into repeating or skipping a row, and page N does not cost more than page 1. `id` is the tiebreaker so the order is total: without it, two jobs sharing a `created_on` could sort either way between calls and land on both sides of a page boundary.

### `getJobByKey(name, key, options)`

The singleton-key counterpart of `getJobById()`. A key identifies a series rather than a row, so it answers with the most recent job:

```js
// what happened last for this key
const last = await boss.getJobByKey('order-processing', 'order-42')

// what the key currently has outstanding
const pending = await boss.getJobByKey('order-processing', 'order-42', { queued: true })
```

### Compatibility

Ordering is opt-in. A call that supplies none of `limit`, `orderBy`, `direction`, or `cursor` produces the statement `findJobs()` has always issued, unordered, with the plan it has today. No existing call changes shape or cost.

One drive-by fix: `findJobs()` now applies the CockroachDB integer normalization `fetch()` and `getJobById()` already perform, so a job read through it has the same shape on every backend. Without it `getJobByKey()` would return `retryLimit` as a string where `getJobById()` returns a number.

### Tests

`test/findJobsFiltersTest.ts`: state filtering including the rejected combinations, bounded results, both orderings, forward and backward paging, a cursor naming a deleted row's successor (the case an offset pager gets wrong), a cursor naming nothing, state filter combined with paging, and the unordered path staying unordered. Plus `getJobByKey` newest-first, the `queued` narrowing, key isolation, and the null cases.
