### PR TITLE
docs: retention anchoring, per-policy key states, cron missed-slot behavior

### DIFF
--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -64,10 +64,29 @@ Creates a new job and returns the job id.
 
   Default: 14 days. How many seconds a job may be in created or retry state before it's deleted. Must be >=1
 
+  The window is measured from `startAfter`, not from when the job was created. See [retention and deferred jobs](#retention-and-deferred-jobs).
+
 * **deleteAfterSeconds**, int
 
   Default: 7 days. How long a job should be retained in the database after it's completed. Set to 0 to never delete completed jobs.
 
+#### Retention and deferred jobs
+
+A job's retention deadline is `startAfter + retentionSeconds`, not `createdOn + retentionSeconds`. Maintenance deletes a job still in `created` or `retry` once that deadline passes.
+
+Anchoring on `startAfter` is what makes long deferrals work. Sending a job a month out with the default 14 day retention keeps it: the deadline lands two weeks past its start time, not two weeks from now. If retention were measured from creation, the job would be swept away a fortnight before it was due to run, silently.
+
+The same anchoring means retention is measured from when a deferred job becomes *eligible*, so a job deferred by an hour still gets its full window to be picked up after that hour, rather than an hour less.
+
+`update()` and `upsert()` preserve the window when they move `startAfter`: the deadline slides by the same amount, so pulling a job forward or pushing it back never leaves it with a deadline already in the past for maintenance to act on.
+
+```js
+// runs in 30 days, and is retained until 14 days after that
+await boss.send('quarterly-report', data, { startAfter: '30 days' })
+
+// a short window on a deferred job still starts at the deferral, not now
+await boss.send('reminder', data, { startAfter: '1 hour', retentionSeconds: 300 })
+```
 
 All retry, expiration, and retention options can also be set on the queue and will be inheritied for each job, unless they are overridden.
   

--- a/docs/api/queues.md
+++ b/docs/api/queues.md
@@ -42,6 +42,29 @@ Allowed policy values:
 | `exclusive` | Only allows 1 job to be queued or active. Can be extended with `singletonKey` |
 | `key_strict_fifo` | FIFO ordering per `singletonKey`. Requires `singletonKey` on every job. Holds back successors while a job with the same key is active, in retry, or failed without blocking other keys. |
 
+#### Which states a policy occupies
+
+Each policy is a unique index over `(name, singletonKey)` restricted to a set of job states. Only a job in one of those states occupies the key's slot, so this is what decides whether a `send()` for an existing key succeeds or resolves `null`.
+
+| Policy | A key is occupied while a job with it is in |
+| - | - |
+| `standard` | nothing, the policy places no per-key constraint |
+| `short` | `created` |
+| `singleton` | `active` |
+| `stately` | `created`, `retry`, and `active`, each counted separately |
+| `exclusive` | `created`, `retry`, or `active`, counted together |
+| `key_strict_fifo` | `active`, `retry`, or `failed` |
+
+Consequences worth knowing:
+
+- **`short` counts `created` only.** A job that failed into `retry` has left the slot, so a new job can be created alongside it. "One job queued" is one job *created*, not one job in any pre-active state. `findJobs(name, { queued: true })` matches `created` and `retry`, a wider set than `short` enforces.
+- **`stately` is per state, so one key can hold three rows at once**, one `created`, one `retry`, one `active`. `exclusive` is the version that counts them together and allows exactly one.
+- **`key_strict_fifo` keeps holding a key after terminal failure.** `failed` is in its set, which is what blocks the key until the job is retried or deleted; see `getBlockedKeys()`.
+- **Terminal states never occupy a key**, apart from `failed` under `key_strict_fifo`. Completed and cancelled jobs accumulate in the table under a key without affecting sends.
+- **A job with no `singletonKey` is treated as having the empty key**, so on a keyed policy the constraint applies to the queue as a whole until keys are used. `key_strict_fifo` is the exception: it requires a key on every job and rejects a send without one.
+
+Throttling with `singletonSeconds` is a separate constraint and is not one of the above. Its index covers every state except `cancelled`, so a job that has already completed or failed still holds its time slot for the remainder of the interval.
+
 > [!WARNING]
 > `stately` queues are special in how retries are handled. By definition, stately queues will not allow multiple jobs to occupy `retry` state. Once a job exists in `retry`, failing another `active` job will bypass the retry mechanism and force the job to `failed`. If this job requires retries, consider a custom retry implementation using a dead letter queue.
 
@@ -143,6 +166,8 @@ Actual detection time is `heartbeatSeconds` + up to `monitorIntervalSeconds` (de
 * **retentionSeconds**, number
 
   Default: 14 days. How many seconds a job may be in created or retry state before it's deleted. Must be >=1
+
+  The window is measured from the job's `startAfter`, not from when the job was created, so a deferred job gets its full retention after it becomes eligible to run rather than spending it waiting. See [retention and deferred jobs](jobs#retention-and-deferred-jobs).
 
 * **deleteAfterSeconds**, int
 

--- a/docs/api/scheduling.md
+++ b/docs/api/scheduling.md
@@ -28,6 +28,25 @@ If needed, the default clock monitoring interval can be adjusted using `clockMon
 
 For more cron documentation and examples see the docs for the [cron-parser package](https://www.npmjs.com/package/cron-parser).
 
+## How occurrences are evaluated
+
+Understanding the pass matters mostly for one question: what happens to an occurrence that falls due while nothing is running.
+
+**One pass per interval, deployment-wide.** A pass is claimed through a timestamp on the `version` table, so whichever instance gets there first runs it and the rest skip. `cronMonitorIntervalSeconds` (default 30, must be between 1 and 45) is how long a claim holds, not a per-instance timer, so adding instances does not add passes.
+
+**A pass fires anything due in the last 60 seconds.** For each schedule it evaluates the expression against database time and sends the job if the most recent occurrence is under 60 seconds old. The 45 second ceiling on `cronMonitorIntervalSeconds` exists to guarantee a pass lands inside that window, so a running deployment cannot step over an occurrence.
+
+**One job per schedule per minute, at most.** A slot is usually visible to more than one pass (a 30 second interval against a 60 second window), so the forwarded job is throttled on the schedule's `(queue, key)` with a 60 second window. This is also the reason 6-placeholder expressions do not deliver second-level precision: whatever the expression says, a schedule cannot produce more than one job a minute.
+
+**Missed occurrences are skipped, not replayed.** There is no catch-up. If no instance runs a pass within 60 seconds of an occurrence, that occurrence is gone, and the next job the schedule produces is its next occurrence rather than the one that was missed. Concretely:
+
+| Gap with no instance running | Result |
+| - | - |
+| Under 60 seconds | The occurrence still fires. The first pass after startup runs immediately and picks it up. |
+| Longer than 60 seconds | Every occurrence more than 60 seconds old is skipped, no matter how many. Nothing is queued to make up for them. |
+
+So a rolling deploy that leaves a sub-minute gap rides through, while a longer outage drops whatever fell inside it. If a schedule must not miss an occurrence, make the job idempotent and have the handler work out what still needs doing, rather than relying on one job per occurrence.
+
 ### `schedule(name, cron, data, options)`
 
 Schedules a job to be sent to the specified queue based on a cron expression. If the schedule already exists, it's updated to the new cron expression.


### PR DESCRIPTION
### 1. Retention is anchored to `startAfter`

`keep_until` is `start_after + retentionSeconds`, not `created_on + retentionSeconds`.

This is the difference between a long deferral working and quietly not working. Send a job 30 days out with the default 14 day retention: read the current wording ("how many seconds a job may be in created or retry state before it's deleted") and the honest conclusion is that maintenance deletes it two weeks *before* it was due to fire. It does not, because the deadline is anchored at the start time. A reader who reasons it out the other way either avoids long deferrals or writes a keep-alive that was never needed.

Also documents that `update()` and `upsert()` slide the deadline by the same amount when they move `startAfter`, so pulling a job forward or pushing it back never leaves it with a deadline already in the past.

Added as a `Retention and deferred jobs` section under `send()` in `jobs.md`, with pointers from the `retentionSeconds` bullets in both `jobs.md` and `queues.md`.

### 2. Which job states each policy's `singletonKey` index covers

Each policy is a unique index over `(name, singletonKey)` restricted to a set of states, and the sets differ in ways a one-line description cannot carry. Adds the table:

| Policy | A key is occupied while a job with it is in |
| - | - |
| `standard` | nothing |
| `short` | `created` |
| `singleton` | `active` |
| `stately` | `created`, `retry`, and `active`, each counted separately |
| `exclusive` | `created`, `retry`, or `active`, counted together |
| `key_strict_fifo` | `active`, `retry`, or `failed` |

The sharp edge is `short`. It covers `created` only, so a job that failed into `retry` has left the slot and a new job can be created alongside it. "Only allows 1 job to be queued" reads as one job in any pre-active state, and `queued` elsewhere in the API (`findJobs({ queued: true })`) does mean `created` + `retry`. Anyone using `short` for at-most-one-pending gets a surprise the first time a job retries.

Plus the consequences that follow: `stately` legitimately holding three rows for one key, `key_strict_fifo` continuing to hold a key after terminal failure (which is what `getBlockedKeys()` is for), terminal states otherwise never occupying a key, and the empty-key treatment of a job sent without a `singletonKey`.

`singletonSeconds` throttling gets a closing note, since it is a separate index and covers every state except `cancelled`: a job that has already completed still holds its time slot.

### 3. The cron scheduler's missed-slot behavior

There is no catch-up, and that is the first thing anyone asks after a deploy gap. Documents the pass model and then the part that matters:

- One pass per `cronMonitorIntervalSeconds` deployment-wide, claimed on the `version` table, so adding instances does not add passes.
- A pass fires anything whose most recent occurrence is under 60 seconds old. The 45 second ceiling on `cronMonitorIntervalSeconds` exists to guarantee a pass lands inside that window.
- One job per schedule per minute at most, since a slot is usually visible to more than one pass. This is also the real reason 6-placeholder expressions cannot deliver second-level precision, which the page currently states as a rule without the mechanism.
- A gap under 60 seconds rides through, because the first pass after startup runs immediately. A longer gap drops every occurrence inside it and nothing replays them.

Closes with the practical advice: if a schedule must not miss an occurrence, make the job idempotent and have the handler work out what still needs doing.

### Notes

Docs only. No source changes, no test changes. Every claim was read off the current implementation: `insertJobs`, `deletion`, `updateJob`, the `job_i1`/`job_i2`/`job_i3`/`job_i4`/`job_i6`/`job_i8` index definitions, `trySetTimestamp`, and `Timekeeper.shouldSendIt`.
