### PR TITLE
fix: cast json parameters through text for type-inferring drivers

### DIFF
--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1503,7 +1503,7 @@ function buildFetchParams (options: FetchJobOptions): FetchQueryParams {
 
     if (hasTiers) {
       paramIndex++
-      tiersParam = `$${paramIndex}::jsonb`
+      tiersParam = `$${paramIndex}::text::jsonb`
       values.push(JSON.stringify(groupConcurrencyConfig.tiers))
     }
   }
@@ -1810,7 +1810,7 @@ export function completeJobs (schema: string, table: string, includeQueued?: boo
 export function completeJobsWithOutputs (schema: string, table: string) {
   return `
     WITH input AS (
-      SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
+      SELECT * FROM json_to_recordset($2::text::json) AS x (id uuid, output jsonb)
     ),
     results AS (
       UPDATE ${schema}.${table} j
@@ -1833,7 +1833,7 @@ export function completeJobsWithOutputs (schema: string, table: string) {
 export function completeJobsWithOutputsDistributed (schema: string, table: string) {
   return `
     WITH input AS (
-      SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
+      SELECT * FROM json_to_recordset($2::text::json) AS x (id uuid, output jsonb)
     )
     UPDATE ${schema}.${table} j
     SET completed_on = now(),
@@ -1978,7 +1978,7 @@ export function insertJobs (schema: string, { table, name, returnId = true, noti
           WHEN ${isDateTimeString('"startAfter"')} THEN CAST("startAfter" as timestamp with time zone)
           ELSE now() + CAST(COALESCE("startAfter",'0') as interval)
           END as start_after
-      FROM json_to_recordset($1::json) as x (
+      FROM json_to_recordset($1::text::json) as x (
         id uuid,
         priority integer,
         data jsonb,
@@ -2302,7 +2302,7 @@ export function failJobsByIdWithOutputs (schema: string, table: string) {
 
   return `
     WITH output_map AS (
-      SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
+      SELECT * FROM json_to_recordset($2::text::json) AS x (id uuid, output jsonb)
     ),
     ${failJobsBody(schema, table, where, output)}
     SELECT COUNT(*) FROM results
@@ -2317,7 +2317,7 @@ export function deadLetterJobsByIdWithOutputs (schema: string, table: string) {
 
   return `
     WITH output_map AS (
-      SELECT * FROM json_to_recordset($2::json) AS x (id uuid, output jsonb)
+      SELECT * FROM json_to_recordset($2::text::json) AS x (id uuid, output jsonb)
     ),
     ${failJobsBody(schema, table, where, output, true)}
     SELECT COUNT(*) FROM results
@@ -2632,7 +2632,7 @@ export function updateJob (schema: string, table: string, name: string, by: 'id'
     SELECT id FROM upd`
 
   return `
-    WITH o AS (SELECT $1::jsonb AS data),
+    WITH o AS (SELECT $1::text::jsonb AS data),
     target AS (
       SELECT job.id
       FROM ${schema}.${table} job, o
@@ -2958,7 +2958,7 @@ export function insertDependencies (schema: string, deps?: unknown[]) {
   const sql = `
     INSERT INTO ${schema}.job_dependency (child_name, child_id, parent_name, parent_id)
     SELECT child_name, child_id, parent_name, parent_id
-    FROM json_to_recordset($1::json) AS x (
+    FROM json_to_recordset($1::text::json) AS x (
       child_name text,
       child_id uuid,
       parent_name text,

--- a/test/jsonParamCastTest.ts
+++ b/test/jsonParamCastTest.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, describe, expect, it } from 'vitest'
+import { ctx } from './hooks.ts'
+import * as helper from './testHelper.ts'
+import * as plans from '../src/plans.ts'
+import type { IDatabase } from '../src/types.ts'
+
+// Some drivers infer a bind parameter's type from the cast in front of it, and that inference cuts
+// both ways depending on what pg-boss binds.
+//
+// Where pg-boss binds an already-stringified payload, `$N::json` reads as "this is JSON" and the
+// string gets encoded a second time: Postgres receives a JSON scalar and json_to_recordset() fails
+// with 22023. That is #880 (Bun.SQL, oven-sh/bun#28819). `$N::text::json` pins the inference to
+// text and changes nothing for the drivers that send the value as text either way.
+//
+// Where pg-boss binds a plain JS object, that same cast is what makes such a driver serialize it as
+// JSON at all - through text it falls back to String(value) and sends `[object Object]`. PGlite
+// does this, so both directions need pinning, which is what this file is for.
+//
+// No Bun in CI: the runtime half models the double-encoding driver with a wrapper, the way
+// distributedDatabaseTest wraps a connection for CockroachDB's INT8-as-string behaviour.
+
+const DIRECT_JSON_CAST = /\$\d+::jsonb?\b/
+const TEXT_ROUTED_JSON_CAST = /\$\d+::text::jsonb?\b/
+
+// 22023 invalid_parameter_value - what json_to_recordset() raises when handed a JSON scalar.
+const INVALID_PARAMETER_VALUE = '22023'
+
+const schema = 'pgboss'
+const table = plans.COMMON_JOB_TABLE
+
+// Statements whose JSON parameter is bound as a string.
+const textRouted: Array<[string, string]> = [
+  ['completeJobsWithOutputs', plans.completeJobsWithOutputs(schema, table)],
+  ['completeJobsWithOutputsDistributed', plans.completeJobsWithOutputsDistributed(schema, table)],
+  ['insertJobs', plans.insertJobs(schema, { table, name: 'q' })],
+  ['failJobsByIdWithOutputs', plans.failJobsByIdWithOutputs(schema, table)],
+  ['deadLetterJobsByIdWithOutputs', plans.deadLetterJobsByIdWithOutputs(schema, table)],
+  ['updateJob', plans.updateJob(schema, table, 'q', 'id', 'newest')],
+  ['insertDependencies', plans.insertDependencies(schema)],
+  // buildFetchParams renders the tier parameter only with groupConcurrency.tiers set, and builds it
+  // by concatenation - which is why a grep for `$N::jsonb` does not turn it up.
+  ['fetchNextJob (group concurrency tiers)', plans.fetchNextJob({
+    schema,
+    table,
+    name: 'q',
+    policy: undefined,
+    limit: 1,
+    ignoreSingletons: null,
+    groupConcurrency: { default: 1, tiers: { enterprise: 3 } }
+  }).text]
+]
+
+// Statements whose JSON parameter is bound as a plain JS object, left for the driver to serialize.
+const driverSerialized: Array<[string, string]> = [
+  ['updateQueue', plans.updateQueue(schema)],
+  ['completeJobs', plans.completeJobs(schema, table)],
+  ['completeJobs (includeQueued)', plans.completeJobs(schema, table, true)],
+  // Wraps the same completeJobsUpdate body; this is the one the CockroachDB leg actually runs.
+  ['completeJobsDistributed', plans.completeJobsDistributed(schema, table)],
+  ['failJobsById', plans.failJobsById(schema, table)]
+]
+
+describe('json bind parameter casts', function () {
+  for (const [name, sql] of textRouted) {
+    it(`${name} routes its json parameter through text`, function () {
+      expect(sql).not.toMatch(DIRECT_JSON_CAST)
+      expect(sql).toMatch(TEXT_ROUTED_JSON_CAST)
+    })
+  }
+
+  for (const [name, sql] of driverSerialized) {
+    it(`${name} keeps its json parameter cast direct`, function () {
+      expect(sql).toMatch(DIRECT_JSON_CAST)
+      expect(sql).not.toMatch(TEXT_ROUTED_JSON_CAST)
+    })
+  }
+
+  // Guards the guards: a typo in either pattern leaves every assertion above trivially true.
+  it('the patterns recognise the casts they are looking for', function () {
+    expect('SELECT $1::json').toMatch(DIRECT_JSON_CAST)
+    expect('SELECT $2::jsonb').toMatch(DIRECT_JSON_CAST)
+    expect('SELECT $1::text::json').not.toMatch(DIRECT_JSON_CAST)
+    expect('SELECT $2::text::jsonb').not.toMatch(DIRECT_JSON_CAST)
+
+    expect('SELECT $1::text::json').toMatch(TEXT_ROUTED_JSON_CAST)
+    expect('SELECT $2::text::jsonb').toMatch(TEXT_ROUTED_JSON_CAST)
+    expect('SELECT $1::json').not.toMatch(TEXT_ROUTED_JSON_CAST)
+  })
+})
+
+// Re-encodes a string bound in front of a json cast, and leaves objects alone - a driver of this
+// kind serializes those correctly.
+//
+// `textRoutedHits` counts the strings it saw bound in front of a `::text::json` cast: every one of
+// those is a parameter that would have been double-encoded before this change. Asserting it is
+// non-zero is what stops the lifecycle test passing vacuously - without it, a boss that quietly
+// ignored the `db` option would look just as green.
+function doubleEncodesJsonParams (db: IDatabase): { db: IDatabase, textRoutedHits: () => number } {
+  let hits = 0
+
+  const wrapped: IDatabase = {
+    executeSql (text: string, values?: unknown[]) {
+      const encoded = values?.map((value, index) => {
+        if (typeof value !== 'string') return value
+
+        if (new RegExp(`\\$${index + 1}::text::jsonb?\\b`).test(text)) hits++
+
+        return new RegExp(`\\$${index + 1}::jsonb?\\b`).test(text) ? JSON.stringify(value) : value
+      })
+
+      return db.executeSql(text, encoded)
+    }
+  }
+
+  return { db: wrapped, textRoutedHits: () => hits }
+}
+
+// Owned by the file rather than the test: hooks.ts stops the boss in afterEach, and the boss is
+// still talking to this connection when it does.
+let rawDb: Awaited<ReturnType<typeof helper.getDb>> | undefined
+
+afterAll(async () => {
+  if (rawDb) await rawDb.close()
+})
+
+describe('json bind parameters under a type-inferring driver', function () {
+  it('runs the job lifecycle through a double-encoding driver', async function () {
+    rawDb ??= await helper.getDb()
+    const driver = doubleEncodesJsonParams(rawDb)
+    ctx.boss = await helper.start({ ...ctx.bossConfig, db: driver.db })
+
+    const queue = ctx.schema
+
+    // insertJobs, the plan #880 reported, through both of its entry points
+    const jobId = await ctx.boss.send(queue, { hello: 'world' })
+    helper.assertTruthy(jobId)
+    await ctx.boss.insert(queue, [{ data: { hello: 'insert' } }])
+
+    // updateJob, the other text-routed plan reachable from a public method. The id is new, so
+    // this misses the update and inserts - three jobs now, and the fetch below has to take all
+    // of them: fetch orders on (priority, created_on) with no tiebreaker, and PGlite's now() is
+    // coarse enough that the three can share a created_on. Taking a subset would pick an
+    // arbitrary one. (separateTimestamps only wraps send/insert, not upsert.)
+    await ctx.boss.upsert(queue, { hello: 'upserted' }, { id: randomUUID() })
+
+    const jobs = await ctx.boss.fetch(queue, { batchSize: 3 })
+    expect(jobs).toHaveLength(3)
+
+    const sent = jobs.find(job => job.id === jobId)
+    helper.assertTruthy(sent)
+    expect(sent.data).toEqual({ hello: 'world' })
+
+    // the object-bound outputs, which have to keep round-tripping
+    await ctx.boss.complete(queue, jobs[0].id, { done: true })
+    await ctx.boss.fail(queue, jobs[1].id, { because: 'test' })
+
+    const completed = await ctx.boss.getJobById(queue, jobs[0].id)
+    helper.assertTruthy(completed)
+    expect(completed.output).toEqual({ done: true })
+
+    await ctx.boss.updateQueue(queue, { retryLimit: 7 })
+    const updated = await ctx.boss.getQueue(queue)
+    helper.assertTruthy(updated)
+    expect(updated.retryLimit).toBe(7)
+
+    // The driver above only matters if pg-boss actually went through it. Every hit is a string
+    // bound in front of a `::text::json` cast - the shape that used to be double-encoded.
+    expect(driver.textRoutedHits()).toBeGreaterThan(0)
+  })
+
+  it('breaks on a direct $N::json cast, and not on the text-routed one', async function () {
+    rawDb ??= await helper.getDb()
+    const { db } = doubleEncodesJsonParams(rawDb)
+    const payload = JSON.stringify([{ id: 1 }, { id: 2 }])
+
+    // Negative control: the statement pg-boss used to emit. This is what establishes that the
+    // wrapper can break a direct cast at all - it drives executeSql itself, so it says nothing
+    // about pg-boss's own path. That part is textRoutedHits() in the test above.
+    await expect(db.executeSql('SELECT * FROM json_to_recordset($1::json) AS x (id int)', [payload]))
+      .rejects.toMatchObject({ code: INVALID_PARAMETER_VALUE })
+
+    const { rows } = await db.executeSql('SELECT * FROM json_to_recordset($1::text::json) AS x (id int)', [payload])
+    expect(rows).toEqual([{ id: 1 }, { id: 2 }])
+  })
+})


### PR DESCRIPTION
Fixes #880. @shayaansultan diagnosed this, found the upstream Bun report and ruled out an adapter-side fix. This implements the cast.

You offered this to @shayaansultan first, and I have not heard from them either way. If they'd still rather take it, I'm happy to close this and hand over the branch.

## The fix

Seven of the ten casts in the issue get the extra `::text` cast; three stay as they are. An eighth is not on that list. `buildFetchParams` builds its tier parameter by concatenation (`` `$${paramIndex}::jsonb` ``), so a grep for `$N::jsonb` misses it, but it pushes `JSON.stringify(tiers)` and fails the same way once `groupConcurrency.tiers` is set. That makes eleven casts in all, eight through text and three direct. No schema change.

## Why three keep the direct cast

`updateQueue`, the shared `completeJobsUpdate` body and `failJobsById`'s output fragment bind a plain JS object, not a stringified payload. There the cast is what makes an inferring driver serialize the object at all, and through text it drops to `String(value)`.

```js
// bun 1.3.14 and 1.4.2, identical, on postgres 18.6
await sql.unsafe('SELECT $1::jsonb AS v', [{ done: true }])        // { v: { done: true } }
await sql.unsafe('SELECT $1::text::jsonb AS v', [{ done: true }])  // error: invalid input syntax for type json
await sql.unsafe('SELECT $1::text AS v', [{ done: true }])         // { v: '[object Object]' }
```

PGlite behaves the same, so moving those three breaks `complete()`, `fail()` and `updateQueue()` on the driver this is fixing. Moving all eleven turns 17 existing tests red under PGlite, across `completeTest`, `failureTest` and `queueTest`. Running against plain Postgres does not show it, because node-postgres serializes an object to JSON text whatever the cast says. With all eleven moved it was still 1035 of 1036, and the one failure was unrelated.

`updateQueue` binds the caller's options object as it arrives, in `executeSql(sql, [name, options])`. The other two bind what `mapCompletionDataArg()` returns, which is `serializeError()` from `serialize-error`, an object despite the local alias.

Stringifying in `manager.ts` and routing all eleven through text would drop the dependency on driver-side serialization, but it changes what a missing output means. `mapCompletionDataArg()` returns `null`, and `'null'::text::jsonb` is a JSON null rather than SQL NULL, unless every call site special-cases `null`, which makes it a change to `manager.ts` rather than to the casts. The suite would not notice either way, since both read back as `null`, but `job.output` is documented schema (`docs/sql/job-table.md`), so a user's `WHERE output IS NULL` would quietly start missing rows.

## Tests

`test/jsonParamCastTest.ts` adds 16 tests and needs no Bun runtime in CI.

- The generated SQL is checked in both directions. On the direct side that is three cast sites across five plans, since `completeJobsUpdate` is shared. A guard test asserts the two patterns still match the casts they name, so a typo cannot leave the assertions passing without checking anything.
- The job lifecycle runs against a wrapper adapter that re-encodes a string bound in front of a json cast. That models the failure mode rather than emulating Bun, as `distributedDatabaseTest` does for CockroachDB's INT8-as-string behaviour.
- That wrapper counts the strings it sees in front of a `::text::json` cast and the lifecycle asserts the count is non-zero, so the test cannot pass unless pg-boss's writes really went through it. Dropping the wrapper takes that assertion to `expected 0 to be greater than 0`.
- A negative control points the same wrapper at a hand-written `$1::json` and needs `22023`.

Reverting `src/plans.ts` alone leaves 9 failed and 7 passed, the eight checks on generated SQL and the lifecycle test.

## Verification

One run of each configuration on this branch.

| configuration | result |
| --- | --- |
| standard | 1051 passed, 1 failed |
| `DISTRIBUTED=true` | 1045 passed, 6 skipped, 1 failed |
| `DB_TYPE=pglite` | 895 passed, 157 skipped, 0 failed |
| `npm run test:cockroachdb` | 13 passed, 1 skipped, 0 failed (v26.2.6) |
| YugabyteDB 2026.1.1.1, Citus 14.2 | not in CI; checked directly that `::text::json[b]` matches the direct casts |

`eslint`, `tsc --noEmit` and `gen:manifest:check` are clean.

The two failures are `queueStatsHistoryTest > should filter by from/to range` under `DISTRIBUTED=true` and `monitorVacuumTest > says so when the holder shares this application_name` under plain Postgres. Neither is near a json cast. The first compares `captured_on`, stamped by the database with `now()`, against a host `new Date()`, and my database sits in a VM whose clock runs about 20 ms ahead, enough to push the row past the `to` bound. Alternating this branch and master over four rounds of the files that flake here, master lost 10 tests and this branch 3. `monitorVacuumTest` is not in that set. It failed once and has not recurred. The CI runs are worth a look.

All eight statements are executed against Postgres by the suite, 1,258 times between the plain Postgres and `DISTRIBUTED=true` runs. On CockroachDB the cluster's statement statistics record 13 distinct statements containing `json_to_recordset(_::STRING::JSONB)` and none with the direct cast, so that run exercises the change rather than just compiling it.

End to end on Bun 1.3.14 and 1.4.2 through `drizzle-orm/bun-sql` and `fromDrizzle`, both `send()` and `insert()` fail on master, where the statement errors so no row is written. They succeed here, with `data` coming back as a jsonb object.

## Out of scope

`complete()` and `fail()` still fail through `drizzle-orm/bun-sql`, on master and here alike, with `malformed array literal: "<uuid>"`. That is the `id = ANY($N::uuid[])` parameter rather than a json one, and `fromDrizzle`'s `sql.param()` binding does not stop the array expanding under bun-sql. Because of it I left `docs/api/adapters.md` alone, since its Drizzle driver list stays accurate while the completion path is broken there. Happy to open a separate issue.
